### PR TITLE
feat: add compute cluster management for training and evaluation

### DIFF
--- a/backend/src/app/api/clusters.py
+++ b/backend/src/app/api/clusters.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from sqlalchemy.orm import Session
+
+from app.db.deps import get_current_user, get_db
+from app.models.user import User
+from app.schemas.cluster import (
+    Cluster as ClusterSchema,
+)
+from app.schemas.cluster import (
+    ClusterCreate,
+    ClusterHeartbeat,
+    ClusterHeartbeatAck,
+    ClusterRegistration,
+    ClusterSummary,
+    ClusterUpdate,
+    cluster_to_dict,
+)
+from app.services import cluster_service
+
+router = APIRouter(prefix="/api/clusters", tags=["clusters"])
+
+
+@router.get("", response_model=list[ClusterSchema])
+def list_clusters(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    rows = cluster_service.list_clusters(db)
+    return [ClusterSchema(**cluster_to_dict(c)) for c in rows]
+
+
+@router.get("/available", response_model=list[ClusterSummary])
+def list_available_clusters(
+    kind: str | None = Query(
+        None,
+        pattern="^(train|eval|both)$",
+        description="Filter to clusters that can run this workload kind.",
+    ),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return clusters that are online, idle, and able to accept work.
+
+    Used by the training and evaluation forms to populate the cluster picker.
+    """
+    rows = cluster_service.list_clusters(db)
+    return [ClusterSummary(**s) for s in cluster_service.summarize(rows, kind=kind)]
+
+
+@router.post("", response_model=ClusterRegistration, status_code=201)
+def create_cluster(
+    payload: ClusterCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    cluster = cluster_service.create_cluster(db, payload)
+    data = cluster_to_dict(cluster)
+    data["register_token"] = cluster.register_token
+    return ClusterRegistration(**data)
+
+
+@router.get("/{cluster_id}", response_model=ClusterSchema)
+def get_cluster(
+    cluster_id: str = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    cluster = cluster_service.get_cluster(db, cluster_id)
+    if not cluster:
+        raise HTTPException(status_code=404, detail="Cluster not found")
+    return ClusterSchema(**cluster_to_dict(cluster))
+
+
+@router.patch("/{cluster_id}", response_model=ClusterSchema)
+def update_cluster(
+    payload: ClusterUpdate,
+    cluster_id: str = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    cluster = cluster_service.update_cluster(db, cluster_id, payload)
+    if not cluster:
+        raise HTTPException(status_code=404, detail="Cluster not found")
+    return ClusterSchema(**cluster_to_dict(cluster))
+
+
+@router.delete("/{cluster_id}", status_code=204)
+def delete_cluster(
+    cluster_id: str = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if not cluster_service.delete_cluster(db, cluster_id):
+        raise HTTPException(status_code=404, detail="Cluster not found")
+
+
+@router.post("/{cluster_id}/heartbeat", response_model=ClusterHeartbeatAck)
+def heartbeat(
+    payload: ClusterHeartbeat,
+    cluster_id: str = Path(...),
+    db: Session = Depends(get_db),
+):
+    """Endpoint called by the cluster agent every N seconds with telemetry.
+
+    Authenticates via the cluster's `register_token` (returned on creation).
+    Does not require a logged-in user, since the agent runs unattended.
+    """
+    try:
+        cluster = cluster_service.record_heartbeat(db, cluster_id, payload)
+    except cluster_service.ClusterError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    if not cluster:
+        raise HTTPException(status_code=404, detail="Cluster not found")
+    return ClusterHeartbeatAck(
+        cluster_id=cluster.id,
+        status=cluster.status,
+        server_time=datetime.now(timezone.utc),
+    )
+
+
+@router.post("/{cluster_id}/release", response_model=ClusterSchema)
+def release(
+    cluster_id: str = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Manually release a cluster (e.g. if a job died without cleaning up)."""
+    cluster = cluster_service.release_cluster(db, cluster_id)
+    if not cluster:
+        raise HTTPException(status_code=404, detail="Cluster not found")
+    return ClusterSchema(**cluster_to_dict(cluster))

--- a/backend/src/app/api/ops.py
+++ b/backend/src/app/api/ops.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
@@ -12,6 +12,7 @@ from app.schemas.common import (
     UploadUrlRequest,
     UploadUrlResponse,
 )
+from app.services import cluster_service
 from app.services.ingest_service import get_presigned_upload
 from app.services.onnx_service import export_onnx as svc_export_onnx
 from app.services.training_service import launch_training
@@ -24,9 +25,7 @@ def get_upload_url(
     payload: UploadUrlRequest,
     current_user: User = Depends(get_current_user),
 ):
-    data = get_presigned_upload(
-        payload.datasetVersionId, payload.filename, payload.contentType
-    )
+    data = get_presigned_upload(payload.datasetVersionId, payload.filename, payload.contentType)
     # Derive the objectKey using the same path template as storage.presign_put_url
     object_key = f"datasets/{payload.datasetVersionId}/{payload.filename}"
     return UploadUrlResponse(
@@ -42,16 +41,20 @@ def train(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    job = launch_training(
-        db,
-        payload.projectId,
-        payload.datasetVersionId,
-        payload.task,
-        payload.params,
-        name=payload.name,
-        base_model=payload.baseModel,
-        owner_id=current_user.id,
-    )
+    try:
+        job = launch_training(
+            db,
+            payload.projectId,
+            payload.datasetVersionId,
+            payload.task,
+            payload.params,
+            name=payload.name,
+            base_model=payload.baseModel,
+            owner_id=current_user.id,
+            cluster_id=payload.clusterId,
+        )
+    except cluster_service.ClusterNotAvailableError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return Job(**job)
 
 
@@ -61,5 +64,10 @@ def export_onnx(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    job = svc_export_onnx(db, payload.experimentId, payload.dynamicAxes)
+    try:
+        job = svc_export_onnx(
+            db, payload.experimentId, payload.dynamicAxes, cluster_id=payload.clusterId
+        )
+    except cluster_service.ClusterNotAvailableError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return Job(**job)

--- a/backend/src/app/db/migrations/versions/0003_clusters.py
+++ b/backend/src/app/db/migrations/versions/0003_clusters.py
@@ -1,0 +1,81 @@
+"""Add clusters table and experiment_runs.cluster_id
+
+Revision ID: 0003_clusters
+Revises: 0002_add_missing_columns
+Create Date: 2026-05-08
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0003_clusters"
+down_revision = "0002_add_missing_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "clusters",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("kind", sa.String(length=16), nullable=False, server_default="both"),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="offline"),
+        sa.Column("cpu_cores", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("ram_total_mb", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("disk_total_gb", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("gpu_vendor", sa.String(length=16), nullable=False, server_default="cpu"),
+        sa.Column("gpu_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("gpu_model", sa.String(length=255), nullable=True),
+        sa.Column("gpu_memory_mb", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("gpus_json", sa.Text(), nullable=True),
+        sa.Column("cpu_usage_pct", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("ram_used_mb", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("disk_used_gb", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("gpu_usage_pct", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("active_job_id", sa.String(length=36), nullable=True),
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        sa.Column("register_token", sa.String(length=64), nullable=False),
+        sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+    )
+    op.create_index("ix_clusters_status", "clusters", ["status"])
+    op.create_index("ix_clusters_kind", "clusters", ["kind"])
+
+    op.add_column(
+        "experiment_runs",
+        sa.Column("cluster_id", sa.String(length=36), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_experiment_runs_cluster_id",
+        "experiment_runs",
+        "clusters",
+        ["cluster_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_experiment_runs_cluster_id", "experiment_runs", type_="foreignkey")
+    op.drop_column("experiment_runs", "cluster_id")
+    op.drop_index("ix_clusters_kind", table_name="clusters")
+    op.drop_index("ix_clusters_status", table_name="clusters")
+    op.drop_table("clusters")

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -5,6 +5,8 @@ import json
 import os
 import time
 
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
 from fastapi import Depends, FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -14,6 +16,7 @@ from sqlalchemy.orm import Session
 from app.api.al import router as al_router
 from app.api.artifacts import router as artifacts_router
 from app.api.auth import router as auth_router
+from app.api.clusters import router as clusters_router
 from app.api.datasets import router as datasets_router
 from app.api.experiments import router as experiments_router
 from app.api.jobs import router as jobs_router
@@ -25,8 +28,6 @@ from app.models.job import Job as JobModel
 from app.observability.logging import configure_logging
 from app.observability.metrics import metrics_middleware
 from app.services.auth import ensure_superuser
-from alembic import command as alembic_command
-from alembic.config import Config as AlembicConfig
 
 # Import new routers (created by the new API implementation)
 try:
@@ -120,6 +121,7 @@ app.include_router(al_router)
 app.include_router(jobs_router)
 app.include_router(experiments_router)
 app.include_router(artifacts_router)
+app.include_router(clusters_router)
 
 # New feature routers (conditionally registered based on availability)
 if _has_annotations:

--- a/backend/src/app/models/__init__.py
+++ b/backend/src/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.annotation import Annotation  # noqa: F401
 from app.models.annotation_schema import AnnotationSchema  # noqa: F401
 from app.models.artifact import ModelArtifact as Artifact  # noqa: F401
 from app.models.asset import Asset  # noqa: F401
+from app.models.cluster import Cluster  # noqa: F401
 from app.models.audit import Audit  # noqa: F401
 from app.models.admin import AuditEvent, Invitation, Notification  # noqa: F401
 from app.models.dataset import Dataset, ClassMap  # noqa: F401

--- a/backend/src/app/models/cluster.py
+++ b/backend/src/app/models/cluster.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import secrets
+import uuid
+
+from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+class Cluster(Base):
+    """Compute cluster (worker node / agent) used for training and evaluation jobs.
+
+    A cluster represents one or more machines reachable by the platform that can
+    execute training or evaluation tasks. Each cluster reports resource telemetry
+    (CPU, RAM, disk, GPU) via heartbeat so the UI can show live availability and
+    users can pick an idle cluster when launching a job.
+    """
+
+    __tablename__ = "clusters"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # "train" | "eval" | "both"
+    kind: Mapped[str] = mapped_column(String(16), nullable=False, default="both")
+    # "online" | "offline" | "busy" | "error"
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="offline")
+
+    # Static capacity (reported on registration / refresh)
+    cpu_cores: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    ram_total_mb: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    disk_total_gb: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # GPU summary. vendor: "nvidia" | "rocm" | "cpu" (no GPU)
+    gpu_vendor: Mapped[str] = mapped_column(String(16), nullable=False, default="cpu")
+    gpu_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    gpu_model: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    gpu_memory_mb: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # JSON array of per-GPU dicts: [{index, name, memory_mb, util_pct, mem_used_mb, temperature_c}, ...]
+    gpus_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Live telemetry (last heartbeat)
+    cpu_usage_pct: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    ram_used_mb: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    disk_used_gb: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    gpu_usage_pct: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+    # Active job tracking
+    active_job_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    # Registration token used by the agent to authenticate heartbeats
+    register_token: Mapped[str] = mapped_column(String(64), nullable=False, default=_token)
+
+    last_heartbeat_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[object] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[object] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/src/app/models/experiment.py
+++ b/backend/src/app/models/experiment.py
@@ -21,6 +21,9 @@ class ExperimentRun(Base):
         String(36), ForeignKey("dataset_versions.id"), nullable=True
     )
     owner_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    cluster_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("clusters.id"), nullable=True
+    )
     name: Mapped[str] = mapped_column(String(255), nullable=False, default="Unnamed Run")
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="queued")
     params_json: Mapped[str | None] = mapped_column("params", Text, nullable=True)  # DB column "params" mapped to params_json

--- a/backend/src/app/schemas/cluster.py
+++ b/backend/src/app/schemas/cluster.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ClusterKind = Literal["train", "eval", "both"]
+ClusterStatus = Literal["online", "offline", "busy", "error"]
+GpuVendor = Literal["nvidia", "rocm", "cpu"]
+
+
+class GpuInfo(BaseModel):
+    """Per-GPU telemetry reported by the agent."""
+
+    index: int
+    name: str | None = None
+    memory_mb: int = 0
+    util_pct: float = 0.0
+    mem_used_mb: int = 0
+    temperature_c: float | None = None
+
+
+class ClusterCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: str | None = None
+    kind: ClusterKind = "both"
+    cpu_cores: int = 0
+    ram_total_mb: int = 0
+    disk_total_gb: int = 0
+    gpu_vendor: GpuVendor = "cpu"
+    gpu_count: int = 0
+    gpu_model: str | None = None
+    gpu_memory_mb: int = 0
+
+
+class ClusterUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    kind: ClusterKind | None = None
+    enabled: bool | None = None
+
+
+class ClusterHeartbeat(BaseModel):
+    """Telemetry payload sent periodically by the agent on a cluster.
+
+    The agent authenticates by including the cluster's `register_token`.
+    """
+
+    register_token: str
+    status: ClusterStatus = "online"
+    cpu_usage_pct: float = 0.0
+    ram_used_mb: int = 0
+    disk_used_gb: int = 0
+    gpu_usage_pct: float = 0.0
+    gpus: list[GpuInfo] | None = None
+    # Optional capacity refresh (in case hardware was reconfigured)
+    cpu_cores: int | None = None
+    ram_total_mb: int | None = None
+    disk_total_gb: int | None = None
+    gpu_vendor: GpuVendor | None = None
+    gpu_count: int | None = None
+    gpu_model: str | None = None
+    gpu_memory_mb: int | None = None
+
+
+class Cluster(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    name: str
+    description: str | None = None
+    kind: ClusterKind
+    status: ClusterStatus
+    enabled: bool
+
+    cpu_cores: int
+    ram_total_mb: int
+    disk_total_gb: int
+
+    gpu_vendor: GpuVendor
+    gpu_count: int
+    gpu_model: str | None = None
+    gpu_memory_mb: int
+
+    cpu_usage_pct: float
+    ram_used_mb: int
+    disk_used_gb: int
+    gpu_usage_pct: float
+
+    active_job_id: str | None = None
+    last_heartbeat_at: datetime | None = None
+    created_at: datetime | None = None
+
+    gpus: list[GpuInfo] = Field(default_factory=list)
+
+
+class ClusterRegistration(Cluster):
+    """Cluster representation returned on creation, including the secret token."""
+
+    register_token: str
+
+
+class ClusterSummary(BaseModel):
+    """Lightweight cluster row used for selectors."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    name: str
+    kind: ClusterKind
+    status: ClusterStatus
+    enabled: bool
+    gpu_vendor: GpuVendor
+    gpu_count: int
+    gpu_model: str | None = None
+    cpu_cores: int
+    ram_total_mb: int
+    available: bool
+
+
+class ClusterHeartbeatAck(BaseModel):
+    ok: bool = True
+    cluster_id: str
+    status: ClusterStatus
+    server_time: datetime
+
+
+def cluster_to_dict(model: Any) -> dict[str, Any]:
+    """Convert a Cluster ORM row to the API dict (parsing gpus_json)."""
+    import json
+
+    gpus: list[dict[str, Any]] = []
+    if getattr(model, "gpus_json", None):
+        try:
+            parsed = json.loads(model.gpus_json)
+            if isinstance(parsed, list):
+                gpus = parsed
+        except Exception:
+            gpus = []
+
+    return {
+        "id": model.id,
+        "name": model.name,
+        "description": model.description,
+        "kind": model.kind,
+        "status": model.status,
+        "enabled": model.enabled,
+        "cpu_cores": model.cpu_cores,
+        "ram_total_mb": model.ram_total_mb,
+        "disk_total_gb": model.disk_total_gb,
+        "gpu_vendor": model.gpu_vendor,
+        "gpu_count": model.gpu_count,
+        "gpu_model": model.gpu_model,
+        "gpu_memory_mb": model.gpu_memory_mb,
+        "cpu_usage_pct": model.cpu_usage_pct,
+        "ram_used_mb": model.ram_used_mb,
+        "disk_used_gb": model.disk_used_gb,
+        "gpu_usage_pct": model.gpu_usage_pct,
+        "active_job_id": model.active_job_id,
+        "last_heartbeat_at": model.last_heartbeat_at,
+        "created_at": model.created_at,
+        "gpus": gpus,
+    }

--- a/backend/src/app/schemas/common.py
+++ b/backend/src/app/schemas/common.py
@@ -22,11 +22,13 @@ class TrainRequest(BaseModel):
     baseModel: str = "yolov8n.pt"
     params: dict[str, Any] = {}
     name: str = "Training Run"
+    clusterId: Optional[str] = None
 
 
 class OnnxExportRequest(BaseModel):
     experimentId: str
     dynamicAxes: Optional[bool] = True
+    clusterId: Optional[str] = None
 
 
 class Job(BaseModel):

--- a/backend/src/app/services/cluster_service.py
+++ b/backend/src/app/services/cluster_service.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.cluster import Cluster
+from app.schemas.cluster import (
+    ClusterCreate,
+    ClusterHeartbeat,
+    ClusterUpdate,
+)
+
+# Heartbeat freshness window: a cluster is treated as offline if no heartbeat
+# was received within this window, regardless of last persisted status.
+HEARTBEAT_TIMEOUT = timedelta(seconds=90)
+
+
+class ClusterError(Exception):
+    pass
+
+
+class ClusterNotAvailableError(ClusterError):
+    pass
+
+
+def create_cluster(db: Session, payload: ClusterCreate) -> Cluster:
+    cluster = Cluster(
+        name=payload.name,
+        description=payload.description,
+        kind=payload.kind,
+        cpu_cores=payload.cpu_cores,
+        ram_total_mb=payload.ram_total_mb,
+        disk_total_gb=payload.disk_total_gb,
+        gpu_vendor=payload.gpu_vendor,
+        gpu_count=payload.gpu_count,
+        gpu_model=payload.gpu_model,
+        gpu_memory_mb=payload.gpu_memory_mb,
+        status="offline",
+    )
+    db.add(cluster)
+    db.commit()
+    db.refresh(cluster)
+    return cluster
+
+
+def update_cluster(db: Session, cluster_id: str, payload: ClusterUpdate) -> Cluster | None:
+    cluster = db.get(Cluster, cluster_id)
+    if not cluster:
+        return None
+    if payload.name is not None:
+        cluster.name = payload.name
+    if payload.description is not None:
+        cluster.description = payload.description
+    if payload.kind is not None:
+        cluster.kind = payload.kind
+    if payload.enabled is not None:
+        cluster.enabled = payload.enabled
+    db.add(cluster)
+    db.commit()
+    db.refresh(cluster)
+    return cluster
+
+
+def delete_cluster(db: Session, cluster_id: str) -> bool:
+    cluster = db.get(Cluster, cluster_id)
+    if not cluster:
+        return False
+    db.delete(cluster)
+    db.commit()
+    return True
+
+
+def list_clusters(db: Session) -> list[Cluster]:
+    rows = db.scalars(select(Cluster).order_by(Cluster.name)).all()
+    # Auto-degrade stale heartbeats so the API surface reflects reality without
+    # requiring a separate sweeper task.
+    cutoff = datetime.now(timezone.utc) - HEARTBEAT_TIMEOUT
+    changed = False
+    for c in rows:
+        if c.status in ("online", "busy") and (
+            c.last_heartbeat_at is None or _aware(c.last_heartbeat_at) < cutoff
+        ):
+            c.status = "offline"
+            changed = True
+    if changed:
+        db.commit()
+    return list(rows)
+
+
+def get_cluster(db: Session, cluster_id: str) -> Cluster | None:
+    return db.get(Cluster, cluster_id)
+
+
+def record_heartbeat(db: Session, cluster_id: str, payload: ClusterHeartbeat) -> Cluster | None:
+    cluster = db.get(Cluster, cluster_id)
+    if not cluster:
+        return None
+    if payload.register_token != cluster.register_token:
+        raise ClusterError("invalid register_token")
+
+    cluster.cpu_usage_pct = float(payload.cpu_usage_pct)
+    cluster.ram_used_mb = int(payload.ram_used_mb)
+    cluster.disk_used_gb = int(payload.disk_used_gb)
+    cluster.gpu_usage_pct = float(payload.gpu_usage_pct)
+
+    if payload.gpus is not None:
+        cluster.gpus_json = json.dumps([g.model_dump() for g in payload.gpus])
+
+    # Optional capacity refresh
+    if payload.cpu_cores is not None:
+        cluster.cpu_cores = payload.cpu_cores
+    if payload.ram_total_mb is not None:
+        cluster.ram_total_mb = payload.ram_total_mb
+    if payload.disk_total_gb is not None:
+        cluster.disk_total_gb = payload.disk_total_gb
+    if payload.gpu_vendor is not None:
+        cluster.gpu_vendor = payload.gpu_vendor
+    if payload.gpu_count is not None:
+        cluster.gpu_count = payload.gpu_count
+    if payload.gpu_model is not None:
+        cluster.gpu_model = payload.gpu_model
+    if payload.gpu_memory_mb is not None:
+        cluster.gpu_memory_mb = payload.gpu_memory_mb
+
+    # If the agent reports busy/error, keep that; otherwise flip to online unless
+    # there's an active job (busy) attached.
+    if payload.status == "error":
+        cluster.status = "error"
+    elif cluster.active_job_id:
+        cluster.status = "busy"
+    else:
+        cluster.status = payload.status if payload.status != "offline" else "online"
+
+    cluster.last_heartbeat_at = datetime.now(timezone.utc)
+    db.add(cluster)
+    db.commit()
+    db.refresh(cluster)
+    return cluster
+
+
+def is_available(cluster: Cluster, *, kind: str | None = None) -> bool:
+    """A cluster is available if enabled, online, idle, and matches the workload kind."""
+    if not cluster.enabled:
+        return False
+    if cluster.status != "online":
+        return False
+    if cluster.active_job_id:
+        return False
+    if cluster.last_heartbeat_at is None:
+        return False
+    if _aware(cluster.last_heartbeat_at) < datetime.now(timezone.utc) - HEARTBEAT_TIMEOUT:
+        return False
+    if kind and cluster.kind not in (kind, "both"):
+        return False
+    return True
+
+
+def list_available(db: Session, *, kind: str | None = None) -> list[Cluster]:
+    return [c for c in list_clusters(db) if is_available(c, kind=kind)]
+
+
+def reserve_cluster(
+    db: Session,
+    cluster_id: str,
+    job_id: str,
+    *,
+    kind: str | None = None,
+) -> Cluster:
+    """Atomically mark the cluster busy with the given job; raise if not available."""
+    cluster = db.get(Cluster, cluster_id)
+    if not cluster:
+        raise ClusterNotAvailableError(f"cluster {cluster_id} not found")
+    if not is_available(cluster, kind=kind):
+        raise ClusterNotAvailableError(
+            f"cluster {cluster.name} is not available for {kind or 'this workload'}"
+        )
+    cluster.active_job_id = job_id
+    cluster.status = "busy"
+    db.add(cluster)
+    db.commit()
+    db.refresh(cluster)
+    return cluster
+
+
+def release_cluster(db: Session, cluster_id: str) -> Cluster | None:
+    cluster = db.get(Cluster, cluster_id)
+    if not cluster:
+        return None
+    cluster.active_job_id = None
+    if cluster.status == "busy":
+        cluster.status = "online"
+    db.add(cluster)
+    db.commit()
+    db.refresh(cluster)
+    return cluster
+
+
+def _aware(dt: datetime) -> datetime:
+    """Coerce a possibly-naive datetime to UTC-aware for comparison."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def summarize(clusters: Iterable[Cluster], *, kind: str | None = None) -> list[dict]:
+    out = []
+    for c in clusters:
+        out.append(
+            {
+                "id": c.id,
+                "name": c.name,
+                "kind": c.kind,
+                "status": c.status,
+                "enabled": c.enabled,
+                "gpu_vendor": c.gpu_vendor,
+                "gpu_count": c.gpu_count,
+                "gpu_model": c.gpu_model,
+                "cpu_cores": c.cpu_cores,
+                "ram_total_mb": c.ram_total_mb,
+                "available": is_available(c, kind=kind),
+            }
+        )
+    return out

--- a/backend/src/app/services/jobs_service.py
+++ b/backend/src/app/services/jobs_service.py
@@ -40,4 +40,20 @@ def update_job_status(
     db.add(job)
     db.commit()
     db.refresh(job)
+
+    if status in ("succeeded", "failed", "cancelled"):
+        _release_cluster_for_job(db, job_id)
     return job
+
+
+def _release_cluster_for_job(db: Session, job_id: str) -> None:
+    """Release any cluster currently reserved for this job."""
+    from app.models.cluster import Cluster
+
+    cluster = db.query(Cluster).filter(Cluster.active_job_id == job_id).first()
+    if cluster:
+        cluster.active_job_id = None
+        if cluster.status == "busy":
+            cluster.status = "online"
+        db.add(cluster)
+        db.commit()

--- a/backend/src/app/services/onnx_service.py
+++ b/backend/src/app/services/onnx_service.py
@@ -5,18 +5,40 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from app.jobs.celery_app import celery_app
+from app.services import cluster_service
 from app.services.jobs_service import create_job
 
 
-def export_onnx(db: Session, experiment_id: str, dynamic_axes: bool | None = None) -> dict[str, Any]:
+def export_onnx(
+    db: Session,
+    experiment_id: str,
+    dynamic_axes: bool | None = None,
+    cluster_id: str | None = None,
+) -> dict[str, Any]:
+    if cluster_id:
+        cluster_service.reserve_cluster(db, cluster_id, job_id="pending", kind="eval")
+
     payload = {
         "experimentId": experiment_id,
         "dynamicAxes": dynamic_axes,
+        "clusterId": cluster_id,
     }
     job_row = create_job(db, "onnx_export", payload)
     payload["jobId"] = job_row.id
+
+    if cluster_id:
+        cluster = cluster_service.get_cluster(db, cluster_id)
+        if cluster:
+            cluster.active_job_id = job_row.id
+            db.add(cluster)
+            db.commit()
+
+    queue = f"cluster.{cluster_id}" if cluster_id else None
     try:
-        celery_app.send_task("app.jobs.tasks.onnx_export.export_task", args=[payload])
+        send_kwargs: dict[str, Any] = {"args": [payload]}
+        if queue:
+            send_kwargs["queue"] = queue
+        celery_app.send_task("app.jobs.tasks.onnx_export.export_task", **send_kwargs)
         job_id = job_row.id
     except Exception:
         job_id = job_row.id
@@ -27,4 +49,5 @@ def export_onnx(db: Session, experiment_id: str, dynamic_axes: bool | None = Non
         "type": "onnx_export",
         "status": "queued",
         "progress": 0.0,
+        "clusterId": cluster_id,
     }

--- a/backend/src/app/services/training_service.py
+++ b/backend/src/app/services/training_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from app.jobs.celery_app import celery_app
 from app.models.experiment import ExperimentRun
+from app.services import cluster_service
 from app.services.jobs_service import create_job
 
 
@@ -20,20 +21,27 @@ def launch_training(
     name: str = "Training Run",
     base_model: str = "yolov8n.pt",
     owner_id: str | None = None,
+    cluster_id: str | None = None,
 ) -> dict[str, Any]:
     # Build full params including task and base_model so the worker can read them
     full_params = dict(params or {})
     full_params.setdefault("task", task)
     full_params.setdefault("base_model", base_model)
 
-    # Create the ExperimentRun row so the worker can look it up by ID
-    # owner_id is required by the model; fall back to a sentinel if not provided
+    # If a cluster was selected, reserve it before creating the run so we fail
+    # fast (and don't leave orphan rows) when the cluster is unavailable.
+    if cluster_id:
+        # Reserve with a placeholder job id; we'll update it once we have the real one.
+        cluster_service.reserve_cluster(db, cluster_id, job_id="pending", kind="train")
+
+    # Create the ExperimentRun row so the worker can look it up by ID.
     effective_owner = owner_id or "system"
     run = ExperimentRun(
         id=str(uuid.uuid4()),
         project_id=project_id,
         dataset_version_id=dataset_version_id,
         owner_id=effective_owner,
+        cluster_id=cluster_id,
         name=name,
         status="queued",
         params_json=json.dumps(full_params),
@@ -50,15 +58,29 @@ def launch_training(
         # Explicitly pass experiment and run IDs so the worker can find the row
         "experimentId": run.id,
         "runId": run.id,
+        "clusterId": cluster_id,
     }
 
     # Create DB job row
     job_row = create_job(db, "train", payload)
     payload["jobId"] = job_row.id
 
-    # Enqueue async job; if broker not available, we still return a job id for contract
+    # Update the cluster reservation with the real job id
+    if cluster_id:
+        cluster = cluster_service.get_cluster(db, cluster_id)
+        if cluster:
+            cluster.active_job_id = job_row.id
+            db.add(cluster)
+            db.commit()
+
+    # Enqueue async job; if broker not available, we still return a job id for contract.
+    # When a cluster is selected, route to its dedicated queue so only its agent picks it up.
+    queue = f"cluster.{cluster_id}" if cluster_id else None
     try:
-        celery_app.send_task("app.jobs.tasks.training.train_task", args=[payload])
+        send_kwargs: dict[str, Any] = {"args": [payload]}
+        if queue:
+            send_kwargs["queue"] = queue
+        celery_app.send_task("app.jobs.tasks.training.train_task", **send_kwargs)
         job_id = job_row.id
     except Exception:
         job_id = job_row.id
@@ -70,4 +92,5 @@ def launch_training(
         "status": "queued",
         "progress": 0.0,
         "experimentId": run.id,
+        "clusterId": cluster_id,
     }

--- a/backend/tests/integration/test_clusters_api.py
+++ b/backend/tests/integration/test_clusters_api.py
@@ -1,0 +1,162 @@
+"""Integration tests for the /api/clusters endpoints.
+
+We bypass `get_current_user` with a dependency override so these tests focus on
+cluster API behaviour and don't depend on the auth/bcrypt stack being healthy
+in the test environment.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.db.deps import get_current_user
+from app.main import app
+from app.models.user import User
+
+
+def _fake_user() -> User:
+    u = User(id="test-user", email="tester@example.com", name="Tester", password_hash="x")
+    return u
+
+
+app.dependency_overrides[get_current_user] = _fake_user
+client = TestClient(app)
+
+
+def _unique(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def test_register_cluster_returns_token_and_lists_offline():
+    name = _unique("ci")
+    r = client.post(
+        "/api/clusters",
+        json={
+            "name": name,
+            "description": "test",
+            "kind": "both",
+            "cpu_cores": 4,
+            "ram_total_mb": 8192,
+            "disk_total_gb": 100,
+            "gpu_vendor": "nvidia",
+            "gpu_count": 1,
+            "gpu_model": "RTX 4090",
+            "gpu_memory_mb": 24576,
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    cluster_id = body["id"]
+    assert body["register_token"]
+    assert body["status"] == "offline"
+    assert body["gpu_vendor"] == "nvidia"
+
+    r2 = client.get("/api/clusters")
+    assert r2.status_code == 200
+    found = [c for c in r2.json() if c["id"] == cluster_id]
+    assert found and found[0]["status"] == "offline"
+
+
+def test_heartbeat_makes_cluster_available_for_training():
+    r = client.post(
+        "/api/clusters",
+        json={"name": _unique("ci-train"), "kind": "train", "gpu_vendor": "rocm", "gpu_count": 1},
+    )
+    cluster_id = r.json()["id"]
+    token = r.json()["register_token"]
+
+    hb = client.post(
+        f"/api/clusters/{cluster_id}/heartbeat",
+        json={
+            "register_token": token,
+            "status": "online",
+            "cpu_usage_pct": 10.0,
+            "ram_used_mb": 1024,
+            "disk_used_gb": 10,
+            "gpu_usage_pct": 5.0,
+            "gpus": [
+                {
+                    "index": 0,
+                    "name": "MI250",
+                    "memory_mb": 65536,
+                    "util_pct": 5.0,
+                    "mem_used_mb": 1024,
+                }
+            ],
+        },
+    )
+    assert hb.status_code == 200, hb.text
+
+    avail = client.get("/api/clusters/available?kind=train").json()
+    found = [c for c in avail if c["id"] == cluster_id]
+    assert found and found[0]["available"] is True
+    assert found[0]["gpu_vendor"] == "rocm"
+
+    eval_avail = client.get("/api/clusters/available?kind=eval").json()
+    found_eval = [c for c in eval_avail if c["id"] == cluster_id]
+    # train-only cluster should appear in eval list but be marked unavailable
+    assert found_eval and found_eval[0]["available"] is False
+
+
+def test_heartbeat_rejects_invalid_token():
+    r = client.post("/api/clusters", json={"name": _unique("ci-badtoken")})
+    cluster_id = r.json()["id"]
+    bad = client.post(
+        f"/api/clusters/{cluster_id}/heartbeat",
+        json={"register_token": "wrong", "status": "online"},
+    )
+    assert bad.status_code == 403
+
+
+def test_train_with_unavailable_cluster_returns_409():
+    r = client.post("/api/projects", json={"name": _unique("ClusterProj"), "description": ""})
+    proj_id = r.json()["id"]
+    r2 = client.post("/api/clusters", json={"name": _unique("ci-offline")})
+    cluster_id = r2.json()["id"]
+
+    train = client.post(
+        "/api/train",
+        json={
+            "projectId": proj_id,
+            "datasetVersionId": "v1",
+            "task": "detect",
+            "clusterId": cluster_id,
+            "params": {},
+        },
+    )
+    assert train.status_code == 409, train.text
+
+
+def test_train_with_available_cluster_marks_it_busy():
+    r = client.post("/api/projects", json={"name": _unique("ClusterProj2"), "description": ""})
+    proj_id = r.json()["id"]
+
+    r2 = client.post(
+        "/api/clusters",
+        json={"name": _unique("ci-online"), "kind": "both", "gpu_vendor": "nvidia", "gpu_count": 1},
+    )
+    cluster_id = r2.json()["id"]
+    token = r2.json()["register_token"]
+
+    client.post(
+        f"/api/clusters/{cluster_id}/heartbeat",
+        json={"register_token": token, "status": "online"},
+    )
+
+    train = client.post(
+        "/api/train",
+        json={
+            "projectId": proj_id,
+            "datasetVersionId": "v1",
+            "task": "detect",
+            "clusterId": cluster_id,
+            "params": {},
+        },
+    )
+    assert train.status_code == 202, train.text
+
+    info = client.get(f"/api/clusters/{cluster_id}").json()
+    assert info["status"] == "busy"
+    assert info["active_job_id"]

--- a/backend/tests/unit/test_cluster_service.py
+++ b/backend/tests/unit/test_cluster_service.py
@@ -1,0 +1,158 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app import models as _models  # noqa: F401  ensure models are registered
+from app.db.base import Base
+from app.schemas.cluster import ClusterCreate, ClusterHeartbeat, GpuInfo
+from app.services import cluster_service
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, future=True)
+    session = Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _create(db, **overrides):
+    fields = {
+        "name": "rig-01",
+        "kind": "both",
+        "cpu_cores": 16,
+        "ram_total_mb": 32768,
+        "disk_total_gb": 500,
+        "gpu_vendor": "nvidia",
+        "gpu_count": 2,
+        "gpu_model": "A100",
+        "gpu_memory_mb": 80 * 1024,
+        **overrides,
+    }
+    payload = ClusterCreate(**fields)
+    return cluster_service.create_cluster(db, payload)
+
+
+def test_create_cluster_assigns_token_and_starts_offline(db):
+    cluster = _create(db)
+    assert cluster.id
+    assert cluster.register_token
+    assert cluster.status == "offline"
+    assert cluster.gpu_vendor == "nvidia"
+    assert cluster.enabled is True
+
+
+def test_heartbeat_marks_online_and_records_telemetry(db):
+    cluster = _create(db)
+    payload = ClusterHeartbeat(
+        register_token=cluster.register_token,
+        status="online",
+        cpu_usage_pct=42.5,
+        ram_used_mb=4096,
+        disk_used_gb=120,
+        gpu_usage_pct=71.0,
+        gpus=[GpuInfo(index=0, name="A100", memory_mb=81920, util_pct=71.0, mem_used_mb=4096)],
+    )
+    updated = cluster_service.record_heartbeat(db, cluster.id, payload)
+    assert updated is not None
+    assert updated.status == "online"
+    assert updated.cpu_usage_pct == 42.5
+    assert updated.gpu_usage_pct == 71.0
+    assert updated.last_heartbeat_at is not None
+    # gpus_json round-trip
+    assert "A100" in (updated.gpus_json or "")
+
+
+def test_heartbeat_rejects_bad_token(db):
+    cluster = _create(db)
+    payload = ClusterHeartbeat(register_token="WRONG", status="online")
+    with pytest.raises(cluster_service.ClusterError):
+        cluster_service.record_heartbeat(db, cluster.id, payload)
+
+
+def test_is_available_requires_online_idle_and_fresh_heartbeat(db):
+    cluster = _create(db)
+    # offline → not available
+    assert not cluster_service.is_available(cluster, kind="train")
+
+    # online + recent heartbeat → available
+    cluster_service.record_heartbeat(
+        db,
+        cluster.id,
+        ClusterHeartbeat(register_token=cluster.register_token, status="online"),
+    )
+    db.refresh(cluster)
+    assert cluster_service.is_available(cluster, kind="train")
+
+    # disabled → unavailable
+    cluster.enabled = False
+    db.add(cluster)
+    db.commit()
+    assert not cluster_service.is_available(cluster, kind="train")
+
+
+def test_is_available_filters_by_kind(db):
+    cluster = _create(db, kind="eval")
+    cluster_service.record_heartbeat(
+        db,
+        cluster.id,
+        ClusterHeartbeat(register_token=cluster.register_token, status="online"),
+    )
+    db.refresh(cluster)
+    assert cluster_service.is_available(cluster, kind="eval")
+    assert not cluster_service.is_available(cluster, kind="train")
+
+
+def test_reserve_marks_busy_and_blocks_double_booking(db):
+    cluster = _create(db)
+    cluster_service.record_heartbeat(
+        db,
+        cluster.id,
+        ClusterHeartbeat(register_token=cluster.register_token, status="online"),
+    )
+    db.refresh(cluster)
+
+    reserved = cluster_service.reserve_cluster(db, cluster.id, "job-1", kind="train")
+    assert reserved.status == "busy"
+    assert reserved.active_job_id == "job-1"
+
+    with pytest.raises(cluster_service.ClusterNotAvailableError):
+        cluster_service.reserve_cluster(db, cluster.id, "job-2", kind="train")
+
+
+def test_release_returns_cluster_to_online(db):
+    cluster = _create(db)
+    cluster_service.record_heartbeat(
+        db,
+        cluster.id,
+        ClusterHeartbeat(register_token=cluster.register_token, status="online"),
+    )
+    db.refresh(cluster)
+    cluster_service.reserve_cluster(db, cluster.id, "job-1", kind="train")
+    released = cluster_service.release_cluster(db, cluster.id)
+    assert released is not None
+    assert released.active_job_id is None
+    assert released.status == "online"
+
+
+def test_stale_heartbeat_treated_as_offline(db):
+    cluster = _create(db)
+    cluster_service.record_heartbeat(
+        db,
+        cluster.id,
+        ClusterHeartbeat(register_token=cluster.register_token, status="online"),
+    )
+    # backdate the heartbeat past the timeout window
+    db.refresh(cluster)
+    cluster.last_heartbeat_at = datetime.now(timezone.utc) - timedelta(seconds=600)
+    db.add(cluster)
+    db.commit()
+    listed = cluster_service.list_clusters(db)
+    assert listed[0].status == "offline"
+    assert not cluster_service.is_available(listed[0], kind="train")

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,6 +22,8 @@ import ArtifactsExport from "./pages/artifacts/export";
 import ActiveLearningIndex from "./pages/active-learning/index";
 import ActiveLearningNew from "./pages/active-learning/new";
 import ALRunDetail from "./pages/active-learning/[alRunId]";
+import ClustersIndex from "./pages/clusters/index";
+import ClustersNew from "./pages/clusters/new";
 import { apiGet } from "@/services/api";
 import Spinner from "@/components/ui/Spinner";
 
@@ -191,6 +193,9 @@ export default function App() {
             <Route path="/active-learning" element={<ProtectedRoute><ActiveLearningIndex /></ProtectedRoute>} />
             <Route path="/active-learning/new" element={<ProtectedRoute><ActiveLearningNew /></ProtectedRoute>} />
             <Route path="/active-learning/:alRunId" element={<ProtectedRoute><ALRunDetail /></ProtectedRoute>} />
+            {/* Clusters */}
+            <Route path="/clusters" element={<ProtectedRoute><ClustersIndex /></ProtectedRoute>} />
+            <Route path="/clusters/new" element={<ProtectedRoute><ClustersNew /></ProtectedRoute>} />
             {/* Annotate */}
             <Route path="/annotate/:assetId" element={<ProtectedRoute><AnnotatorPage /></ProtectedRoute>} />
             {/* Admin */}

--- a/frontend/src/components/common/ClusterSelect.tsx
+++ b/frontend/src/components/common/ClusterSelect.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Select from '@/components/ui/Select';
+import { apiGet } from '@/services/api';
+
+export interface ClusterOption {
+  id: string;
+  name: string;
+  kind: 'train' | 'eval' | 'both';
+  status: 'online' | 'offline' | 'busy' | 'error';
+  enabled: boolean;
+  gpu_vendor: 'nvidia' | 'rocm' | 'cpu';
+  gpu_count: number;
+  gpu_model?: string | null;
+  cpu_cores: number;
+  ram_total_mb: number;
+  available: boolean;
+}
+
+interface Props {
+  /** Workload kind filter sent to the backend (`/api/clusters/available?kind=...`). */
+  kind: 'train' | 'eval';
+  value: string;
+  onChange: (clusterId: string) => void;
+  /** When true, allow selecting an empty value (auto-pick / shared queue). */
+  allowAuto?: boolean;
+  id?: string;
+}
+
+function describe(c: ClusterOption): string {
+  const gpu =
+    c.gpu_vendor === 'cpu'
+      ? 'CPU'
+      : `${c.gpu_count}× ${c.gpu_vendor.toUpperCase()}${c.gpu_model ? ` (${c.gpu_model})` : ''}`;
+  const ramGb = (c.ram_total_mb / 1024).toFixed(0);
+  const status = c.available
+    ? 'IDLE'
+    : c.status === 'busy'
+      ? 'BUSY'
+      : c.status === 'offline'
+        ? 'OFFLINE'
+        : c.status.toUpperCase();
+  return `${c.name} · ${gpu} · ${c.cpu_cores}c / ${ramGb}GB · ${status}`;
+}
+
+export default function ClusterSelect({ kind, value, onChange, allowAuto = true, id }: Props) {
+  const [clusters, setClusters] = useState<ClusterOption[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiGet<ClusterOption[]>(`/api/clusters/available?kind=${kind}`)
+      .then((data) => {
+        if (!cancelled) setClusters(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load clusters');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [kind]);
+
+  const available = clusters?.filter((c) => c.available) ?? [];
+  const unavailable = clusters?.filter((c) => !c.available) ?? [];
+
+  return (
+    <div className="space-y-1">
+      <Select id={id} value={value} onChange={(e) => onChange(e.target.value)}>
+        {allowAuto && <option value="">— auto-assign (shared queue) —</option>}
+        {!allowAuto && available.length === 0 && <option value="">— no clusters available —</option>}
+        {available.length > 0 && (
+          <optgroup label="Available">
+            {available.map((c) => (
+              <option key={c.id} value={c.id}>
+                {describe(c)}
+              </option>
+            ))}
+          </optgroup>
+        )}
+        {unavailable.length > 0 && (
+          <optgroup label="Unavailable">
+            {unavailable.map((c) => (
+              <option key={c.id} value={c.id} disabled>
+                {describe(c)}
+              </option>
+            ))}
+          </optgroup>
+        )}
+      </Select>
+      {error && (
+        <p className="text-[0.6875rem] font-mono text-[var(--hud-danger-text)]">{error}</p>
+      )}
+      {clusters && clusters.length === 0 && (
+        <p className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)]">
+          No clusters registered.{' '}
+          <Link to="/clusters/new" className="text-[var(--hud-accent)] hover:underline">
+            Register one →
+          </Link>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -8,6 +8,7 @@ const NAV_LINKS = [
   { to: '/experiments',      label: 'EXPERIMENTS' },
   { to: '/artifacts',        label: 'ARTIFACTS'   },
   { to: '/active-learning',  label: 'ACTIVE LEARN'},
+  { to: '/clusters',         label: 'CLUSTERS'    },
   { to: '/admin/users',      label: 'ADMIN'       },
 ];
 

--- a/frontend/src/pages/clusters/index.tsx
+++ b/frontend/src/pages/clusters/index.tsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Badge from '@/components/ui/Badge';
+import Button from '@/components/ui/Button';
+import Spinner from '@/components/ui/Spinner';
+import EmptyState from '@/components/common/EmptyState';
+import ErrorState from '@/components/common/ErrorState';
+import { apiGet } from '@/services/api';
+
+interface Gpu {
+  index: number;
+  name?: string | null;
+  memory_mb: number;
+  util_pct: number;
+  mem_used_mb: number;
+  temperature_c?: number | null;
+}
+
+interface Cluster {
+  id: string;
+  name: string;
+  description?: string | null;
+  kind: 'train' | 'eval' | 'both';
+  status: 'online' | 'offline' | 'busy' | 'error';
+  enabled: boolean;
+  cpu_cores: number;
+  ram_total_mb: number;
+  disk_total_gb: number;
+  gpu_vendor: 'nvidia' | 'rocm' | 'cpu';
+  gpu_count: number;
+  gpu_model?: string | null;
+  gpu_memory_mb: number;
+  cpu_usage_pct: number;
+  ram_used_mb: number;
+  disk_used_gb: number;
+  gpu_usage_pct: number;
+  active_job_id?: string | null;
+  last_heartbeat_at?: string | null;
+  gpus: Gpu[];
+}
+
+const REFRESH_MS = 5000;
+
+function statusBadge(status: Cluster['status'], enabled: boolean) {
+  if (!enabled) return <Badge variant="default">DISABLED</Badge>;
+  if (status === 'online') return <Badge variant="success">● ONLINE · IDLE</Badge>;
+  if (status === 'busy') return <Badge variant="info">● BUSY</Badge>;
+  if (status === 'error') return <Badge variant="danger">● ERROR</Badge>;
+  return <Badge variant="warning">● OFFLINE</Badge>;
+}
+
+function vendorBadge(vendor: Cluster['gpu_vendor'], count: number) {
+  if (vendor === 'nvidia') return <Badge variant="success">NVIDIA · {count}× GPU</Badge>;
+  if (vendor === 'rocm') return <Badge variant="warning">AMD ROCm · {count}× GPU</Badge>;
+  return <Badge variant="default">CPU ONLY</Badge>;
+}
+
+function kindBadge(kind: Cluster['kind']) {
+  const label = kind === 'both' ? 'TRAIN + EVAL' : kind.toUpperCase();
+  return <Badge variant="info">{label}</Badge>;
+}
+
+function pct(n: number) {
+  return `${Math.round(n)}%`;
+}
+function gb(mb: number) {
+  return `${(mb / 1024).toFixed(1)} GB`;
+}
+
+function UsageBar({ value, label }: { value: number; label: string }) {
+  const v = Math.max(0, Math.min(100, value));
+  const tone =
+    v > 90
+      ? 'bg-[var(--hud-danger)]'
+      : v > 70
+        ? 'bg-[var(--hud-warning)]'
+        : 'bg-[var(--hud-accent)]';
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between text-[0.6875rem] font-mono text-[var(--hud-text-muted)]">
+        <span>{label}</span>
+        <span className="text-[var(--hud-text-data)]">{pct(v)}</span>
+      </div>
+      <div className="h-1 bg-[var(--hud-inset)] overflow-hidden">
+        <div className={`h-full ${tone}`} style={{ width: `${v}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function ClusterCard({ c }: { c: Cluster }) {
+  const ramPct = c.ram_total_mb > 0 ? (c.ram_used_mb / c.ram_total_mb) * 100 : 0;
+  const diskPct = c.disk_total_gb > 0 ? (c.disk_used_gb / c.disk_total_gb) * 100 : 0;
+  const heartbeatAgo = c.last_heartbeat_at
+    ? `${Math.max(0, Math.round((Date.now() - new Date(c.last_heartbeat_at).getTime()) / 1000))}s ago`
+    : 'never';
+
+  return (
+    <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)] p-4 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-semibold text-[var(--hud-text-primary)] truncate">
+            {c.name}
+          </div>
+          {c.description && (
+            <div className="text-[0.6875rem] text-[var(--hud-text-muted)] truncate">
+              {c.description}
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col gap-1 items-end">
+          {statusBadge(c.status, c.enabled)}
+          {kindBadge(c.kind)}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-1">
+        {vendorBadge(c.gpu_vendor, c.gpu_count)}
+        {c.gpu_model && (
+          <Badge variant="default" className="truncate max-w-[12rem]">
+            {c.gpu_model}
+          </Badge>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+        <UsageBar value={c.cpu_usage_pct} label={`CPU · ${c.cpu_cores}c`} />
+        <UsageBar value={ramPct} label={`RAM · ${gb(c.ram_total_mb)}`} />
+        <UsageBar value={diskPct} label={`DISK · ${c.disk_total_gb} GB`} />
+        <UsageBar
+          value={c.gpu_usage_pct}
+          label={`GPU · ${c.gpu_count > 0 ? gb(c.gpu_memory_mb) : 'n/a'}`}
+        />
+      </div>
+
+      {c.gpus.length > 0 && (
+        <div className="border border-[var(--hud-border-subtle)] bg-[var(--hud-inset)] p-2 space-y-1">
+          <div className="label-overline">Per-GPU</div>
+          {c.gpus.map((g) => (
+            <div
+              key={g.index}
+              className="flex items-center justify-between text-[0.6875rem] font-mono text-[var(--hud-text-muted)]"
+            >
+              <span className="truncate">
+                #{g.index} {g.name || ''}
+              </span>
+              <span className="text-[var(--hud-text-data)]">
+                {pct(g.util_pct)} · {(g.mem_used_mb / 1024).toFixed(1)}/
+                {(g.memory_mb / 1024).toFixed(1)}GB
+                {g.temperature_c != null ? ` · ${Math.round(g.temperature_c)}°C` : ''}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between text-[0.6875rem] font-mono text-[var(--hud-text-muted)] pt-1 border-t border-[var(--hud-border-subtle)]">
+        <span>HEARTBEAT · {heartbeatAgo}</span>
+        {c.active_job_id && (
+          <span className="text-[var(--hud-info-text)]">JOB · {c.active_job_id.slice(0, 8)}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ClustersIndex() {
+  const [clusters, setClusters] = useState<Cluster[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const data = await apiGet<Cluster[]>('/api/clusters');
+        if (!cancelled) {
+          setClusters(data);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load clusters');
+      }
+    }
+    load();
+    const t = setInterval(load, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
+        <div>
+          <div className="label-overline mb-0.5">// Clusters</div>
+          <h1>Compute Clusters</h1>
+          <p className="text-xs text-[var(--hud-text-muted)] mt-1">
+            Live view of training and evaluation workers. Resource telemetry refreshes every {REFRESH_MS / 1000}s.
+          </p>
+        </div>
+        <Link to="/clusters/new">
+          <Button>+ REGISTER CLUSTER</Button>
+        </Link>
+      </div>
+
+      {error && <ErrorState description={error} />}
+
+      {clusters === null && !error && (
+        <div className="flex items-center gap-2 text-xs font-mono text-[var(--hud-text-muted)]">
+          <Spinner size={14} /> Loading clusters…
+        </div>
+      )}
+
+      {clusters && clusters.length === 0 && (
+        <EmptyState
+          title="No clusters registered"
+          description="Register a worker by running the agent with the token from + REGISTER CLUSTER."
+        />
+      )}
+
+      {clusters && clusters.length > 0 && (
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {clusters.map((c) => (
+            <ClusterCard key={c.id} c={c} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/clusters/new.tsx
+++ b/frontend/src/pages/clusters/new.tsx
@@ -1,0 +1,203 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import Input from '@/components/ui/Input';
+import Select from '@/components/ui/Select';
+import Button from '@/components/ui/Button';
+import Alert from '@/components/ui/Alert';
+import { apiPost } from '@/services/api';
+
+interface RegisteredCluster {
+  id: string;
+  name: string;
+  register_token: string;
+}
+
+export default function ClustersNew() {
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    kind: 'both' as 'train' | 'eval' | 'both',
+    cpu_cores: 8,
+    ram_total_mb: 16384,
+    disk_total_gb: 200,
+    gpu_vendor: 'nvidia' as 'nvidia' | 'rocm' | 'cpu',
+    gpu_count: 1,
+    gpu_model: '',
+    gpu_memory_mb: 24576,
+  });
+  const [registered, setRegistered] = useState<RegisteredCluster | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  function setField<K extends keyof typeof form>(key: K, value: (typeof form)[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.name.trim()) {
+      setError('Cluster name is required');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiPost<RegisteredCluster>('/api/clusters', form);
+      setRegistered(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to register cluster');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (registered) {
+    const apiBase = window.location.origin.replace('5173', '8000');
+    const installCmd = `docker run -d --name vf-agent \\
+  --restart unless-stopped \\
+  --gpus all \\
+  -e VF_API_URL=${apiBase} \\
+  -e VF_CLUSTER_ID=${registered.id} \\
+  -e VF_REGISTER_TOKEN=${registered.register_token} \\
+  visionforge/agent:latest`;
+    return (
+      <div className="max-w-2xl space-y-4">
+        <h1>Cluster registered</h1>
+        <Alert variant="success">
+          Run this command on the worker machine to start the agent. The token below appears only once
+          — save it now.
+        </Alert>
+        <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)] p-3">
+          <div className="label-overline mb-2">Cluster ID</div>
+          <div className="font-mono text-xs text-[var(--hud-text-data)] mb-3">{registered.id}</div>
+          <div className="label-overline mb-2">Register token</div>
+          <div className="font-mono text-xs text-[var(--hud-text-data)] break-all mb-3">
+            {registered.register_token}
+          </div>
+          <div className="label-overline mb-2">Agent install command</div>
+          <pre className="bg-[var(--hud-inset)] border border-[var(--hud-border-subtle)] p-3 text-[0.6875rem] font-mono whitespace-pre-wrap break-all text-[var(--hud-text-data)]">
+            {installCmd}
+          </pre>
+        </div>
+        <div className="flex gap-2">
+          <Button onClick={() => navigate('/clusters')}>Done</Button>
+          <Link to="/clusters">
+            <Button variant="outline">Back to clusters</Button>
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-xl space-y-4">
+      <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
+        <div>
+          <div className="label-overline mb-0.5">// Clusters / New</div>
+          <h1>Register Cluster</h1>
+        </div>
+        <Link to="/clusters" className="text-xs font-mono text-[var(--hud-accent)] hover:underline">
+          ← CLUSTERS
+        </Link>
+      </div>
+
+      <form onSubmit={onSubmit} className="space-y-3">
+        <div>
+          <label className="label-overline block mb-1">Name</label>
+          <Input value={form.name} onChange={(e) => setField('name', e.target.value)} placeholder="gpu-rig-01" />
+        </div>
+        <div>
+          <label className="label-overline block mb-1">Description</label>
+          <Input
+            value={form.description}
+            onChange={(e) => setField('description', e.target.value)}
+            placeholder="On-prem 2× A100 box"
+          />
+        </div>
+        <div>
+          <label className="label-overline block mb-1">Workload kind</label>
+          <Select value={form.kind} onChange={(e) => setField('kind', e.target.value as typeof form.kind)}>
+            <option value="both">Training + Evaluation</option>
+            <option value="train">Training only</option>
+            <option value="eval">Evaluation only</option>
+          </Select>
+        </div>
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <label className="label-overline block mb-1">CPU cores</label>
+            <Input
+              type="number"
+              min={1}
+              value={form.cpu_cores}
+              onChange={(e) => setField('cpu_cores', parseInt(e.target.value) || 0)}
+            />
+          </div>
+          <div>
+            <label className="label-overline block mb-1">RAM (MB)</label>
+            <Input
+              type="number"
+              min={0}
+              value={form.ram_total_mb}
+              onChange={(e) => setField('ram_total_mb', parseInt(e.target.value) || 0)}
+            />
+          </div>
+          <div>
+            <label className="label-overline block mb-1">Disk (GB)</label>
+            <Input
+              type="number"
+              min={0}
+              value={form.disk_total_gb}
+              onChange={(e) => setField('disk_total_gb', parseInt(e.target.value) || 0)}
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="label-overline block mb-1">GPU vendor</label>
+            <Select
+              value={form.gpu_vendor}
+              onChange={(e) => setField('gpu_vendor', e.target.value as typeof form.gpu_vendor)}
+            >
+              <option value="nvidia">NVIDIA (CUDA)</option>
+              <option value="rocm">AMD (ROCm)</option>
+              <option value="cpu">CPU only</option>
+            </Select>
+          </div>
+          <div>
+            <label className="label-overline block mb-1">GPU count</label>
+            <Input
+              type="number"
+              min={0}
+              value={form.gpu_count}
+              onChange={(e) => setField('gpu_count', parseInt(e.target.value) || 0)}
+            />
+          </div>
+          <div>
+            <label className="label-overline block mb-1">GPU model</label>
+            <Input
+              value={form.gpu_model}
+              onChange={(e) => setField('gpu_model', e.target.value)}
+              placeholder="A100 80GB / RX 7900 XTX"
+            />
+          </div>
+          <div>
+            <label className="label-overline block mb-1">GPU memory (MB)</label>
+            <Input
+              type="number"
+              min={0}
+              value={form.gpu_memory_mb}
+              onChange={(e) => setField('gpu_memory_mb', parseInt(e.target.value) || 0)}
+            />
+          </div>
+        </div>
+
+        {error && <Alert variant="error">{error}</Alert>}
+
+        <Button type="submit" disabled={loading}>
+          {loading ? 'Registering…' : 'Register cluster'}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/experiments/new.tsx
+++ b/frontend/src/pages/experiments/new.tsx
@@ -5,6 +5,7 @@ import Select from '@/components/ui/Select';
 import Button from '@/components/ui/Button';
 import Alert from '@/components/ui/Alert';
 import Spinner from '@/components/ui/Spinner';
+import ClusterSelect from '@/components/common/ClusterSelect';
 import { apiGet, apiPost } from '@/services/api';
 
 interface Project { id: string; name: string; }
@@ -46,6 +47,7 @@ export default function ExperimentsNew() {
     name: 'Baseline',
     task: 'detect',
     baseModel: 'yolov8n.pt',
+    clusterId: '',
     epochs: 50,
     batchSize: 16,
     imageSize: 640,
@@ -89,6 +91,7 @@ export default function ExperimentsNew() {
         task: form.task,
         baseModel: form.baseModel,
         name: form.name,
+        clusterId: form.clusterId || null,
         params: {
           epochs: form.epochs,
           batch: form.batchSize,
@@ -192,6 +195,28 @@ export default function ExperimentsNew() {
                 </Select>
               </div>
             </div>
+          </div>
+        </div>
+
+        {/* Cluster selection */}
+        <div className="border border-t-0 border-[var(--hud-border-default)] bg-[var(--hud-surface)]">
+          <div className="border-b border-[var(--hud-border-subtle)] px-4 py-2 flex items-center gap-2">
+            <div className="h-1.5 w-1.5 bg-[var(--hud-accent)]" />
+            <span className="label-overline">Compute Cluster</span>
+          </div>
+          <div className="p-4 space-y-2">
+            <FieldLabel htmlFor="cluster-select">Run on cluster</FieldLabel>
+            <ClusterSelect
+              id="cluster-select"
+              kind="train"
+              value={form.clusterId}
+              onChange={(v) => setField('clusterId', v)}
+              allowAuto
+            />
+            <p className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)]">
+              Pick an idle cluster to dedicate this run, or leave on auto-assign to use the shared
+              queue. Busy clusters are listed but disabled.
+            </p>
           </div>
         </div>
 


### PR DESCRIPTION
Adds first-class cluster (worker / agent) management so team members can see
live resource usage and pick an idle, capable cluster when launching training
or evaluation jobs.

Backend
- New `clusters` table (Alembic 0003) with kind=train|eval|both, GPU vendor
  (nvidia / rocm / cpu), GPU count/model/memory, CPU/RAM/disk capacity and
  live telemetry, status (online/offline/busy/error), enabled flag, register
  token, last heartbeat
- `experiment_runs.cluster_id` FK so each run records the cluster it ran on
- Cluster service: registration, heartbeat with token auth, availability
  filtering (kind + freshness + idle + enabled), reservation/release, stale-
  heartbeat auto-degrade
- `/api/clusters` CRUD + `/available?kind=train|eval` selector endpoint +
  unauthenticated `/heartbeat` for the agent
- `/api/train` and `/api/export/onnx` accept `clusterId` and return 409 if
  the cluster is unavailable; reservations route Celery tasks to a per-cluster
  queue and are released on terminal job status

Frontend
- `/clusters` page: live grid with CPU/RAM/disk/GPU bars, per-GPU telemetry,
  vendor badges (NVIDIA / AMD ROCm / CPU), heartbeat freshness, polled every 5s
- `/clusters/new` page: register a cluster and surface the agent install
  command + register token
- Reusable `ClusterSelect` component grouped by Available / Unavailable
- New training run wizard now has a "Compute Cluster" section using
  `ClusterSelect`; `clusterId` is passed through to `/api/train`
- AppShell nav entry "CLUSTERS"

Tests
- 8 unit tests covering create / heartbeat / token rejection / kind filter /
  reserve double-booking / release / stale heartbeat
- 5 integration tests covering registration response, availability after
  heartbeat, kind filtering, 409 on unavailable, busy state after train

https://claude.ai/code/session_01KX1NAFNrsBd5BrCJzA88Tk