### PR TITLE
feat: phase 1 — annotator, evaluation, inference, datumaro, bcrypt-only

### DIFF
--- a/backend/src/app/api/annotations.py
+++ b/backend/src/app/api/annotations.py
@@ -9,9 +9,12 @@ from sqlalchemy.orm import Session
 from app.db.deps import get_current_user, get_db
 from app.models.user import User
 from app.services.annotation_service import (
+    AnnotationError,
+    VersionConflictError,
     create_annotation,
     delete_annotation,
     get_asset_annotations,
+    get_history,
     mark_asset_labeled,
     update_annotation,
 )
@@ -21,7 +24,7 @@ router = APIRouter(prefix="/api/annotations", tags=["annotations"])
 
 class AnnotationCreate(BaseModel):
     asset_id: str
-    type: str  # "box", "polygon", "classification", etc.
+    type: str  # "box" | "polygon" | "keypoint" | "classification"
     geometry: dict
     class_name: str | None = None
 
@@ -29,6 +32,8 @@ class AnnotationCreate(BaseModel):
 class AnnotationUpdate(BaseModel):
     geometry: dict | None = None
     class_name: str | None = None
+    # Optimistic lock — required for safe concurrent edits, optional for fire-and-forget.
+    expected_version: int | None = None
 
 
 def _ann_to_dict(ann) -> dict:
@@ -39,6 +44,8 @@ def _ann_to_dict(ann) -> dict:
         "geometry": json.loads(ann.geometry) if isinstance(ann.geometry, str) else ann.geometry,
         "class_name": ann.class_name,
         "author_id": ann.author_id,
+        "version": ann.version,
+        "updated_at": ann.updated_at.isoformat() if ann.updated_at else None,
         "created_at": ann.created_at.isoformat() if ann.created_at else None,
     }
 
@@ -49,14 +56,17 @@ def create(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    ann = create_annotation(
-        db,
-        asset_id=body.asset_id,
-        author_id=current_user.id,
-        type=body.type,
-        geometry=body.geometry,
-        class_name=body.class_name,
-    )
+    try:
+        ann = create_annotation(
+            db,
+            asset_id=body.asset_id,
+            author_id=current_user.id,
+            type=body.type,
+            geometry=body.geometry,
+            class_name=body.class_name,
+        )
+    except AnnotationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return _ann_to_dict(ann)
 
 
@@ -67,7 +77,18 @@ def update(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    ann = update_annotation(db, annotation_id, geometry=body.geometry, class_name=body.class_name)
+    try:
+        ann = update_annotation(
+            db,
+            annotation_id,
+            geometry=body.geometry,
+            class_name=body.class_name,
+            expected_version=body.expected_version,
+        )
+    except VersionConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except AnnotationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not ann:
         raise HTTPException(status_code=404, detail="Annotation not found")
     return _ann_to_dict(ann)
@@ -81,6 +102,27 @@ def delete(
 ):
     if not delete_annotation(db, annotation_id):
         raise HTTPException(status_code=404, detail="Annotation not found")
+
+
+@router.get("/{annotation_id}/history")
+def history(
+    annotation_id: str = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    rows = get_history(db, annotation_id)
+    # geometry stored as JSON string in history; parse for clients
+    out = []
+    for h in rows:
+        item = dict(h)
+        g = item.get("geometry")
+        if isinstance(g, str):
+            try:
+                item["geometry"] = json.loads(g)
+            except Exception:
+                pass
+        out.append(item)
+    return out
 
 
 @router.get("/assets/{asset_id}")

--- a/backend/src/app/api/artifacts.py
+++ b/backend/src/app/api/artifacts.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+import base64
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
@@ -10,6 +13,7 @@ from app.models.dataset_version import DatasetVersion
 from app.models.experiment import ExperimentRun
 from app.models.user import User
 from app.schemas.common import Job
+from app.services import inference_service
 from app.services.onnx_service import export_onnx as svc_export_onnx
 
 router = APIRouter(prefix="/api", tags=["artifacts"])
@@ -78,6 +82,72 @@ def export_model(
     return Job(**job)
 
 
+class PredictRequest(BaseModel):
+    """Predict from a base64-encoded image (alternative to multipart upload)."""
+
+    image_base64: str
+    score_threshold: float = 0.25
+
+
+@router.post("/artifacts/models/{model_id}/predict")
+async def predict(
+    model_id: str,
+    file: UploadFile | None = File(None),
+    score_threshold: float = Form(0.25),
+    body: PredictRequest | None = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Run inference on the artifact. Accepts either multipart `file` or JSON
+    body with `image_base64`. Returns model predictions (detections / classification).
+    """
+    artifact = db.get(ModelArtifact, model_id)
+    if not artifact:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    if file is not None:
+        image_bytes = await file.read()
+        threshold = score_threshold
+    elif body is not None:
+        try:
+            image_bytes = base64.b64decode(body.image_base64)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="invalid base64") from exc
+        threshold = body.score_threshold
+    else:
+        raise HTTPException(status_code=400, detail="provide `file` or `image_base64`")
+
+    if not image_bytes:
+        raise HTTPException(status_code=400, detail="empty image")
+
+    try:
+        result = inference_service.predict(artifact, image_bytes, score_threshold=threshold)
+    except inference_service.InferenceError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return {
+        "model_id": model_id,
+        "model_name": artifact.name,
+        "model_version": artifact.version,
+        "result": result,
+    }
+
+
+@router.post("/artifacts/cache/clear")
+def clear_inference_cache(
+    current_user: User = Depends(get_current_user),
+):
+    """Drop all loaded models from the in-process inference cache."""
+    inference_service._cache.clear()  # type: ignore[attr-defined]
+    return {"ok": True}
+
+
+@router.get("/artifacts/cache")
+def get_inference_cache(
+    current_user: User = Depends(get_current_user),
+):
+    return inference_service.cache_stats()
+
+
 @router.get("/artifacts/models/{model_id}/lineage")
 def get_lineage(
     model_id: str,
@@ -89,9 +159,7 @@ def get_lineage(
         raise HTTPException(status_code=404, detail="Model not found")
     run = db.get(ExperimentRun, artifact.run_id) if artifact.run_id else None
     version = (
-        db.get(DatasetVersion, run.dataset_version_id)
-        if run and run.dataset_version_id
-        else None
+        db.get(DatasetVersion, run.dataset_version_id) if run and run.dataset_version_id else None
     )
     dataset = db.get(Dataset, version.dataset_id) if version else None
     return {
@@ -102,13 +170,7 @@ def get_lineage(
             "type": artifact.type,
             "format": artifact.format,
         },
-        "experiment_run": (
-            {"id": run.id, "name": run.name, "status": run.status} if run else None
-        ),
-        "dataset_version": (
-            {"id": version.id, "version": version.version} if version else None
-        ),
-        "dataset": (
-            {"id": dataset.id, "name": dataset.name} if dataset else None
-        ),
+        "experiment_run": ({"id": run.id, "name": run.name, "status": run.status} if run else None),
+        "dataset_version": ({"id": version.id, "version": version.version} if version else None),
+        "dataset": ({"id": dataset.id, "name": dataset.name} if dataset else None),
     }

--- a/backend/src/app/api/artifacts.py
+++ b/backend/src/app/api/artifacts.py
@@ -83,43 +83,15 @@ def export_model(
 
 
 class PredictRequest(BaseModel):
-    """Predict from a base64-encoded image (alternative to multipart upload)."""
+    """JSON body for the base64 endpoint."""
 
     image_base64: str
     score_threshold: float = 0.25
 
 
-@router.post("/artifacts/models/{model_id}/predict")
-async def predict(
-    model_id: str,
-    file: UploadFile | None = File(None),
-    score_threshold: float = Form(0.25),
-    body: PredictRequest | None = None,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    """Run inference on the artifact. Accepts either multipart `file` or JSON
-    body with `image_base64`. Returns model predictions (detections / classification).
-    """
-    artifact = db.get(ModelArtifact, model_id)
-    if not artifact:
-        raise HTTPException(status_code=404, detail="Model not found")
-
-    if file is not None:
-        image_bytes = await file.read()
-        threshold = score_threshold
-    elif body is not None:
-        try:
-            image_bytes = base64.b64decode(body.image_base64)
-        except Exception as exc:
-            raise HTTPException(status_code=400, detail="invalid base64") from exc
-        threshold = body.score_threshold
-    else:
-        raise HTTPException(status_code=400, detail="provide `file` or `image_base64`")
-
+def _predict_response(model_id: str, artifact, image_bytes: bytes, threshold: float) -> dict:
     if not image_bytes:
         raise HTTPException(status_code=400, detail="empty image")
-
     try:
         result = inference_service.predict(artifact, image_bytes, score_threshold=threshold)
     except inference_service.InferenceError as exc:
@@ -130,6 +102,44 @@ async def predict(
         "model_version": artifact.version,
         "result": result,
     }
+
+
+@router.post("/artifacts/models/{model_id}/predict")
+async def predict_multipart(
+    model_id: str,
+    file: UploadFile = File(...),
+    score_threshold: float = Form(0.25),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Run inference on the artifact via multipart upload (`file` field).
+
+    Use this from browser file inputs / curl. For JSON callers, see
+    `/predict-json` which accepts a base64-encoded image.
+    """
+    artifact = db.get(ModelArtifact, model_id)
+    if not artifact:
+        raise HTTPException(status_code=404, detail="Model not found")
+    image_bytes = await file.read()
+    return _predict_response(model_id, artifact, image_bytes, score_threshold)
+
+
+@router.post("/artifacts/models/{model_id}/predict-json")
+def predict_json(
+    model_id: str,
+    body: PredictRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Run inference on the artifact via a JSON body with a base64 image."""
+    artifact = db.get(ModelArtifact, model_id)
+    if not artifact:
+        raise HTTPException(status_code=404, detail="Model not found")
+    try:
+        image_bytes = base64.b64decode(body.image_base64)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="invalid base64") from exc
+    return _predict_response(model_id, artifact, image_bytes, body.score_threshold)
 
 
 @router.post("/artifacts/cache/clear")

--- a/backend/src/app/api/assets.py
+++ b/backend/src/app/api/assets.py
@@ -145,11 +145,13 @@ def get_asset_neighbors(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Return previous/next asset ids in the same dataset version (by created_at).
+    """Return previous/next asset ids in the same dataset version.
 
-    Used by the annotator to navigate frames without leaving the editor.
+    Ordering is `(created_at, id)` ascending. Uses two indexed range queries
+    plus a count, so it stays O(log n) per call instead of materialising the
+    whole asset list.
     """
-    from sqlalchemy import asc, select
+    from sqlalchemy import and_, asc, desc, func, or_, select
 
     from app.models.asset import Asset
 
@@ -157,24 +159,61 @@ def get_asset_neighbors(
     if not asset:
         raise HTTPException(status_code=404, detail="Asset not found")
 
-    q = select(Asset).where(
-        Asset.dataset_id == asset.dataset_id,
-    )
+    base_filters = [Asset.dataset_id == asset.dataset_id]
     if asset.version_id:
-        q = q.where(Asset.version_id == asset.version_id)
+        base_filters.append(Asset.version_id == asset.version_id)
     if label_status:
-        q = q.where(Asset.label_status == label_status)
-    q = q.order_by(asc(Asset.created_at), asc(Asset.id))
+        base_filters.append(Asset.label_status == label_status)
 
-    ids = [a.id for a in db.scalars(q).all()]
-    if asset_id not in ids:
-        return {"prev": None, "next": None, "index": None, "total": len(ids)}
-    i = ids.index(asset_id)
+    # The ordering key is (created_at, id). "before" rows are strictly less
+    # than the cursor, "after" rows are strictly greater.
+    cursor_created = asset.created_at
+    cursor_id = asset.id
+
+    if cursor_created is None:
+        # No created_at to compare; fall back to id-only ordering.
+        before_filter = Asset.id < cursor_id
+        after_filter = Asset.id > cursor_id
+        order_before = (desc(Asset.id),)
+        order_after = (asc(Asset.id),)
+    else:
+        before_filter = or_(
+            Asset.created_at < cursor_created,
+            and_(Asset.created_at == cursor_created, Asset.id < cursor_id),
+        )
+        after_filter = or_(
+            Asset.created_at > cursor_created,
+            and_(Asset.created_at == cursor_created, Asset.id > cursor_id),
+        )
+        order_before = (desc(Asset.created_at), desc(Asset.id))
+        order_after = (asc(Asset.created_at), asc(Asset.id))
+
+    prev_id = db.scalar(
+        select(Asset.id).where(*base_filters, before_filter).order_by(*order_before).limit(1)
+    )
+    next_id = db.scalar(
+        select(Asset.id).where(*base_filters, after_filter).order_by(*order_after).limit(1)
+    )
+    total = (
+        db.scalar(
+            select(func.count()).select_from(select(Asset.id).where(*base_filters).subquery())
+        )
+        or 0
+    )
+    index_before = (
+        db.scalar(
+            select(func.count()).select_from(
+                select(Asset.id).where(*base_filters, before_filter).subquery()
+            )
+        )
+        or 0
+    )
+
     return {
-        "prev": ids[i - 1] if i > 0 else None,
-        "next": ids[i + 1] if i + 1 < len(ids) else None,
-        "index": i,
-        "total": len(ids),
+        "prev": prev_id,
+        "next": next_id,
+        "index": index_before,
+        "total": total,
     }
 
 

--- a/backend/src/app/api/assets.py
+++ b/backend/src/app/api/assets.py
@@ -138,6 +138,46 @@ def dataset_stats(
     return get_dataset_stats(db, dataset_id, version_id=version_id)
 
 
+@router.get("/assets/{asset_id}/neighbors")
+def get_asset_neighbors(
+    asset_id: str = Path(...),
+    label_status: str | None = Query(None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return previous/next asset ids in the same dataset version (by created_at).
+
+    Used by the annotator to navigate frames without leaving the editor.
+    """
+    from sqlalchemy import asc, select
+
+    from app.models.asset import Asset
+
+    asset = db.get(Asset, asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+
+    q = select(Asset).where(
+        Asset.dataset_id == asset.dataset_id,
+    )
+    if asset.version_id:
+        q = q.where(Asset.version_id == asset.version_id)
+    if label_status:
+        q = q.where(Asset.label_status == label_status)
+    q = q.order_by(asc(Asset.created_at), asc(Asset.id))
+
+    ids = [a.id for a in db.scalars(q).all()]
+    if asset_id not in ids:
+        return {"prev": None, "next": None, "index": None, "total": len(ids)}
+    i = ids.index(asset_id)
+    return {
+        "prev": ids[i - 1] if i > 0 else None,
+        "next": ids[i + 1] if i + 1 < len(ids) else None,
+        "index": i,
+        "total": len(ids),
+    }
+
+
 @router.post("/ingest/confirm", status_code=201)
 def confirm_asset_upload(
     body: ConfirmUploadRequest,

--- a/backend/src/app/api/datasets.py
+++ b/backend/src/app/api/datasets.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 
 import json
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Path,
+    Query,
+    Response,
+    UploadFile,
+)
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -11,6 +21,7 @@ from app.db.deps import get_current_user, get_db
 from app.models.dataset import ClassMap, Dataset
 from app.models.dataset_version import DatasetVersion
 from app.models.user import User
+from app.services import datumaro_service
 from app.services.dataset_service import snapshot_version
 from app.services.project_dataset_service import create_dataset as svc_create_dataset
 
@@ -170,6 +181,100 @@ def create_snapshot(
         "asset_count": v.asset_count,
         "locked": v.locked,
     }
+
+
+@router.get("/datasets/formats")
+def list_dataset_formats(
+    current_user: User = Depends(get_current_user),
+):
+    return {"formats": list(datumaro_service.SUPPORTED_FORMATS)}
+
+
+@router.post("/datasets/{dataset_id}/import", status_code=201)
+async def import_dataset(
+    dataset_id: str = Path(...),
+    file: UploadFile = File(...),
+    fmt: str = Form("coco"),
+    version_id: str | None = Form(None),
+    image_uri_base: str = Form(""),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Import an annotation archive (zip) in COCO/YOLO/Pascal VOC/CVAT/etc.
+
+    If `version_id` is omitted, a fresh draft version is created. The archive
+    must contain images plus annotation files for the chosen format.
+    """
+    d = db.get(Dataset, dataset_id)
+    if not d:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+
+    # Resolve target version
+    if version_id:
+        version = db.get(DatasetVersion, version_id)
+        if not version or version.dataset_id != dataset_id:
+            raise HTTPException(status_code=404, detail="Version not found")
+        if version.locked:
+            raise HTTPException(status_code=409, detail="Version is locked")
+    else:
+        latest = db.scalars(
+            select(DatasetVersion)
+            .where(DatasetVersion.dataset_id == dataset_id)
+            .order_by(DatasetVersion.version.desc())
+            .limit(1)
+        ).first()
+        next_v = (latest.version + 1) if latest else 1
+        version = DatasetVersion(dataset_id=dataset_id, version=next_v)
+        db.add(version)
+        db.commit()
+        db.refresh(version)
+
+    archive_bytes = await file.read()
+    if not archive_bytes:
+        raise HTTPException(status_code=400, detail="empty archive")
+
+    try:
+        summary = datumaro_service.import_archive(
+            db,
+            dataset_id=dataset_id,
+            version_id=version.id,
+            archive_bytes=archive_bytes,
+            fmt=fmt,
+            image_uri_base=image_uri_base,
+        )
+    except datumaro_service.DatumaroError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "dataset_id": dataset_id,
+        "version_id": version.id,
+        "format": fmt,
+        "asset_count": summary.asset_count,
+        "annotation_count": summary.annotation_count,
+        "classes": summary.classes,
+        "warnings": summary.warnings,
+    }
+
+
+@router.get("/datasets/{dataset_id}/export")
+def export_dataset(
+    dataset_id: str = Path(...),
+    version_id: str = Query(...),
+    fmt: str = Query("coco"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Export a dataset version as a zip archive in the requested format."""
+    try:
+        archive = datumaro_service.export_archive(
+            db, dataset_id=dataset_id, version_id=version_id, fmt=fmt
+        )
+    except datumaro_service.DatumaroError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    headers = {
+        "Content-Disposition": f'attachment; filename="dataset-{dataset_id}-{version_id}-{fmt}.zip"'
+    }
+    return Response(content=archive, media_type="application/zip", headers=headers)
 
 
 @router.put("/datasets/{dataset_id}/classes")

--- a/backend/src/app/api/datasets.py
+++ b/backend/src/app/api/datasets.py
@@ -75,6 +75,16 @@ def list_datasets(
     return result
 
 
+# NOTE: register the static `/datasets/formats` route BEFORE the dynamic
+# `/datasets/{dataset_id}` route — otherwise FastAPI matches "formats" as a
+# dataset id and returns 404.
+@router.get("/datasets/formats")
+def list_dataset_formats(
+    current_user: User = Depends(get_current_user),
+):
+    return {"formats": list(datumaro_service.SUPPORTED_FORMATS)}
+
+
 @router.get("/datasets/{dataset_id}")
 def get_dataset(
     dataset_id: str = Path(...),
@@ -181,13 +191,6 @@ def create_snapshot(
         "asset_count": v.asset_count,
         "locked": v.locked,
     }
-
-
-@router.get("/datasets/formats")
-def list_dataset_formats(
-    current_user: User = Depends(get_current_user),
-):
-    return {"formats": list(datumaro_service.SUPPORTED_FORMATS)}
 
 
 @router.post("/datasets/{dataset_id}/import", status_code=201)

--- a/backend/src/app/api/evaluations.py
+++ b/backend/src/app/api/evaluations.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from sqlalchemy.orm import Session
+
+from app.db.deps import get_current_user, get_db
+from app.models.user import User
+from app.schemas.common import Job
+from app.schemas.evaluation import (
+    EvaluationCreate,
+    EvaluationOut,
+    EvaluationSummary,
+)
+from app.services import cluster_service, evaluation_service
+
+router = APIRouter(prefix="/api/evaluations", tags=["evaluations"])
+
+
+@router.get("", response_model=list[EvaluationSummary])
+def list_evaluations(
+    artifact_id: str | None = Query(None),
+    dataset_version_id: str | None = Query(None),
+    project_id: str | None = Query(None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    rows = evaluation_service.list_evaluations(
+        db,
+        artifact_id=artifact_id,
+        dataset_version_id=dataset_version_id,
+        project_id=project_id,
+    )
+    return [EvaluationSummary(**evaluation_service.summarize(r)) for r in rows]
+
+
+@router.post("", response_model=Job, status_code=202)
+def create_evaluation(
+    payload: EvaluationCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    try:
+        _, job = evaluation_service.create_evaluation(db, payload)
+    except evaluation_service.EvaluationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except cluster_service.ClusterNotAvailableError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return Job(**job)
+
+
+@router.get("/{evaluation_id}", response_model=EvaluationOut)
+def get_evaluation(
+    evaluation_id: str = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    row = evaluation_service.get_evaluation(db, evaluation_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Evaluation not found")
+    return EvaluationOut(**evaluation_service.to_dict(row))

--- a/backend/src/app/api/evaluations.py
+++ b/backend/src/app/api/evaluations.py
@@ -5,9 +5,9 @@ from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
 from app.models.user import User
-from app.schemas.common import Job
 from app.schemas.evaluation import (
     EvaluationCreate,
+    EvaluationJobResponse,
     EvaluationOut,
     EvaluationSummary,
 )
@@ -33,7 +33,7 @@ def list_evaluations(
     return [EvaluationSummary(**evaluation_service.summarize(r)) for r in rows]
 
 
-@router.post("", response_model=Job, status_code=202)
+@router.post("", response_model=EvaluationJobResponse, status_code=202)
 def create_evaluation(
     payload: EvaluationCreate,
     db: Session = Depends(get_db),
@@ -45,7 +45,7 @@ def create_evaluation(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except cluster_service.ClusterNotAvailableError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return Job(**job)
+    return EvaluationJobResponse(**job)
 
 
 @router.get("/{evaluation_id}", response_model=EvaluationOut)

--- a/backend/src/app/db/migrations/versions/0001_initial_schema.py
+++ b/backend/src/app/db/migrations/versions/0001_initial_schema.py
@@ -1,13 +1,12 @@
 """Initial schema with all models
 
 Revision ID: 0001_initial_schema
-Revises: 
+Revises:
 Create Date: 2025-09-23
 """
 
 from alembic import op
 import sqlalchemy as sa
-
 
 # revision identifiers, used by Alembic.
 revision = "0001_initial_schema"
@@ -44,7 +43,9 @@ def upgrade() -> None:
     op.create_table(
         "projects",
         sa.Column("id", sa.String(length=36), primary_key=True),
-        sa.Column("workspace_id", sa.String(length=36), sa.ForeignKey("workspaces.id"), nullable=False),
+        sa.Column(
+            "workspace_id", sa.String(length=36), sa.ForeignKey("workspaces.id"), nullable=False
+        ),
         sa.Column("name", sa.String(length=255), nullable=False),
         sa.Column("slug", sa.String(length=255), nullable=False),
         sa.Column("description", sa.Text, nullable=True),
@@ -70,7 +71,9 @@ def upgrade() -> None:
         sa.Column("project_id", sa.String(length=36), sa.ForeignKey("projects.id"), nullable=False),
         sa.Column("name", sa.String(length=255), nullable=False),
         sa.Column("description", sa.Text, nullable=True),
-        sa.Column("class_map_id", sa.String(length=36), sa.ForeignKey("class_maps.id"), nullable=True),
+        sa.Column(
+            "class_map_id", sa.String(length=36), sa.ForeignKey("class_maps.id"), nullable=True
+        ),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
     )
 
@@ -107,7 +110,9 @@ def upgrade() -> None:
         "memberships",
         sa.Column("id", sa.String(length=36), primary_key=True),
         sa.Column("user_id", sa.String(length=36), sa.ForeignKey("users.id"), nullable=False),
-        sa.Column("workspace_id", sa.String(length=36), sa.ForeignKey("workspaces.id"), nullable=False),
+        sa.Column(
+            "workspace_id", sa.String(length=36), sa.ForeignKey("workspaces.id"), nullable=False
+        ),
         sa.Column("role", sa.String(length=32), nullable=False),
         sa.Column("invited_by", sa.String(length=36), sa.ForeignKey("users.id"), nullable=True),
         sa.Column("invited_at", sa.DateTime(timezone=True), nullable=True),
@@ -185,7 +190,9 @@ def upgrade() -> None:
     op.create_table(
         "invitations",
         sa.Column("id", sa.String(length=36), primary_key=True),
-        sa.Column("workspace_id", sa.String(length=36), sa.ForeignKey("workspaces.id"), nullable=False),
+        sa.Column(
+            "workspace_id", sa.String(length=36), sa.ForeignKey("workspaces.id"), nullable=False
+        ),
         sa.Column("email", sa.String(length=320), nullable=False),
         sa.Column("role", sa.String(length=32), nullable=False),
         sa.Column("token", sa.String(length=255), nullable=False),
@@ -236,7 +243,12 @@ def upgrade() -> None:
         "al_runs",
         sa.Column("id", sa.String(length=36), primary_key=True),
         sa.Column("project_id", sa.String(length=36), sa.ForeignKey("projects.id"), nullable=False),
-        sa.Column("dataset_version_id", sa.String(length=36), sa.ForeignKey("dataset_versions.id"), nullable=False),
+        sa.Column(
+            "dataset_version_id",
+            sa.String(length=36),
+            sa.ForeignKey("dataset_versions.id"),
+            nullable=False,
+        ),
         sa.Column("strategy", sa.String(length=64), nullable=False),
         sa.Column("status", sa.String(length=32), nullable=False),
         sa.Column("config_json", sa.Text, nullable=True),

--- a/backend/src/app/db/migrations/versions/0002_add_missing_columns.py
+++ b/backend/src/app/db/migrations/versions/0002_add_missing_columns.py
@@ -4,6 +4,7 @@ Revision ID: 0002_add_missing_columns
 Revises: 0001_initial_schema
 Create Date: 2026-03-15
 """
+
 from alembic import op
 import sqlalchemy as sa
 
@@ -17,7 +18,9 @@ def upgrade() -> None:
     # experiment_runs: add name, code_hash, started_at columns
     op.add_column("experiment_runs", sa.Column("name", sa.String(255), nullable=True))
     op.add_column("experiment_runs", sa.Column("code_hash", sa.String(64), nullable=True))
-    op.add_column("experiment_runs", sa.Column("started_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "experiment_runs", sa.Column("started_at", sa.DateTime(timezone=True), nullable=True)
+    )
 
     # model_artifacts: add storage_path, format, name columns
     op.add_column("model_artifacts", sa.Column("storage_path", sa.String(1024), nullable=True))
@@ -25,7 +28,9 @@ def upgrade() -> None:
     op.add_column("model_artifacts", sa.Column("name", sa.String(255), nullable=True))
 
     # users: add is_superuser
-    op.add_column("users", sa.Column("is_superuser", sa.Boolean(), nullable=True, server_default="false"))
+    op.add_column(
+        "users", sa.Column("is_superuser", sa.Boolean(), nullable=True, server_default="false")
+    )
 
     # jobs: add error_message, result_json, logs_uri (if not exists)
     op.add_column("jobs", sa.Column("error_message", sa.Text(), nullable=True))
@@ -33,7 +38,9 @@ def upgrade() -> None:
     op.add_column("jobs", sa.Column("logs_uri", sa.String(1024), nullable=True))
     op.add_column(
         "jobs",
-        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True, server_default=sa.func.now()),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=True, server_default=sa.func.now()
+        ),
     )
 
 

--- a/backend/src/app/db/migrations/versions/0004_force_bcrypt.py
+++ b/backend/src/app/db/migrations/versions/0004_force_bcrypt.py
@@ -1,0 +1,33 @@
+"""Invalidate any non-bcrypt password hashes (force password reset).
+
+Revision ID: 0004_force_bcrypt
+Revises: 0003_clusters
+Create Date: 2026-05-08
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0004_force_bcrypt"
+down_revision = "0003_clusters"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Null out any hash that doesn't look like bcrypt. Affected users will fail
+    # to log in (`authenticate` returns None) and must reset via admin tool.
+    bind = op.get_bind()
+    bind.execute(sa.text("""
+            UPDATE users
+               SET password_hash = NULL
+             WHERE password_hash IS NOT NULL
+               AND password_hash NOT LIKE '$2a$%'
+               AND password_hash NOT LIKE '$2b$%'
+               AND password_hash NOT LIKE '$2y$%'
+            """))
+
+
+def downgrade() -> None:
+    # Cannot un-null without the original plaintext.
+    pass

--- a/backend/src/app/db/migrations/versions/0005_evaluations.py
+++ b/backend/src/app/db/migrations/versions/0005_evaluations.py
@@ -1,0 +1,69 @@
+"""Add evaluations table.
+
+Revision ID: 0005_evaluations
+Revises: 0004_force_bcrypt
+Create Date: 2026-05-08
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0005_evaluations"
+down_revision = "0004_force_bcrypt"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "evaluations",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.String(length=36),
+            sa.ForeignKey("projects.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "artifact_id",
+            sa.String(length=36),
+            sa.ForeignKey("model_artifacts.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "dataset_version_id",
+            sa.String(length=36),
+            sa.ForeignKey("dataset_versions.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "cluster_id",
+            sa.String(length=36),
+            sa.ForeignKey("clusters.id"),
+            nullable=True,
+        ),
+        sa.Column("job_id", sa.String(length=36), sa.ForeignKey("jobs.id"), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False, server_default="queued"),
+        sa.Column("metrics_json", sa.Text(), nullable=True),
+        sa.Column("per_class_json", sa.Text(), nullable=True),
+        sa.Column("confusion_json", sa.Text(), nullable=True),
+        sa.Column("classes_json", sa.Text(), nullable=True),
+        sa.Column("samples_json", sa.Text(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=True,
+        ),
+    )
+    op.create_index("ix_evaluations_artifact_id", "evaluations", ["artifact_id"])
+    op.create_index("ix_evaluations_dataset_version_id", "evaluations", ["dataset_version_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_evaluations_dataset_version_id", table_name="evaluations")
+    op.drop_index("ix_evaluations_artifact_id", table_name="evaluations")
+    op.drop_table("evaluations")

--- a/backend/src/app/db/migrations/versions/0006_annotation_versioning.py
+++ b/backend/src/app/db/migrations/versions/0006_annotation_versioning.py
@@ -1,0 +1,30 @@
+"""Add annotation.version and annotation.updated_at for optimistic locking.
+
+Revision ID: 0006_annotation_versioning
+Revises: 0005_evaluations
+Create Date: 2026-05-08
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0006_annotation_versioning"
+down_revision = "0005_evaluations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "annotations",
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+    )
+    op.add_column(
+        "annotations",
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("annotations", "updated_at")
+    op.drop_column("annotations", "version")

--- a/backend/src/app/jobs/tasks/evaluation.py
+++ b/backend/src/app/jobs/tasks/evaluation.py
@@ -152,19 +152,25 @@ def compute_detection_metrics(
 
     for item in items:
         gts = list(item.get("gt") or [])
-        preds = sorted(item.get("pred") or [], key=lambda p: -float(p.get("score", 0.0)))
-        used = [False] * len(gts)
+        preds = sorted(
+            item.get("pred") or [], key=lambda p: -float(p.get("score", 0.0))
+        )
         for cls in {g.get("class") for g in gts}:
             if cls in idx:
                 pr_npos[cls] += sum(1 for g in gts if g.get("class") == cls)
         for g in gts:
             if g.get("class") in idx:
                 support[g["class"]] += 1
+
+        # ---- Pass 1: class-STRICT matching for TP / FP / FN / AP ----
+        # Each prediction is greedily matched to the highest-IoU same-class GT
+        # above the threshold. This is the standard mAP@iou definition.
+        used_strict = [False] * len(gts)
         for p in preds:
             best_j = -1
             best_iou = 0.0
             for j, g in enumerate(gts):
-                if used[j]:
+                if used_strict[j]:
                     continue
                 if g.get("class") != p.get("class"):
                     continue
@@ -174,20 +180,40 @@ def compute_detection_metrics(
                     best_j = j
             cls = p.get("class")
             if best_j >= 0 and best_iou >= iou_threshold:
-                used[best_j] = True
+                used_strict[best_j] = True
                 if cls in idx:
                     tp[cls] += 1
-                    matrix[idx[cls]][idx[cls]] += 1
                 pr_data[cls].append((float(p.get("score", 0.0)), 1))
             else:
                 if cls in idx:
                     fp[cls] += 1
                 pr_data[cls].append((float(p.get("score", 0.0)), 0))
         for j, g in enumerate(gts):
-            if not used[j]:
+            if not used_strict[j]:
                 cls = g.get("class")
                 if cls in idx:
                     fn[cls] += 1
+
+        # ---- Pass 2: class-AGNOSTIC matching for the confusion matrix ----
+        # Match each prediction to its best-IoU GT regardless of class so we
+        # can record off-diagonal cells (predicted X when ground truth was Y).
+        used_any = [False] * len(gts)
+        for p in preds:
+            best_j = -1
+            best_iou = 0.0
+            for j, g in enumerate(gts):
+                if used_any[j]:
+                    continue
+                iou = _iou(tuple(p["bbox"]), tuple(g["bbox"]))
+                if iou > best_iou:
+                    best_iou = iou
+                    best_j = j
+            if best_j >= 0 and best_iou >= iou_threshold:
+                used_any[best_j] = True
+                pred_cls = p.get("class")
+                gt_cls = gts[best_j].get("class")
+                if pred_cls in idx and gt_cls in idx:
+                    matrix[idx[gt_cls]][idx[pred_cls]] += 1
 
     per_class: dict[str, Any] = {}
     macro_p = macro_r = macro_f1 = macro_ap = 0.0
@@ -380,7 +406,9 @@ def evaluate_task(payload: dict) -> dict:
         # Determine task: detection if any annotation has type "box", else classification
         first_asset_anns = list(
             db.scalars(
-                select(Annotation).where(Annotation.asset_id.in_([a.id for a in assets[:50]]))
+                select(Annotation).where(
+                    Annotation.asset_id.in_([a.id for a in assets[:50]])
+                )
             ).all()
         )
         is_detection = any(a.type == "box" for a in first_asset_anns)
@@ -396,7 +424,9 @@ def evaluate_task(payload: dict) -> dict:
             samples: list[dict[str, Any]] = []
             for i, asset in enumerate(assets):
                 anns = list(
-                    db.scalars(select(Annotation).where(Annotation.asset_id == asset.id)).all()
+                    db.scalars(
+                        select(Annotation).where(Annotation.asset_id == asset.id)
+                    ).all()
                 )
                 gts = []
                 for a in anns:
@@ -469,7 +499,9 @@ def evaluate_task(payload: dict) -> dict:
                         progress=0.1 + 0.85 * (i / len(assets)),
                     )
 
-            result = compute_detection_metrics(items, classes, iou_threshold=iou_threshold)
+            result = compute_detection_metrics(
+                items, classes, iou_threshold=iou_threshold
+            )
             write_result(
                 db,
                 eval_id,
@@ -485,7 +517,9 @@ def evaluate_task(payload: dict) -> dict:
             samples = []
             for i, asset in enumerate(assets):
                 anns = list(
-                    db.scalars(select(Annotation).where(Annotation.asset_id == asset.id)).all()
+                    db.scalars(
+                        select(Annotation).where(Annotation.asset_id == asset.id)
+                    ).all()
                 )
                 gt_cls: str | None = None
                 for a in anns:
@@ -562,7 +596,10 @@ def _load_model(artifact, scratch_dir: Path) -> Any:
     if fmt == "onnx" or str(local).endswith(".onnx"):
         import onnxruntime as ort  # type: ignore
 
-        return ("onnx", ort.InferenceSession(str(local), providers=["CPUExecutionProvider"]))
+        return (
+            "onnx",
+            ort.InferenceSession(str(local), providers=["CPUExecutionProvider"]),
+        )
     # Default: YOLO weights
     from ultralytics import YOLO  # type: ignore
 
@@ -589,7 +626,9 @@ def _predict_detections(model, asset, score_threshold: float) -> list[dict[str, 
                     {
                         "class": names.get(cls_idx, str(cls_idx)),
                         "bbox": (cx - w / 2, cy - h / 2, w, h),
-                        "score": float(box.conf.item()) if hasattr(box, "conf") else 0.0,
+                        "score": (
+                            float(box.conf.item()) if hasattr(box, "conf") else 0.0
+                        ),
                     }
                 )
         return out

--- a/backend/src/app/jobs/tasks/evaluation.py
+++ b/backend/src/app/jobs/tasks/evaluation.py
@@ -275,6 +275,21 @@ def _download_to(uri: str, dest: Path) -> bool:
         return False
 
 
+def _asset_split(asset) -> str | None:
+    """Read the asset's split tag (test/val/train) from its meta_data JSON."""
+    md = getattr(asset, "meta_data", None)
+    if not md:
+        return None
+    try:
+        parsed = json.loads(md)
+    except Exception:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    val = parsed.get("split") or parsed.get("subset")
+    return str(val).lower() if val else None
+
+
 def _load_classes_for_dataset(db, version) -> list[str]:
     from app.models.dataset import ClassMap, Dataset
 
@@ -302,6 +317,7 @@ def evaluate_task(payload: dict) -> dict:
     iou_threshold = float(payload.get("iouThreshold", 0.5))
     sample_budget = int(payload.get("sampleFpFnCount", 50))
     max_samples = int(payload.get("maxSamples", 0)) or None
+    split = (payload.get("split") or "all").lower()
 
     db = _make_session()
     try:
@@ -336,6 +352,14 @@ def evaluate_task(payload: dict) -> dict:
                 )
             ).all()
         )
+        # Apply split filter. We look in `meta_data.split` (set by the importers /
+        # annotation tools). When "all", every labeled asset is in scope; when a
+        # specific split is requested but no asset carries that tag, we fall back
+        # to "all" rather than silently scoring zero samples.
+        if split and split != "all":
+            tagged = [a for a in assets if _asset_split(a) == split]
+            if tagged:
+                assets = tagged
         if max_samples:
             assets = assets[:max_samples]
         if not assets:
@@ -361,8 +385,11 @@ def evaluate_task(payload: dict) -> dict:
         )
         is_detection = any(a.type == "box" for a in first_asset_anns)
 
-        # Load model
-        model = _load_model(artifact)
+        # Single per-task scratch dir — cleans up the downloaded weights when we
+        # exit the `with` block, regardless of success/failure.
+        scratch_ctx = tempfile.TemporaryDirectory()
+        scratch_dir = Path(scratch_ctx.name)
+        model = _load_model(artifact, scratch_dir)
 
         if is_detection:
             items: list[dict[str, Any]] = []
@@ -516,17 +543,20 @@ def evaluate_task(payload: dict) -> dict:
             pass
         return {"status": "failed", "error": msg}
     finally:
+        try:
+            scratch_ctx.cleanup()
+        except (UnboundLocalError, NameError, FileNotFoundError):
+            pass
         db.close()
 
 
-def _load_model(artifact) -> Any:
-    """Lazy model loader. Tries Ultralytics YOLO first, then ONNXRuntime."""
+def _load_model(artifact, scratch_dir: Path) -> Any:
+    """Lazy model loader. Downloads weights into `scratch_dir` (caller-managed)."""
     storage_path = artifact.storage_path
     if not storage_path:
         raise RuntimeError("artifact has no storage_path")
-    local = Path(tempfile.mkdtemp()) / Path(storage_path).name
-    ok = _download_to(storage_path, local)
-    if not ok:
+    local = scratch_dir / Path(storage_path).name
+    if not _download_to(storage_path, local):
         raise RuntimeError(f"could not fetch artifact from {storage_path}")
     fmt = (artifact.format or artifact.type or "").lower()
     if fmt == "onnx" or str(local).endswith(".onnx"):
@@ -541,10 +571,12 @@ def _load_model(artifact) -> Any:
 
 def _predict_detections(model, asset, score_threshold: float) -> list[dict[str, Any]]:
     kind, m = model
-    img_path = Path(tempfile.mkdtemp()) / "img"
-    if not _download_to(asset.uri, img_path):
-        return []
-    if kind == "yolo":
+    with tempfile.TemporaryDirectory() as tmp:
+        img_path = Path(tmp) / "img"
+        if not _download_to(asset.uri, img_path):
+            return []
+        if kind != "yolo":
+            return []
         results = m.predict(str(img_path), conf=score_threshold, verbose=False)
         out: list[dict[str, Any]] = []
         for r in results:
@@ -561,15 +593,16 @@ def _predict_detections(model, asset, score_threshold: float) -> list[dict[str, 
                     }
                 )
         return out
-    return []
 
 
 def _predict_classification(model, asset, classes: list[str]) -> tuple[str, float]:
     kind, m = model
-    img_path = Path(tempfile.mkdtemp()) / "img"
-    if not _download_to(asset.uri, img_path):
-        return ("unknown", 0.0)
-    if kind == "yolo":
+    with tempfile.TemporaryDirectory() as tmp:
+        img_path = Path(tmp) / "img"
+        if not _download_to(asset.uri, img_path):
+            return ("unknown", 0.0)
+        if kind != "yolo":
+            return ("unknown", 0.0)
         results = m.predict(str(img_path), verbose=False)
         for r in results:
             probs = getattr(r, "probs", None)

--- a/backend/src/app/jobs/tasks/evaluation.py
+++ b/backend/src/app/jobs/tasks/evaluation.py
@@ -1,0 +1,583 @@
+"""Celery task: evaluate a trained model artifact against a dataset version.
+
+Runs the artifact (PyTorch / ONNX) over labeled assets in the requested split,
+computes summary metrics, per-class P/R/F1, a confusion matrix, and a sample
+of false positives / false negatives for the FP/FN viewer.
+
+Heavy ML deps (ultralytics, torch, onnxruntime) are imported lazily so the
+module is safe to load in test environments where those wheels are absent.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+try:
+    from celery import shared_task  # type: ignore
+except Exception:  # pragma: no cover
+
+    def shared_task(*args, **kwargs):
+        def _wrap(fn):
+            return fn
+
+        return _wrap
+
+
+def _make_session():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    db_url = os.getenv("DATABASE_URL", "sqlite+pysqlite:///./test.db")
+    connect_args = {"check_same_thread": False} if db_url.startswith("sqlite") else {}
+    engine = create_engine(db_url, connect_args=connect_args)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False)()
+
+
+def _iou(box_a: tuple[float, ...], box_b: tuple[float, ...]) -> float:
+    ax1, ay1, aw, ah = box_a
+    bx1, by1, bw, bh = box_b
+    ax2, ay2 = ax1 + aw, ay1 + ah
+    bx2, by2 = bx1 + bw, by1 + bh
+    ix1, iy1 = max(ax1, bx1), max(ay1, by1)
+    ix2, iy2 = min(ax2, bx2), min(ay2, by2)
+    iw, ih = max(0.0, ix2 - ix1), max(0.0, iy2 - iy1)
+    inter = iw * ih
+    area_a = max(0.0, aw) * max(0.0, ah)
+    area_b = max(0.0, bw) * max(0.0, bh)
+    union = area_a + area_b - inter
+    if union <= 0:
+        return 0.0
+    return inter / union
+
+
+def compute_classification_metrics(
+    pairs: list[tuple[str, str]], classes: list[str]
+) -> dict[str, Any]:
+    """Build accuracy + per-class P/R/F1 + confusion matrix from (pred, gt) pairs."""
+    n = len(pairs)
+    if n == 0:
+        return {
+            "metrics": {"accuracy": 0.0, "precision": 0.0, "recall": 0.0, "f1": 0.0},
+            "per_class": {},
+            "confusion": [[0] * len(classes) for _ in classes],
+            "classes": classes,
+        }
+    idx = {c: i for i, c in enumerate(classes)}
+    matrix = [[0 for _ in classes] for _ in classes]
+    correct = 0
+    tp = defaultdict(int)
+    fp = defaultdict(int)
+    fn = defaultdict(int)
+    support = defaultdict(int)
+    for pred, gt in pairs:
+        if gt in idx:
+            support[gt] += 1
+        if pred == gt:
+            correct += 1
+            if pred in idx:
+                tp[pred] += 1
+                matrix[idx[gt]][idx[pred]] += 1
+        else:
+            if pred in idx:
+                fp[pred] += 1
+            if gt in idx:
+                fn[gt] += 1
+            if pred in idx and gt in idx:
+                matrix[idx[gt]][idx[pred]] += 1
+
+    per_class: dict[str, Any] = {}
+    macro_p = macro_r = macro_f1 = 0.0
+    counted = 0
+    for c in classes:
+        p = tp[c] / (tp[c] + fp[c]) if (tp[c] + fp[c]) > 0 else 0.0
+        r = tp[c] / (tp[c] + fn[c]) if (tp[c] + fn[c]) > 0 else 0.0
+        f1 = 2 * p * r / (p + r) if (p + r) > 0 else 0.0
+        per_class[c] = {
+            "precision": round(p, 4),
+            "recall": round(r, 4),
+            "f1": round(f1, 4),
+            "support": support[c],
+        }
+        if support[c] > 0:
+            macro_p += p
+            macro_r += r
+            macro_f1 += f1
+            counted += 1
+
+    if counted > 0:
+        macro_p /= counted
+        macro_r /= counted
+        macro_f1 /= counted
+
+    return {
+        "metrics": {
+            "accuracy": round(correct / n, 4),
+            "precision": round(macro_p, 4),
+            "recall": round(macro_r, 4),
+            "f1": round(macro_f1, 4),
+            "samples": n,
+        },
+        "per_class": per_class,
+        "confusion": matrix,
+        "classes": classes,
+    }
+
+
+def compute_detection_metrics(
+    items: list[dict[str, Any]],
+    classes: list[str],
+    *,
+    iou_threshold: float = 0.5,
+) -> dict[str, Any]:
+    """Compute detection mAP@iou + per-class P/R/F1 + confusion matrix.
+
+    `items` is a list of {asset_id, gt: [{class, bbox}], pred: [{class, bbox, score}]}.
+    bbox is (x, y, w, h) in pixel space.
+    """
+    idx = {c: i for i, c in enumerate(classes)}
+    matrix = [[0 for _ in classes] for _ in classes]
+    tp = defaultdict(int)
+    fp = defaultdict(int)
+    fn = defaultdict(int)
+    support = defaultdict(int)
+
+    # AP@iou via interpolated PR per class
+    pr_data: dict[str, list[tuple[float, int]]] = defaultdict(list)  # (score, is_tp)
+    pr_npos: dict[str, int] = defaultdict(int)
+
+    for item in items:
+        gts = list(item.get("gt") or [])
+        preds = sorted(item.get("pred") or [], key=lambda p: -float(p.get("score", 0.0)))
+        used = [False] * len(gts)
+        for cls in {g.get("class") for g in gts}:
+            if cls in idx:
+                pr_npos[cls] += sum(1 for g in gts if g.get("class") == cls)
+        for g in gts:
+            if g.get("class") in idx:
+                support[g["class"]] += 1
+        for p in preds:
+            best_j = -1
+            best_iou = 0.0
+            for j, g in enumerate(gts):
+                if used[j]:
+                    continue
+                if g.get("class") != p.get("class"):
+                    continue
+                iou = _iou(tuple(p["bbox"]), tuple(g["bbox"]))
+                if iou > best_iou:
+                    best_iou = iou
+                    best_j = j
+            cls = p.get("class")
+            if best_j >= 0 and best_iou >= iou_threshold:
+                used[best_j] = True
+                if cls in idx:
+                    tp[cls] += 1
+                    matrix[idx[cls]][idx[cls]] += 1
+                pr_data[cls].append((float(p.get("score", 0.0)), 1))
+            else:
+                if cls in idx:
+                    fp[cls] += 1
+                pr_data[cls].append((float(p.get("score", 0.0)), 0))
+        for j, g in enumerate(gts):
+            if not used[j]:
+                cls = g.get("class")
+                if cls in idx:
+                    fn[cls] += 1
+
+    per_class: dict[str, Any] = {}
+    macro_p = macro_r = macro_f1 = macro_ap = 0.0
+    counted = 0
+    for c in classes:
+        p = tp[c] / (tp[c] + fp[c]) if (tp[c] + fp[c]) > 0 else 0.0
+        r = tp[c] / (tp[c] + fn[c]) if (tp[c] + fn[c]) > 0 else 0.0
+        f1 = 2 * p * r / (p + r) if (p + r) > 0 else 0.0
+        # AP@iou: sort by score desc and integrate
+        rows = sorted(pr_data[c], key=lambda x: -x[0])
+        cum_tp = cum_fp = 0
+        recalls = [0.0]
+        precisions = [1.0]
+        npos = pr_npos.get(c, 0) or 1
+        for _score, is_tp in rows:
+            if is_tp:
+                cum_tp += 1
+            else:
+                cum_fp += 1
+            recall = cum_tp / npos
+            prec = cum_tp / max(1, cum_tp + cum_fp)
+            recalls.append(recall)
+            precisions.append(prec)
+        # 11-point interpolation
+        ap = 0.0
+        for t in [i / 10 for i in range(11)]:
+            valid = [precisions[i] for i in range(len(recalls)) if recalls[i] >= t]
+            ap += max(valid) if valid else 0.0
+        ap /= 11.0
+        per_class[c] = {
+            "precision": round(p, 4),
+            "recall": round(r, 4),
+            "f1": round(f1, 4),
+            "support": support[c],
+            "ap50": round(ap, 4),
+        }
+        if support[c] > 0:
+            macro_p += p
+            macro_r += r
+            macro_f1 += f1
+            macro_ap += ap
+            counted += 1
+
+    if counted > 0:
+        macro_p /= counted
+        macro_r /= counted
+        macro_f1 /= counted
+        macro_ap /= counted
+
+    return {
+        "metrics": {
+            "mAP50": round(macro_ap, 4),
+            "precision": round(macro_p, 4),
+            "recall": round(macro_r, 4),
+            "f1": round(macro_f1, 4),
+            "samples": len(items),
+        },
+        "per_class": per_class,
+        "confusion": matrix,
+        "classes": classes,
+    }
+
+
+def _download_to(uri: str, dest: Path) -> bool:
+    """Download an asset URI (S3 key, http URL, or local path) to dest."""
+    try:
+        if uri.startswith(("http://", "https://")):
+            import urllib.request
+
+            urllib.request.urlretrieve(uri, str(dest))  # noqa: S310
+            return True
+        if os.path.exists(uri):
+            import shutil
+
+            shutil.copy(uri, dest)
+            return True
+        # Treat as MinIO key
+        from app.services.storage import get_minio_client
+
+        bucket = os.getenv("MINIO_BUCKET", os.getenv("S3_BUCKET", "visionforge"))
+        client = get_minio_client()
+        client.fget_object(bucket, uri, str(dest))
+        return True
+    except Exception:
+        return False
+
+
+def _load_classes_for_dataset(db, version) -> list[str]:
+    from app.models.dataset import ClassMap, Dataset
+
+    dataset = db.get(Dataset, version.dataset_id)
+    if dataset and dataset.class_map_id:
+        cm = db.get(ClassMap, dataset.class_map_id)
+        if cm and cm.classes:
+            try:
+                classes = json.loads(cm.classes)
+                if isinstance(classes, list) and classes:
+                    return [str(c) for c in classes]
+            except Exception:
+                pass
+    return []
+
+
+@shared_task(name="app.jobs.tasks.evaluation.evaluate_task")
+def evaluate_task(payload: dict) -> dict:
+    """Run the eval. Returns a status dict; persists results to the Evaluation row."""
+    job_id = payload.get("jobId")
+    eval_id = payload.get("evaluationId")
+    artifact_id = payload.get("artifactId")
+    version_id = payload.get("datasetVersionId")
+    score_threshold = float(payload.get("scoreThreshold", 0.25))
+    iou_threshold = float(payload.get("iouThreshold", 0.5))
+    sample_budget = int(payload.get("sampleFpFnCount", 50))
+    max_samples = int(payload.get("maxSamples", 0)) or None
+
+    db = _make_session()
+    try:
+        from app.models.annotation import Annotation
+        from app.models.artifact import ModelArtifact
+        from app.models.asset import Asset
+        from app.models.dataset_version import DatasetVersion
+        from app.services.evaluation_service import write_result
+        from app.services.jobs_service import update_job_status
+
+        if job_id:
+            update_job_status(db, job_id, status="running", progress=0.05)
+        write_result(db, eval_id, status="running")
+
+        artifact = db.get(ModelArtifact, artifact_id)
+        version = db.get(DatasetVersion, version_id)
+        if not artifact or not version:
+            raise RuntimeError("artifact or dataset version not found")
+
+        classes = _load_classes_for_dataset(db, version)
+        if not classes:
+            classes = ["object"]
+
+        # Pull labeled assets in this version
+        from sqlalchemy import select
+
+        assets = list(
+            db.scalars(
+                select(Asset).where(
+                    Asset.version_id == version.id,
+                    Asset.label_status.in_(("labeled", "prelabeled")),
+                )
+            ).all()
+        )
+        if max_samples:
+            assets = assets[:max_samples]
+        if not assets:
+            write_result(
+                db,
+                eval_id,
+                status="succeeded",
+                metrics={"samples": 0},
+                per_class={},
+                confusion=[[0] * len(classes) for _ in classes],
+                classes=classes,
+                samples=[],
+            )
+            if job_id:
+                update_job_status(db, job_id, status="succeeded", progress=1.0)
+            return {"status": "succeeded", "samples": 0}
+
+        # Determine task: detection if any annotation has type "box", else classification
+        first_asset_anns = list(
+            db.scalars(
+                select(Annotation).where(Annotation.asset_id.in_([a.id for a in assets[:50]]))
+            ).all()
+        )
+        is_detection = any(a.type == "box" for a in first_asset_anns)
+
+        # Load model
+        model = _load_model(artifact)
+
+        if is_detection:
+            items: list[dict[str, Any]] = []
+            samples: list[dict[str, Any]] = []
+            for i, asset in enumerate(assets):
+                anns = list(
+                    db.scalars(select(Annotation).where(Annotation.asset_id == asset.id)).all()
+                )
+                gts = []
+                for a in anns:
+                    if a.type != "box":
+                        continue
+                    try:
+                        g = json.loads(a.geometry)
+                        gts.append(
+                            {
+                                "class": a.class_name or "object",
+                                "bbox": (
+                                    g.get("x", 0),
+                                    g.get("y", 0),
+                                    g.get("w", 0),
+                                    g.get("h", 0),
+                                ),
+                            }
+                        )
+                    except Exception:
+                        continue
+
+                preds = _predict_detections(model, asset, score_threshold)
+                items.append({"asset_id": asset.id, "gt": gts, "pred": preds})
+
+                # Build FP/FN samples (cap)
+                if len(samples) < sample_budget:
+                    used = [False] * len(gts)
+                    for p in preds:
+                        match_j = -1
+                        match_iou = 0.0
+                        for j, g in enumerate(gts):
+                            if used[j]:
+                                continue
+                            if g["class"] != p["class"]:
+                                continue
+                            iou = _iou(tuple(p["bbox"]), tuple(g["bbox"]))
+                            if iou > match_iou:
+                                match_iou = iou
+                                match_j = j
+                        if match_j >= 0 and match_iou >= iou_threshold:
+                            used[match_j] = True
+                        else:
+                            samples.append(
+                                {
+                                    "asset_id": asset.id,
+                                    "predicted": p["class"],
+                                    "ground_truth": None,
+                                    "score": p.get("score"),
+                                    "kind": "fp",
+                                }
+                            )
+                            if len(samples) >= sample_budget:
+                                break
+                    for j, g in enumerate(gts):
+                        if not used[j] and len(samples) < sample_budget:
+                            samples.append(
+                                {
+                                    "asset_id": asset.id,
+                                    "predicted": None,
+                                    "ground_truth": g["class"],
+                                    "kind": "fn",
+                                }
+                            )
+
+                if job_id and i % 10 == 0:
+                    update_job_status(
+                        db,
+                        job_id,
+                        status="running",
+                        progress=0.1 + 0.85 * (i / len(assets)),
+                    )
+
+            result = compute_detection_metrics(items, classes, iou_threshold=iou_threshold)
+            write_result(
+                db,
+                eval_id,
+                status="succeeded",
+                metrics=result["metrics"],
+                per_class=result["per_class"],
+                confusion=result["confusion"],
+                classes=classes,
+                samples=samples,
+            )
+        else:
+            pairs: list[tuple[str, str]] = []
+            samples = []
+            for i, asset in enumerate(assets):
+                anns = list(
+                    db.scalars(select(Annotation).where(Annotation.asset_id == asset.id)).all()
+                )
+                gt_cls: str | None = None
+                for a in anns:
+                    if a.type == "classification":
+                        gt_cls = a.class_name
+                        break
+                if gt_cls is None:
+                    continue
+                pred_cls, score = _predict_classification(model, asset, classes)
+                pairs.append((pred_cls, gt_cls))
+                if pred_cls != gt_cls and len(samples) < sample_budget:
+                    samples.append(
+                        {
+                            "asset_id": asset.id,
+                            "predicted": pred_cls,
+                            "ground_truth": gt_cls,
+                            "score": score,
+                            "kind": "fp",
+                        }
+                    )
+                if job_id and i % 10 == 0:
+                    update_job_status(
+                        db,
+                        job_id,
+                        status="running",
+                        progress=0.1 + 0.85 * (i / len(assets)),
+                    )
+
+            result = compute_classification_metrics(pairs, classes)
+            write_result(
+                db,
+                eval_id,
+                status="succeeded",
+                metrics=result["metrics"],
+                per_class=result["per_class"],
+                confusion=result["confusion"],
+                classes=classes,
+                samples=samples,
+            )
+
+        if job_id:
+            update_job_status(db, job_id, status="succeeded", progress=1.0)
+        return {"status": "succeeded"}
+
+    except Exception as exc:  # noqa: BLE001
+        msg = str(exc)
+        try:
+            from app.services.evaluation_service import write_result as _wr
+            from app.services.jobs_service import update_job_status as _us
+
+            _wr(db, eval_id, status="failed", error_message=msg)
+            if job_id:
+                _us(db, job_id, status="failed", progress=0.0)
+        except Exception:
+            pass
+        return {"status": "failed", "error": msg}
+    finally:
+        db.close()
+
+
+def _load_model(artifact) -> Any:
+    """Lazy model loader. Tries Ultralytics YOLO first, then ONNXRuntime."""
+    storage_path = artifact.storage_path
+    if not storage_path:
+        raise RuntimeError("artifact has no storage_path")
+    local = Path(tempfile.mkdtemp()) / Path(storage_path).name
+    ok = _download_to(storage_path, local)
+    if not ok:
+        raise RuntimeError(f"could not fetch artifact from {storage_path}")
+    fmt = (artifact.format or artifact.type or "").lower()
+    if fmt == "onnx" or str(local).endswith(".onnx"):
+        import onnxruntime as ort  # type: ignore
+
+        return ("onnx", ort.InferenceSession(str(local), providers=["CPUExecutionProvider"]))
+    # Default: YOLO weights
+    from ultralytics import YOLO  # type: ignore
+
+    return ("yolo", YOLO(str(local)))
+
+
+def _predict_detections(model, asset, score_threshold: float) -> list[dict[str, Any]]:
+    kind, m = model
+    img_path = Path(tempfile.mkdtemp()) / "img"
+    if not _download_to(asset.uri, img_path):
+        return []
+    if kind == "yolo":
+        results = m.predict(str(img_path), conf=score_threshold, verbose=False)
+        out: list[dict[str, Any]] = []
+        for r in results:
+            names = getattr(r, "names", {}) or {}
+            for box in getattr(r, "boxes", []) or []:
+                cls_idx = int(box.cls.item()) if hasattr(box, "cls") else 0
+                xy = box.xywh[0].tolist() if hasattr(box, "xywh") else [0, 0, 0, 0]
+                cx, cy, w, h = xy
+                out.append(
+                    {
+                        "class": names.get(cls_idx, str(cls_idx)),
+                        "bbox": (cx - w / 2, cy - h / 2, w, h),
+                        "score": float(box.conf.item()) if hasattr(box, "conf") else 0.0,
+                    }
+                )
+        return out
+    return []
+
+
+def _predict_classification(model, asset, classes: list[str]) -> tuple[str, float]:
+    kind, m = model
+    img_path = Path(tempfile.mkdtemp()) / "img"
+    if not _download_to(asset.uri, img_path):
+        return ("unknown", 0.0)
+    if kind == "yolo":
+        results = m.predict(str(img_path), verbose=False)
+        for r in results:
+            probs = getattr(r, "probs", None)
+            if probs is not None:
+                top = int(probs.top1)
+                names = getattr(r, "names", {}) or {}
+                return (
+                    names.get(top, str(top)),
+                    float(probs.top1conf.item()),
+                )
+    return ("unknown", 0.0)

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -18,6 +18,7 @@ from app.api.artifacts import router as artifacts_router
 from app.api.auth import router as auth_router
 from app.api.clusters import router as clusters_router
 from app.api.datasets import router as datasets_router
+from app.api.evaluations import router as evaluations_router
 from app.api.experiments import router as experiments_router
 from app.api.jobs import router as jobs_router
 from app.api.middleware import auth_rate_limit_middleware, logging_middleware
@@ -122,6 +123,7 @@ app.include_router(jobs_router)
 app.include_router(experiments_router)
 app.include_router(artifacts_router)
 app.include_router(clusters_router)
+app.include_router(evaluations_router)
 
 # New feature routers (conditionally registered based on availability)
 if _has_annotations:

--- a/backend/src/app/models/__init__.py
+++ b/backend/src/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.annotation_schema import AnnotationSchema  # noqa: F401
 from app.models.artifact import ModelArtifact as Artifact  # noqa: F401
 from app.models.asset import Asset  # noqa: F401
 from app.models.cluster import Cluster  # noqa: F401
+from app.models.evaluation import Evaluation  # noqa: F401
 from app.models.audit import Audit  # noqa: F401
 from app.models.admin import AuditEvent, Invitation, Notification  # noqa: F401
 from app.models.dataset import Dataset, ClassMap  # noqa: F401

--- a/backend/src/app/models/admin.py
+++ b/backend/src/app/models/admin.py
@@ -16,7 +16,9 @@ class Invitation(Base):
     __tablename__ = "invitations"
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
-    workspace_id: Mapped[str] = mapped_column(String(36), ForeignKey("workspaces.id"), nullable=False)
+    workspace_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("workspaces.id"), nullable=False
+    )
     email: Mapped[str] = mapped_column(String(320), nullable=False)
     role: Mapped[str] = mapped_column(String(32), nullable=False)
     token: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)

--- a/backend/src/app/models/alitem.py
+++ b/backend/src/app/models/alitem.py
@@ -21,5 +21,7 @@ class ALItem(Base):
     priority: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
     proposed_json: Mapped[str | None] = mapped_column(Text, nullable=True)
     resolved_status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")
-    resolved_by: Mapped[str | None] = mapped_column(String(36), ForeignKey("users.id"), nullable=True)
+    resolved_by: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("users.id"), nullable=True
+    )
     resolved_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/src/app/models/annotation.py
+++ b/backend/src/app/models/annotation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -12,14 +12,23 @@ def _uuid() -> str:
     return str(uuid.uuid4())
 
 
+# Allowed annotation types. Keep in sync with the frontend toolbox.
+ANNOTATION_TYPES = ("box", "polygon", "keypoint", "classification")
+
+
 class Annotation(Base):
     __tablename__ = "annotations"
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
     asset_id: Mapped[str] = mapped_column(String(36), ForeignKey("assets.id"), nullable=False)
-    type: Mapped[str] = mapped_column(String(50), nullable=False)  # box, polygon, etc.
+    type: Mapped[str] = mapped_column(String(50), nullable=False)
     geometry: Mapped[str] = mapped_column(Text, nullable=False)  # JSON
     class_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
     author_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
+    # Optimistic-lock counter. Bumped on every update; clients must send the
+    # current version to apply changes.
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    updated_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[object] = mapped_column(DateTime(timezone=True), server_default=func.now())
-    history: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON array
+    # JSON array of {version, geometry, class_name, updated_at}
+    history: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/src/app/models/artifact.py
+++ b/backend/src/app/models/artifact.py
@@ -17,7 +17,9 @@ class ModelArtifact(Base):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
     project_id: Mapped[str] = mapped_column(String(36), ForeignKey("projects.id"), nullable=False)
-    run_id: Mapped[str | None] = mapped_column(String(36), ForeignKey("experiment_runs.id"), nullable=True)
+    run_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("experiment_runs.id"), nullable=True
+    )
     name: Mapped[str] = mapped_column(String(255), nullable=False, default="")
     version: Mapped[str] = mapped_column(String(32), nullable=False, default="1")
     type: Mapped[str] = mapped_column(String(50), nullable=False)  # pytorch, onnx

--- a/backend/src/app/models/asset.py
+++ b/backend/src/app/models/asset.py
@@ -17,7 +17,9 @@ class Asset(Base):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
     dataset_id: Mapped[str] = mapped_column(String(36), ForeignKey("datasets.id"), nullable=False)
-    version_id: Mapped[str | None] = mapped_column(String(36), ForeignKey("dataset_versions.id"), nullable=True)
+    version_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("dataset_versions.id"), nullable=True
+    )
     uri: Mapped[str] = mapped_column(String(500), nullable=False)
     mime_type: Mapped[str] = mapped_column(String(100), nullable=False)
     width: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/backend/src/app/models/dataset.py
+++ b/backend/src/app/models/dataset.py
@@ -19,7 +19,9 @@ class Dataset(Base):
     project_id: Mapped[str] = mapped_column(String(36), ForeignKey("projects.id"), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    class_map_id: Mapped[str | None] = mapped_column(String(36), ForeignKey("class_maps.id"), nullable=True)
+    class_map_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("class_maps.id"), nullable=True
+    )
     created_at: Mapped[object] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     versions = relationship("DatasetVersion", back_populates="dataset")
@@ -30,4 +32,6 @@ class ClassMap(Base):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
     project_id: Mapped[str] = mapped_column(String(36), ForeignKey("projects.id"), nullable=False)
-    classes: Mapped[str] = mapped_column(Text, nullable=False)  # JSON array of {name, color, description}
+    classes: Mapped[str] = mapped_column(
+        Text, nullable=False
+    )  # JSON array of {name, color, description}

--- a/backend/src/app/models/evaluation.py
+++ b/backend/src/app/models/evaluation.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class Evaluation(Base):
+    """Result of running a trained model against a dataset version split.
+
+    Stores summary metrics (mAP, accuracy, per-class P/R/F1) plus links to a
+    sample of false positives and false negatives for the FP/FN viewer UI.
+    """
+
+    __tablename__ = "evaluations"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    project_id: Mapped[str] = mapped_column(String(36), ForeignKey("projects.id"), nullable=False)
+    artifact_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("model_artifacts.id"), nullable=False
+    )
+    dataset_version_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("dataset_versions.id"), nullable=False
+    )
+    cluster_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("clusters.id"), nullable=True
+    )
+    job_id: Mapped[str | None] = mapped_column(String(36), ForeignKey("jobs.id"), nullable=True)
+
+    # "queued" | "running" | "succeeded" | "failed"
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="queued")
+
+    # JSON: {"mAP50": 0.812, "mAP50-95": 0.643, "accuracy": 0.91, "precision": 0.87, ...}
+    metrics_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # JSON: {"class_name": {"precision": .., "recall": .., "f1": .., "support": .., "ap50": ..}}
+    per_class_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # JSON: 2D array of counts; classes_json holds row/col labels
+    confusion_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    classes_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # JSON: list of {asset_id, predicted, ground_truth, score, kind: "fp"|"fn"}
+    samples_json: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    started_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[object] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/src/app/models/experiment.py
+++ b/backend/src/app/models/experiment.py
@@ -26,8 +26,12 @@ class ExperimentRun(Base):
     )
     name: Mapped[str] = mapped_column(String(255), nullable=False, default="Unnamed Run")
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="queued")
-    params_json: Mapped[str | None] = mapped_column("params", Text, nullable=True)  # DB column "params" mapped to params_json
-    metrics_json: Mapped[str | None] = mapped_column("metrics", Text, nullable=True)  # DB column "metrics" mapped to metrics_json
+    params_json: Mapped[str | None] = mapped_column(
+        "params", Text, nullable=True
+    )  # DB column "params" mapped to params_json
+    metrics_json: Mapped[str | None] = mapped_column(
+        "metrics", Text, nullable=True
+    )  # DB column "metrics" mapped to metrics_json
     artifacts: Mapped[str | None] = mapped_column(Text, nullable=True)
     code_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
     started_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/src/app/models/project.py
+++ b/backend/src/app/models/project.py
@@ -16,7 +16,9 @@ class Project(Base):
     __tablename__ = "projects"
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
-    workspace_id: Mapped[str] = mapped_column(String(36), ForeignKey("workspaces.id"), nullable=False)
+    workspace_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("workspaces.id"), nullable=False
+    )
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     slug: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -24,4 +26,6 @@ class Project(Base):
     tags: Mapped[str | None] = mapped_column(String(1000), nullable=True)  # JSON array
     archived_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[object] = mapped_column(DateTime(timezone=True), server_default=func.now())
-    updated_at: Mapped[object] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    updated_at: Mapped[object] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/src/app/models/workspace.py
+++ b/backend/src/app/models/workspace.py
@@ -37,8 +37,12 @@ class Membership(Base):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
     user_id: Mapped[str] = mapped_column(String(36), ForeignKey("users.id"), nullable=False)
-    workspace_id: Mapped[str] = mapped_column(String(36), ForeignKey("workspaces.id"), nullable=False)
+    workspace_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("workspaces.id"), nullable=False
+    )
     role: Mapped[Role] = mapped_column(String(32), nullable=False, default=Role.VIEWER)
-    invited_by: Mapped[str | None] = mapped_column(String(36), ForeignKey("users.id"), nullable=True)
+    invited_by: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("users.id"), nullable=True
+    )
     invited_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)
     accepted_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/src/app/schemas/common.py
+++ b/backend/src/app/schemas/common.py
@@ -32,6 +32,14 @@ class OnnxExportRequest(BaseModel):
 
 
 class Job(BaseModel):
+    """Generic async job response.
+
+    Includes optional linkage fields so callers can wire the job back to the
+    domain object that spawned it (training run / evaluation / cluster) without
+    a second round trip and without `response_model=Job` silently dropping
+    the field.
+    """
+
     id: str
     jobId: str
     type: str
@@ -39,3 +47,6 @@ class Job(BaseModel):
     progress: float
     errorMessage: str | None = None
     createdAt: str | None = None
+    clusterId: str | None = None
+    experimentId: str | None = None
+    evaluationId: str | None = None

--- a/backend/src/app/schemas/common.py
+++ b/backend/src/app/schemas/common.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 class UploadUrlRequest(BaseModel):
     datasetVersionId: str
     filename: str
-    contentType: Optional[str] = None
+    contentType: str | None = None
 
 
 class UploadUrlResponse(BaseModel):
@@ -22,13 +22,13 @@ class TrainRequest(BaseModel):
     baseModel: str = "yolov8n.pt"
     params: dict[str, Any] = {}
     name: str = "Training Run"
-    clusterId: Optional[str] = None
+    clusterId: str | None = None
 
 
 class OnnxExportRequest(BaseModel):
     experimentId: str
-    dynamicAxes: Optional[bool] = True
-    clusterId: Optional[str] = None
+    dynamicAxes: bool | None = True
+    clusterId: str | None = None
 
 
 class Job(BaseModel):
@@ -37,5 +37,5 @@ class Job(BaseModel):
     type: str
     status: str
     progress: float
-    errorMessage: Optional[str] = None
-    createdAt: Optional[str] = None
+    errorMessage: str | None = None
+    createdAt: str | None = None

--- a/backend/src/app/schemas/dataset.py
+++ b/backend/src/app/schemas/dataset.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 class DatasetCreate(BaseModel):
     name: str
 
+
 class Dataset(BaseModel):
     id: str
     project_id: str

--- a/backend/src/app/schemas/evaluation.py
+++ b/backend/src/app/schemas/evaluation.py
@@ -67,3 +67,19 @@ class EvaluationSummary(BaseModel):
     primary_metric_name: str | None = None
     created_at: datetime | None = None
     completed_at: datetime | None = None
+
+
+class EvaluationJobResponse(BaseModel):
+    """Response for POST /api/evaluations.
+
+    Carries both the job linkage (for status polling) and the evaluation id
+    (so the UI can navigate to the evaluation detail page).
+    """
+
+    id: str  # alias of jobId, for backwards compat with the generic Job schema
+    jobId: str
+    type: str = "evaluation"
+    status: str
+    progress: float = 0.0
+    evaluationId: str
+    clusterId: str | None = None

--- a/backend/src/app/schemas/evaluation.py
+++ b/backend/src/app/schemas/evaluation.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class EvaluationCreate(BaseModel):
+    artifact_id: str
+    dataset_version_id: str
+    # Filter assets by label_status; default labeled only.
+    split: str = "test"  # "test" | "val" | "all"
+    cluster_id: str | None = None
+    iou_threshold: float = 0.5
+    score_threshold: float = 0.25
+    max_samples: int = 0  # 0 = no cap
+    # Sample budget for FP/FN viewer; 0 disables.
+    sample_fpfn_count: int = 50
+
+
+class PerClass(BaseModel):
+    precision: float
+    recall: float
+    f1: float
+    support: int
+    ap50: float | None = None
+
+
+class FpFnSample(BaseModel):
+    asset_id: str
+    predicted: str | None = None
+    ground_truth: str | None = None
+    score: float | None = None
+    kind: str  # "fp" | "fn" | "match"
+
+
+class EvaluationOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    project_id: str
+    artifact_id: str
+    dataset_version_id: str
+    cluster_id: str | None = None
+    job_id: str | None = None
+    status: str
+    metrics: dict[str, Any] | None = None
+    per_class: dict[str, PerClass] | None = None
+    confusion: list[list[int]] | None = None
+    classes: list[str] | None = None
+    samples: list[FpFnSample] | None = None
+    error_message: str | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    created_at: datetime | None = None
+
+
+class EvaluationSummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    artifact_id: str
+    dataset_version_id: str
+    status: str
+    primary_metric: float | None = None
+    primary_metric_name: str | None = None
+    created_at: datetime | None = None
+    completed_at: datetime | None = None

--- a/backend/src/app/schemas/project.py
+++ b/backend/src/app/schemas/project.py
@@ -7,6 +7,7 @@ class ProjectCreate(BaseModel):
     name: str
     description: Optional[str] = None
 
+
 class Project(BaseModel):
     id: str
     name: str

--- a/backend/src/app/services/annotation_service.py
+++ b/backend/src/app/services/annotation_service.py
@@ -19,7 +19,9 @@ class VersionConflictError(AnnotationError):
 
 
 def get_asset_annotations(db: Session, asset_id: str) -> list[Annotation]:
-    return list(db.scalars(select(Annotation).where(Annotation.asset_id == asset_id)).all())
+    return list(
+        db.scalars(select(Annotation).where(Annotation.asset_id == asset_id)).all()
+    )
 
 
 def create_annotation(
@@ -70,26 +72,39 @@ def update_annotation(
         raise VersionConflictError(
             f"annotation version mismatch: have {ann.version}, expected {expected_version}"
         )
-    if geometry is not None:
+
+    # Determine whether anything actually changes. An update with neither
+    # field is a no-op — return the current row without bumping the version
+    # (which would create needless optimistic-lock conflicts).
+    geometry_changing = geometry is not None
+    class_changing = class_name is not None and class_name != ann.class_name
+    if not geometry_changing and not class_changing:
+        return ann
+
+    if geometry_changing:
         _validate_geometry(ann.type, geometry)
-        # Push the previous state into history (cap at 20)
-        history: list[dict] = []
-        if ann.history:
-            try:
-                history = json.loads(ann.history) or []
-            except Exception:
-                history = []
-        history.append(
-            {
-                "version": ann.version,
-                "geometry": ann.geometry,
-                "class_name": ann.class_name,
-                "updated_at": ann.updated_at.isoformat() if ann.updated_at else None,
-            }
-        )
-        ann.history = json.dumps(history[-20:])
+
+    # Snapshot the previous state into history whenever either the geometry
+    # OR the class label changes, so the audit trail is faithful.
+    history: list[dict] = []
+    if ann.history:
+        try:
+            history = json.loads(ann.history) or []
+        except Exception:
+            history = []
+    history.append(
+        {
+            "version": ann.version,
+            "geometry": ann.geometry,
+            "class_name": ann.class_name,
+            "updated_at": ann.updated_at.isoformat() if ann.updated_at else None,
+        }
+    )
+    ann.history = json.dumps(history[-20:])
+
+    if geometry_changing:
         ann.geometry = json.dumps(geometry)
-    if class_name is not None:
+    if class_changing:
         ann.class_name = class_name
     ann.version = (ann.version or 1) + 1
     ann.updated_at = datetime.now(timezone.utc)

--- a/backend/src/app/services/annotation_service.py
+++ b/backend/src/app/services/annotation_service.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from app.models.annotation import Annotation
+from app.models.annotation import ANNOTATION_TYPES, Annotation
 from app.models.asset import Asset
+
+
+class AnnotationError(Exception):
+    pass
+
+
+class VersionConflictError(AnnotationError):
+    """Raised when a client's version doesn't match the server's."""
 
 
 def get_asset_annotations(db: Session, asset_id: str) -> list[Annotation]:
@@ -22,15 +31,21 @@ def create_annotation(
     geometry: dict,
     class_name: str | None,
 ) -> Annotation:
+    if type not in ANNOTATION_TYPES:
+        raise AnnotationError(
+            f"unsupported annotation type '{type}', expected one of {ANNOTATION_TYPES}"
+        )
+    _validate_geometry(type, geometry)
     ann = Annotation(
         asset_id=asset_id,
         author_id=author_id,
         type=type,
         geometry=json.dumps(geometry),
         class_name=class_name,
+        version=1,
+        updated_at=datetime.now(timezone.utc),
     )
     db.add(ann)
-    # Update asset label_status if was unlabeled
     asset = db.get(Asset, asset_id)
     if asset and asset.label_status in ("unlabeled", "unlabelled"):
         asset.label_status = "in_progress"
@@ -46,17 +61,38 @@ def update_annotation(
     *,
     geometry: dict | None = None,
     class_name: str | None = None,
+    expected_version: int | None = None,
 ) -> Annotation | None:
     ann = db.get(Annotation, annotation_id)
     if not ann:
         return None
+    if expected_version is not None and ann.version != expected_version:
+        raise VersionConflictError(
+            f"annotation version mismatch: have {ann.version}, expected {expected_version}"
+        )
     if geometry is not None:
-        old_history = json.loads(ann.history or "[]")
-        old_history.append({"geometry": ann.geometry, "class_name": ann.class_name})
-        ann.history = json.dumps(old_history[-10:])  # keep last 10 versions
+        _validate_geometry(ann.type, geometry)
+        # Push the previous state into history (cap at 20)
+        history: list[dict] = []
+        if ann.history:
+            try:
+                history = json.loads(ann.history) or []
+            except Exception:
+                history = []
+        history.append(
+            {
+                "version": ann.version,
+                "geometry": ann.geometry,
+                "class_name": ann.class_name,
+                "updated_at": ann.updated_at.isoformat() if ann.updated_at else None,
+            }
+        )
+        ann.history = json.dumps(history[-20:])
         ann.geometry = json.dumps(geometry)
     if class_name is not None:
         ann.class_name = class_name
+    ann.version = (ann.version or 1) + 1
+    ann.updated_at = datetime.now(timezone.utc)
     db.add(ann)
     db.commit()
     db.refresh(ann)
@@ -72,9 +108,48 @@ def delete_annotation(db: Session, annotation_id: str) -> bool:
     return True
 
 
+def get_history(db: Session, annotation_id: str) -> list[dict]:
+    ann = db.get(Annotation, annotation_id)
+    if not ann or not ann.history:
+        return []
+    try:
+        return json.loads(ann.history) or []
+    except Exception:
+        return []
+
+
 def mark_asset_labeled(db: Session, asset_id: str) -> None:
     asset = db.get(Asset, asset_id)
     if asset:
         asset.label_status = "labeled"
         db.add(asset)
         db.commit()
+
+
+def _validate_geometry(atype: str, geometry: dict) -> None:
+    if atype == "box":
+        for k in ("x", "y", "w", "h"):
+            if k not in geometry:
+                raise AnnotationError(f"box geometry missing '{k}'")
+        if geometry.get("w", 0) <= 0 or geometry.get("h", 0) <= 0:
+            raise AnnotationError("box geometry must have positive width/height")
+    elif atype == "polygon":
+        points = geometry.get("points")
+        if not isinstance(points, list) or len(points) < 3:
+            raise AnnotationError("polygon requires at least 3 points")
+        for p in points:
+            if "x" not in p or "y" not in p:
+                raise AnnotationError("polygon point missing 'x' or 'y'")
+    elif atype == "keypoint":
+        points = geometry.get("points")
+        if not isinstance(points, list) or len(points) < 1:
+            raise AnnotationError("keypoint requires at least 1 point")
+        for p in points:
+            if "x" not in p or "y" not in p:
+                raise AnnotationError("keypoint point missing 'x' or 'y'")
+    elif atype == "classification":
+        if not geometry.get("class") and not geometry.get("class_name"):
+            # Allow empty class field — class_name on the row carries the label.
+            pass
+    else:  # pragma: no cover - guarded above
+        raise AnnotationError(f"unsupported type {atype}")

--- a/backend/src/app/services/asset_service.py
+++ b/backend/src/app/services/asset_service.py
@@ -82,9 +82,7 @@ def get_dataset_stats(db: Session, dataset_id: str, version_id: str | None = Non
     # Class distribution from annotations
     class_counts: dict[str, int] = {}
     if asset_ids:
-        anns = list(
-            db.scalars(select(Annotation).where(Annotation.asset_id.in_(asset_ids))).all()
-        )
+        anns = list(db.scalars(select(Annotation).where(Annotation.asset_id.in_(asset_ids))).all())
         for ann in anns:
             cls = ann.class_name or "unlabeled"
             class_counts[cls] = class_counts.get(cls, 0) + 1

--- a/backend/src/app/services/auth.py
+++ b/backend/src/app/services/auth.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timedelta, timezone
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -101,6 +101,18 @@ def get_current_user_from_token(token: str, db: Session) -> User:
     return user
 
 
+def admin_reset_password(db: Session, user_id: str, new_password: str) -> User | None:
+    """Admin-only password reset. Issues a fresh bcrypt hash."""
+    user = db.scalar(select(User).where(User.id == user_id))
+    if not user:
+        return None
+    user.password_hash = _hash_password(new_password)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
 def register(db: Session, *, name: str, email: str, password: str) -> User:
     existing = db.scalar(select(User).where(User.email == email))
     if existing:
@@ -112,28 +124,18 @@ def register(db: Session, *, name: str, email: str, password: str) -> User:
     return u
 
 
-def authenticate(email: str, password: str) -> Optional[tuple[str, str, AuthUser]]:
+def authenticate(email: str, password: str) -> tuple[str, str, AuthUser] | None:
     with SessionLocal() as db:
         user = db.scalar(select(User).where(User.email == email))
         if not user or not user.password_hash:
             return None
 
-        # Support legacy SHA256 hashes during migration: verify by comparison,
-        # then re-hash with bcrypt on successful login.
-        if _is_bcrypt_hash(user.password_hash):
-            if not _verify_password(password, user.password_hash):
-                return None
-        else:
-            # Legacy SHA256 path
-            import hashlib
-
-            legacy_hash = hashlib.sha256(password.encode("utf-8")).hexdigest()
-            if user.password_hash != legacy_hash:
-                return None
-            # Upgrade to bcrypt in-place
-            user.password_hash = _hash_password(password)
-            db.add(user)
-            db.commit()
+        # Bcrypt-only. Legacy SHA256 hashes are rejected and the user must
+        # complete a password reset (via the password reset flow / admin tool).
+        if not _is_bcrypt_hash(user.password_hash):
+            return None
+        if not _verify_password(password, user.password_hash):
+            return None
 
         auth_user: AuthUser = {
             "id": user.id,

--- a/backend/src/app/services/dataset_service.py
+++ b/backend/src/app/services/dataset_service.py
@@ -34,9 +34,7 @@ def create_dataset(
     return ds, ver
 
 
-def snapshot_version(
-    db: Session, dataset_id: str, notes: str | None = None
-) -> DatasetVersion:
+def snapshot_version(db: Session, dataset_id: str, notes: str | None = None) -> DatasetVersion:
     """Create a new locked snapshot version for a dataset."""
     # Compute next version number
     versions = list(

--- a/backend/src/app/services/datumaro_service.py
+++ b/backend/src/app/services/datumaro_service.py
@@ -77,13 +77,29 @@ def import_archive(
     with tempfile.TemporaryDirectory() as tmp:
         archive_dir = Path(tmp)
         with zipfile.ZipFile(io.BytesIO(archive_bytes)) as zf:
-            zf.extractall(archive_dir)
+            _safe_extract(zf, archive_dir)
 
         if fmt == "coco":
             return _import_coco(db, dataset, version, archive_dir, image_uri_base)
         if fmt == "yolo":
             return _import_yolo(db, dataset, version, archive_dir, image_uri_base)
         return _import_via_datumaro(db, dataset, version, archive_dir, fmt, image_uri_base)
+
+
+def _safe_extract(zf: zipfile.ZipFile, dest: Path) -> None:
+    """Extract a zip after rejecting any entry that would escape `dest`.
+
+    Defends against Zip Slip: entries with absolute paths or `..` components
+    that resolve outside the destination directory raise DatumaroError.
+    """
+    dest_resolved = dest.resolve()
+    for member in zf.infolist():
+        target = (dest / member.filename).resolve()
+        try:
+            target.relative_to(dest_resolved)
+        except ValueError as exc:
+            raise DatumaroError(f"unsafe path in archive: {member.filename!r}") from exc
+    zf.extractall(dest)
 
 
 def _import_coco(

--- a/backend/src/app/services/datumaro_service.py
+++ b/backend/src/app/services/datumaro_service.py
@@ -1,0 +1,621 @@
+"""Dataset import/export.
+
+Native (no-dep) handlers for COCO and YOLO formats, plus a Datumaro-backed
+path for everything else (Pascal VOC, CVAT, LabelMe, …) when the optional
+`datumaro` package is installed.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tempfile
+import zipfile
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.annotation import Annotation
+from app.models.asset import Asset
+from app.models.dataset import ClassMap, Dataset
+from app.models.dataset_version import DatasetVersion
+
+# ----------------------------------------------------------------------------
+# Public types
+# ----------------------------------------------------------------------------
+
+SUPPORTED_FORMATS = ("coco", "yolo", "pascal_voc", "cvat", "labelme", "datumaro")
+
+
+@dataclass
+class ImportSummary:
+    asset_count: int
+    annotation_count: int
+    classes: list[str]
+    warnings: list[str]
+
+
+class DatumaroError(Exception):
+    pass
+
+
+# ----------------------------------------------------------------------------
+# Import
+# ----------------------------------------------------------------------------
+
+
+def import_archive(
+    db: Session,
+    *,
+    dataset_id: str,
+    version_id: str,
+    archive_bytes: bytes,
+    fmt: str,
+    image_uri_base: str = "",
+) -> ImportSummary:
+    """Import a dataset archive (zip) into the dataset version.
+
+    `image_uri_base` lets the caller prefix asset URIs (e.g. with the MinIO
+    storage key for the uploaded archive) so the platform can reference the
+    images later.
+    """
+    fmt = (fmt or "coco").lower()
+    if fmt not in SUPPORTED_FORMATS:
+        raise DatumaroError(f"unsupported format: {fmt}")
+
+    dataset = db.get(Dataset, dataset_id)
+    if not dataset:
+        raise DatumaroError("dataset not found")
+    version = db.get(DatasetVersion, version_id)
+    if not version:
+        raise DatumaroError("dataset version not found")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        archive_dir = Path(tmp)
+        with zipfile.ZipFile(io.BytesIO(archive_bytes)) as zf:
+            zf.extractall(archive_dir)
+
+        if fmt == "coco":
+            return _import_coco(db, dataset, version, archive_dir, image_uri_base)
+        if fmt == "yolo":
+            return _import_yolo(db, dataset, version, archive_dir, image_uri_base)
+        return _import_via_datumaro(db, dataset, version, archive_dir, fmt, image_uri_base)
+
+
+def _import_coco(
+    db: Session,
+    dataset: Dataset,
+    version: DatasetVersion,
+    root: Path,
+    image_uri_base: str,
+) -> ImportSummary:
+    json_files = list(root.rglob("*.json"))
+    if not json_files:
+        raise DatumaroError("no COCO JSON found")
+    coco_path = json_files[0]
+    with coco_path.open() as f:
+        coco = json.load(f)
+
+    cats = coco.get("categories") or []
+    class_id_to_name: dict[int, str] = {c["id"]: c.get("name") or str(c["id"]) for c in cats}
+    classes = [c.get("name") for c in cats if c.get("name")]
+    _persist_classes(db, dataset, classes)
+
+    image_id_to_asset: dict[int, str] = {}
+    asset_count = 0
+    warnings: list[str] = []
+
+    for img in coco.get("images") or []:
+        file_name = img.get("file_name") or ""
+        width = img.get("width") or 0
+        height = img.get("height") or 0
+        uri = _join_uri(image_uri_base, file_name)
+        asset = Asset(
+            dataset_id=dataset.id,
+            version_id=version.id,
+            uri=uri,
+            mime_type=_guess_mime(file_name),
+            width=width,
+            height=height,
+            label_status="labeled",
+            meta_data=json.dumps({"filename": file_name, "coco_image_id": img.get("id")}),
+        )
+        db.add(asset)
+        db.flush()
+        image_id_to_asset[int(img["id"])] = asset.id
+        asset_count += 1
+
+    annotation_count = 0
+    for ann in coco.get("annotations") or []:
+        asset_id = image_id_to_asset.get(int(ann.get("image_id", -1)))
+        if not asset_id:
+            warnings.append(f"orphan annotation image_id={ann.get('image_id')}")
+            continue
+        cat_id = int(ann.get("category_id", -1))
+        cls = class_id_to_name.get(cat_id, "object")
+        bbox = ann.get("bbox") or []
+        if len(bbox) == 4:
+            x, y, w, h = bbox
+            geom = {"x": x, "y": y, "w": w, "h": h}
+            atype = "box"
+        elif ann.get("segmentation"):
+            seg = ann["segmentation"]
+            poly = seg[0] if isinstance(seg, list) and seg else []
+            points = [{"x": poly[i], "y": poly[i + 1]} for i in range(0, len(poly) - 1, 2)]
+            geom = {"points": points}
+            atype = "polygon"
+        else:
+            continue
+        a = Annotation(
+            asset_id=asset_id,
+            type=atype,
+            geometry=json.dumps(geom),
+            class_name=cls,
+            author_id=_system_user_id(),
+        )
+        db.add(a)
+        annotation_count += 1
+
+    version.asset_count = (version.asset_count or 0) + asset_count
+    db.add(version)
+    db.commit()
+    return ImportSummary(asset_count, annotation_count, classes, warnings)
+
+
+def _import_yolo(
+    db: Session,
+    dataset: Dataset,
+    version: DatasetVersion,
+    root: Path,
+    image_uri_base: str,
+) -> ImportSummary:
+    """YOLO layout: images/<split>/*.jpg, labels/<split>/*.txt, classes.txt or data.yaml."""
+    classes: list[str] = []
+    classes_file = next(
+        (p for p in root.rglob("classes.txt")),
+        None,
+    )
+    if classes_file:
+        classes = [line.strip() for line in classes_file.read_text().splitlines() if line.strip()]
+    else:
+        yaml_path = next((p for p in root.rglob("data.yaml")), None)
+        if yaml_path:
+            for line in yaml_path.read_text().splitlines():
+                if line.strip().startswith("names:"):
+                    rest = line.split(":", 1)[1].strip()
+                    if rest.startswith("["):
+                        rest = rest.strip("[]")
+                        classes = [c.strip().strip("'\"") for c in rest.split(",") if c.strip()]
+    if not classes:
+        classes = ["object"]
+    _persist_classes(db, dataset, classes)
+
+    image_exts = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+    images = [p for p in root.rglob("*") if p.suffix.lower() in image_exts]
+
+    asset_count = 0
+    annotation_count = 0
+    warnings: list[str] = []
+    for img_path in images:
+        # Find matching label
+        rel = img_path.relative_to(root)
+        candidates = [
+            root / Path(str(rel).replace("images", "labels")).with_suffix(".txt"),
+            img_path.with_suffix(".txt"),
+        ]
+        label_path = next((c for c in candidates if c.exists()), None)
+
+        try:
+            from PIL import Image  # type: ignore
+
+            with Image.open(img_path) as im:
+                w, h = im.size
+        except Exception:
+            w, h = 0, 0
+
+        uri = _join_uri(image_uri_base, str(rel))
+        asset = Asset(
+            dataset_id=dataset.id,
+            version_id=version.id,
+            uri=uri,
+            mime_type=_guess_mime(img_path.name),
+            width=w,
+            height=h,
+            label_status="labeled" if label_path else "unlabelled",
+            meta_data=json.dumps({"filename": img_path.name}),
+        )
+        db.add(asset)
+        db.flush()
+        asset_count += 1
+
+        if not label_path:
+            continue
+        for line in label_path.read_text().splitlines():
+            parts = line.strip().split()
+            if len(parts) < 5:
+                continue
+            try:
+                cls_idx = int(parts[0])
+                cx, cy, bw, bh = map(float, parts[1:5])
+            except ValueError:
+                warnings.append(f"bad YOLO line: {line}")
+                continue
+            cls = classes[cls_idx] if 0 <= cls_idx < len(classes) else f"class_{cls_idx}"
+            x = (cx - bw / 2) * (w or 1)
+            y = (cy - bh / 2) * (h or 1)
+            ww = bw * (w or 1)
+            hh = bh * (h or 1)
+            a = Annotation(
+                asset_id=asset.id,
+                type="box",
+                geometry=json.dumps({"x": x, "y": y, "w": ww, "h": hh}),
+                class_name=cls,
+                author_id=_system_user_id(),
+            )
+            db.add(a)
+            annotation_count += 1
+
+    version.asset_count = (version.asset_count or 0) + asset_count
+    db.add(version)
+    db.commit()
+    return ImportSummary(asset_count, annotation_count, classes, warnings)
+
+
+def _import_via_datumaro(
+    db: Session,
+    dataset: Dataset,
+    version: DatasetVersion,
+    root: Path,
+    fmt: str,
+    image_uri_base: str,
+) -> ImportSummary:
+    try:
+        import datumaro as dm  # type: ignore
+    except Exception as exc:
+        raise DatumaroError(f"format '{fmt}' requires the optional 'datumaro' package") from exc
+
+    project = dm.Dataset.import_from(str(root), fmt)
+    classes = [c for c in project.categories().get("label", dm.LabelCategories()).items]
+    classes = [c.name for c in classes] if classes else []
+    _persist_classes(db, dataset, classes)
+
+    asset_count = 0
+    annotation_count = 0
+    warnings: list[str] = []
+    for item in project:
+        media = getattr(item, "media", None)
+        path = getattr(media, "path", None) if media else None
+        size = getattr(media, "size", None) if media else None
+        w, h = (size[1], size[0]) if size else (0, 0)
+
+        uri = _join_uri(image_uri_base, str(path) if path else item.id)
+        asset = Asset(
+            dataset_id=dataset.id,
+            version_id=version.id,
+            uri=uri,
+            mime_type=_guess_mime(uri),
+            width=w,
+            height=h,
+            label_status="labeled" if item.annotations else "unlabelled",
+            meta_data=json.dumps({"filename": str(path) if path else item.id}),
+        )
+        db.add(asset)
+        db.flush()
+        asset_count += 1
+        for a in item.annotations:
+            geom: dict[str, Any] | None = None
+            atype: str | None = None
+            cls = (
+                project.categories().get("label", dm.LabelCategories()).items[a.label].name
+                if hasattr(a, "label") and a.label is not None
+                else "object"
+            )
+            if a.type == dm.AnnotationType.bbox:
+                geom = {"x": a.x, "y": a.y, "w": a.w, "h": a.h}
+                atype = "box"
+            elif a.type == dm.AnnotationType.polygon:
+                pts = a.points
+                points = [{"x": pts[i], "y": pts[i + 1]} for i in range(0, len(pts) - 1, 2)]
+                geom = {"points": points}
+                atype = "polygon"
+            elif a.type == dm.AnnotationType.label:
+                geom = {"class": cls}
+                atype = "classification"
+            else:
+                warnings.append(f"unsupported annotation type {a.type}")
+                continue
+            db.add(
+                Annotation(
+                    asset_id=asset.id,
+                    type=atype,
+                    geometry=json.dumps(geom),
+                    class_name=cls,
+                    author_id=_system_user_id(),
+                )
+            )
+            annotation_count += 1
+
+    version.asset_count = (version.asset_count or 0) + asset_count
+    db.add(version)
+    db.commit()
+    return ImportSummary(asset_count, annotation_count, classes, warnings)
+
+
+# ----------------------------------------------------------------------------
+# Export
+# ----------------------------------------------------------------------------
+
+
+def export_archive(
+    db: Session,
+    *,
+    dataset_id: str,
+    version_id: str,
+    fmt: str,
+) -> bytes:
+    """Build a zip archive of the dataset version in the requested format.
+    Returns the raw zip bytes.
+    """
+    fmt = (fmt or "coco").lower()
+    if fmt not in SUPPORTED_FORMATS:
+        raise DatumaroError(f"unsupported format: {fmt}")
+    dataset = db.get(Dataset, dataset_id)
+    version = db.get(DatasetVersion, version_id)
+    if not dataset or not version:
+        raise DatumaroError("dataset or version not found")
+
+    classes = _load_classes(db, dataset)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        if fmt == "coco":
+            zf.writestr(
+                "annotations.json",
+                json.dumps(_build_coco(db, dataset, version, classes), indent=2),
+            )
+        elif fmt == "yolo":
+            zf.writestr("classes.txt", "\n".join(classes))
+            for asset, anns in _iter_assets_with_annotations(db, version):
+                w = asset.width or 1
+                h = asset.height or 1
+                lines = []
+                for a in anns:
+                    if a.type != "box":
+                        continue
+                    try:
+                        g = json.loads(a.geometry)
+                    except Exception:
+                        continue
+                    cx = (g.get("x", 0) + g.get("w", 0) / 2) / w
+                    cy = (g.get("y", 0) + g.get("h", 0) / 2) / h
+                    bw = g.get("w", 0) / w
+                    bh = g.get("h", 0) / h
+                    cls_idx = classes.index(a.class_name) if a.class_name in classes else 0
+                    lines.append(f"{cls_idx} {cx:.6f} {cy:.6f} {bw:.6f} {bh:.6f}")
+                stem = Path(asset.uri).stem
+                zf.writestr(f"labels/{stem}.txt", "\n".join(lines))
+        else:
+            # Fall back to Datumaro for non-trivial formats
+            try:
+                import datumaro as dm  # type: ignore
+            except Exception as exc:
+                raise DatumaroError(
+                    f"format '{fmt}' requires the optional 'datumaro' package"
+                ) from exc
+            with tempfile.TemporaryDirectory() as out_dir:
+                ds = _build_datumaro_dataset(db, dataset, version, classes, dm)
+                ds.export(out_dir, fmt)
+                # Zip the directory
+                for root, _dirs, files in os.walk(out_dir):
+                    for f in files:
+                        p = Path(root) / f
+                        zf.write(p, p.relative_to(out_dir))
+    return buf.getvalue()
+
+
+def _build_coco(
+    db: Session,
+    dataset: Dataset,
+    version: DatasetVersion,
+    classes: list[str],
+) -> dict[str, Any]:
+    images: list[dict[str, Any]] = []
+    annotations: list[dict[str, Any]] = []
+    categories = [{"id": i + 1, "name": c} for i, c in enumerate(classes)]
+    cls_to_id = {c["name"]: c["id"] for c in categories}
+
+    ann_id = 1
+    for asset, anns in _iter_assets_with_annotations(db, version):
+        meta = {}
+        if asset.meta_data:
+            try:
+                meta = json.loads(asset.meta_data)
+            except Exception:
+                pass
+        images.append(
+            {
+                "id": len(images) + 1,
+                "file_name": meta.get("filename") or Path(asset.uri).name,
+                "width": asset.width,
+                "height": asset.height,
+            }
+        )
+        img_id = len(images)
+        for a in anns:
+            if a.type == "box":
+                try:
+                    g = json.loads(a.geometry)
+                except Exception:
+                    continue
+                annotations.append(
+                    {
+                        "id": ann_id,
+                        "image_id": img_id,
+                        "category_id": cls_to_id.get(a.class_name or "", 1),
+                        "bbox": [g.get("x", 0), g.get("y", 0), g.get("w", 0), g.get("h", 0)],
+                        "area": g.get("w", 0) * g.get("h", 0),
+                        "iscrowd": 0,
+                    }
+                )
+                ann_id += 1
+            elif a.type == "polygon":
+                try:
+                    g = json.loads(a.geometry)
+                except Exception:
+                    continue
+                points = g.get("points") or []
+                flat = [v for p in points for v in (p.get("x", 0), p.get("y", 0))]
+                annotations.append(
+                    {
+                        "id": ann_id,
+                        "image_id": img_id,
+                        "category_id": cls_to_id.get(a.class_name or "", 1),
+                        "segmentation": [flat],
+                        "bbox": _bbox_of_polygon(points),
+                        "area": _polygon_area(points),
+                        "iscrowd": 0,
+                    }
+                )
+                ann_id += 1
+    return {"images": images, "annotations": annotations, "categories": categories}
+
+
+def _build_datumaro_dataset(
+    db: Session,
+    dataset: Dataset,
+    version: DatasetVersion,
+    classes: list[str],
+    dm: Any,
+) -> Any:  # pragma: no cover - exercised only with datumaro installed
+    items = []
+    cats = dm.LabelCategories.from_iterable(classes)
+    for asset, anns in _iter_assets_with_annotations(db, version):
+        ann_objs = []
+        for a in anns:
+            try:
+                g = json.loads(a.geometry)
+            except Exception:
+                continue
+            label = classes.index(a.class_name) if a.class_name in classes else 0
+            if a.type == "box":
+                ann_objs.append(
+                    dm.Bbox(g.get("x", 0), g.get("y", 0), g.get("w", 0), g.get("h", 0), label=label)
+                )
+            elif a.type == "polygon":
+                pts = []
+                for p in g.get("points") or []:
+                    pts.extend([p.get("x", 0), p.get("y", 0)])
+                ann_objs.append(dm.Polygon(pts, label=label))
+            elif a.type == "classification":
+                ann_objs.append(dm.Label(label=label))
+        items.append(
+            dm.DatasetItem(
+                id=Path(asset.uri).stem,
+                annotations=ann_objs,
+                media=dm.Image(path=asset.uri, size=(asset.height or 0, asset.width or 0)),
+            )
+        )
+    return dm.Dataset.from_iterable(items, categories={dm.AnnotationType.label: cats})
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+
+def _persist_classes(db: Session, dataset: Dataset, classes: list[str]) -> None:
+    if not classes:
+        return
+    if dataset.class_map_id:
+        cm = db.get(ClassMap, dataset.class_map_id)
+        if cm:
+            existing: list[str] = []
+            try:
+                existing = json.loads(cm.classes or "[]")
+            except Exception:
+                existing = []
+            merged = list(dict.fromkeys([*existing, *classes]))
+            cm.classes = json.dumps(merged)
+            db.add(cm)
+            return
+    cm = ClassMap(project_id=dataset.project_id, classes=json.dumps(classes))
+    db.add(cm)
+    db.flush()
+    dataset.class_map_id = cm.id
+    db.add(dataset)
+
+
+def _load_classes(db: Session, dataset: Dataset) -> list[str]:
+    if not dataset.class_map_id:
+        return []
+    cm = db.get(ClassMap, dataset.class_map_id)
+    if not cm or not cm.classes:
+        return []
+    try:
+        return json.loads(cm.classes)
+    except Exception:
+        return []
+
+
+def _iter_assets_with_annotations(
+    db: Session, version: DatasetVersion
+) -> Iterator[tuple[Asset, list[Annotation]]]:
+    from sqlalchemy import select
+
+    assets = list(db.scalars(select(Asset).where(Asset.version_id == version.id)).all())
+    for asset in assets:
+        anns = list(db.scalars(select(Annotation).where(Annotation.asset_id == asset.id)).all())
+        yield asset, anns
+
+
+def _system_user_id() -> str:
+    return os.getenv("VF_SYSTEM_USER_ID", "system")
+
+
+def _guess_mime(name: str) -> str:
+    n = name.lower()
+    if n.endswith((".jpg", ".jpeg")):
+        return "image/jpeg"
+    if n.endswith(".png"):
+        return "image/png"
+    if n.endswith(".webp"):
+        return "image/webp"
+    if n.endswith(".bmp"):
+        return "image/bmp"
+    if n.endswith((".mp4", ".mov", ".avi", ".webm")):
+        return "video/mp4"
+    return "application/octet-stream"
+
+
+def _join_uri(base: str, suffix: str) -> str:
+    if not base:
+        return suffix
+    if base.endswith("/"):
+        return base + suffix.lstrip("/")
+    return f"{base}/{suffix.lstrip('/')}"
+
+
+def _bbox_of_polygon(points: list[dict[str, float]]) -> list[float]:
+    if not points:
+        return [0, 0, 0, 0]
+    xs = [p.get("x", 0) for p in points]
+    ys = [p.get("y", 0) for p in points]
+    return [min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys)]
+
+
+def _polygon_area(points: list[dict[str, float]]) -> float:
+    if len(points) < 3:
+        return 0.0
+    area = 0.0
+    n = len(points)
+    for i in range(n):
+        x1 = points[i].get("x", 0)
+        y1 = points[i].get("y", 0)
+        x2 = points[(i + 1) % n].get("x", 0)
+        y2 = points[(i + 1) % n].get("y", 0)
+        area += x1 * y2 - x2 * y1
+    return abs(area) / 2.0

--- a/backend/src/app/services/datumaro_service.py
+++ b/backend/src/app/services/datumaro_service.py
@@ -83,23 +83,46 @@ def import_archive(
             return _import_coco(db, dataset, version, archive_dir, image_uri_base)
         if fmt == "yolo":
             return _import_yolo(db, dataset, version, archive_dir, image_uri_base)
-        return _import_via_datumaro(db, dataset, version, archive_dir, fmt, image_uri_base)
+        return _import_via_datumaro(
+            db, dataset, version, archive_dir, fmt, image_uri_base
+        )
 
 
 def _safe_extract(zf: zipfile.ZipFile, dest: Path) -> None:
-    """Extract a zip after rejecting any entry that would escape `dest`.
+    """Extract a zip safely.
 
-    Defends against Zip Slip: entries with absolute paths or `..` components
-    that resolve outside the destination directory raise DatumaroError.
+    For each member: validate that the resolved target stays under `dest`,
+    skip directory entries (we mkdir as needed), and refuse symlinks
+    altogether. We then write each file ourselves rather than calling
+    `zf.extractall`, which avoids any TOCTOU between validation and
+    extraction.
     """
     dest_resolved = dest.resolve()
     for member in zf.infolist():
+        # Refuse symlinks: their target is the link path, not the file content,
+        # and the OS would resolve them at follow time.
+        if (member.external_attr >> 16) & 0o170000 == 0o120000:
+            raise DatumaroError(f"unsafe symlink in archive: {member.filename!r}")
+
+        # Build and verify the target path.
         target = (dest / member.filename).resolve()
         try:
             target.relative_to(dest_resolved)
         except ValueError as exc:
             raise DatumaroError(f"unsafe path in archive: {member.filename!r}") from exc
-    zf.extractall(dest)
+
+        if member.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zf.open(member, "r") as src, target.open("wb") as out:
+            # 1 MB chunks
+            while True:
+                chunk = src.read(1024 * 1024)
+                if not chunk:
+                    break
+                out.write(chunk)
 
 
 def _import_coco(
@@ -117,7 +140,9 @@ def _import_coco(
         coco = json.load(f)
 
     cats = coco.get("categories") or []
-    class_id_to_name: dict[int, str] = {c["id"]: c.get("name") or str(c["id"]) for c in cats}
+    class_id_to_name: dict[int, str] = {
+        c["id"]: c.get("name") or str(c["id"]) for c in cats
+    }
     classes = [c.get("name") for c in cats if c.get("name")]
     _persist_classes(db, dataset, classes)
 
@@ -138,7 +163,9 @@ def _import_coco(
             width=width,
             height=height,
             label_status="labeled",
-            meta_data=json.dumps({"filename": file_name, "coco_image_id": img.get("id")}),
+            meta_data=json.dumps(
+                {"filename": file_name, "coco_image_id": img.get("id")}
+            ),
         )
         db.add(asset)
         db.flush()
@@ -161,7 +188,9 @@ def _import_coco(
         elif ann.get("segmentation"):
             seg = ann["segmentation"]
             poly = seg[0] if isinstance(seg, list) and seg else []
-            points = [{"x": poly[i], "y": poly[i + 1]} for i in range(0, len(poly) - 1, 2)]
+            points = [
+                {"x": poly[i], "y": poly[i + 1]} for i in range(0, len(poly) - 1, 2)
+            ]
             geom = {"points": points}
             atype = "polygon"
         else:
@@ -196,7 +225,11 @@ def _import_yolo(
         None,
     )
     if classes_file:
-        classes = [line.strip() for line in classes_file.read_text().splitlines() if line.strip()]
+        classes = [
+            line.strip()
+            for line in classes_file.read_text().splitlines()
+            if line.strip()
+        ]
     else:
         yaml_path = next((p for p in root.rglob("data.yaml")), None)
         if yaml_path:
@@ -205,7 +238,9 @@ def _import_yolo(
                     rest = line.split(":", 1)[1].strip()
                     if rest.startswith("["):
                         rest = rest.strip("[]")
-                        classes = [c.strip().strip("'\"") for c in rest.split(",") if c.strip()]
+                        classes = [
+                            c.strip().strip("'\"") for c in rest.split(",") if c.strip()
+                        ]
     if not classes:
         classes = ["object"]
     _persist_classes(db, dataset, classes)
@@ -260,7 +295,9 @@ def _import_yolo(
             except ValueError:
                 warnings.append(f"bad YOLO line: {line}")
                 continue
-            cls = classes[cls_idx] if 0 <= cls_idx < len(classes) else f"class_{cls_idx}"
+            cls = (
+                classes[cls_idx] if 0 <= cls_idx < len(classes) else f"class_{cls_idx}"
+            )
             x = (cx - bw / 2) * (w or 1)
             y = (cy - bh / 2) * (h or 1)
             ww = bw * (w or 1)
@@ -292,7 +329,9 @@ def _import_via_datumaro(
     try:
         import datumaro as dm  # type: ignore
     except Exception as exc:
-        raise DatumaroError(f"format '{fmt}' requires the optional 'datumaro' package") from exc
+        raise DatumaroError(
+            f"format '{fmt}' requires the optional 'datumaro' package"
+        ) from exc
 
     project = dm.Dataset.import_from(str(root), fmt)
     classes = [c for c in project.categories().get("label", dm.LabelCategories()).items]
@@ -326,7 +365,10 @@ def _import_via_datumaro(
             geom: dict[str, Any] | None = None
             atype: str | None = None
             cls = (
-                project.categories().get("label", dm.LabelCategories()).items[a.label].name
+                project.categories()
+                .get("label", dm.LabelCategories())
+                .items[a.label]
+                .name
                 if hasattr(a, "label") and a.label is not None
                 else "object"
             )
@@ -335,7 +377,9 @@ def _import_via_datumaro(
                 atype = "box"
             elif a.type == dm.AnnotationType.polygon:
                 pts = a.points
-                points = [{"x": pts[i], "y": pts[i + 1]} for i in range(0, len(pts) - 1, 2)]
+                points = [
+                    {"x": pts[i], "y": pts[i + 1]} for i in range(0, len(pts) - 1, 2)
+                ]
                 geom = {"points": points}
                 atype = "polygon"
             elif a.type == dm.AnnotationType.label:
@@ -395,6 +439,15 @@ def export_archive(
             )
         elif fmt == "yolo":
             zf.writestr("classes.txt", "\n".join(classes))
+            # Mapping from asset.id → exported label filename. We'd love to use
+            # the original filename stem (so a YOLO consumer can match
+            # `images/foo.jpg` ↔ `labels/foo.txt`), but two assets can share
+            # the same stem (e.g. `train/img_0001.jpg` and `val/img_0001.jpg`).
+            # We disambiguate by suffixing a short slice of the asset id when a
+            # collision is detected. A `manifest.csv` records the mapping so
+            # downstream consumers can reconstruct the original layout.
+            used_stems: dict[str, str] = {}  # stem → asset_id
+            manifest_rows: list[str] = ["asset_id,uri,label_file"]
             for asset, anns in _iter_assets_with_annotations(db, version):
                 w = asset.width or 1
                 h = asset.height or 1
@@ -410,10 +463,19 @@ def export_archive(
                     cy = (g.get("y", 0) + g.get("h", 0) / 2) / h
                     bw = g.get("w", 0) / w
                     bh = g.get("h", 0) / h
-                    cls_idx = classes.index(a.class_name) if a.class_name in classes else 0
+                    cls_idx = (
+                        classes.index(a.class_name) if a.class_name in classes else 0
+                    )
                     lines.append(f"{cls_idx} {cx:.6f} {cy:.6f} {bw:.6f} {bh:.6f}")
-                stem = Path(asset.uri).stem
-                zf.writestr(f"labels/{stem}.txt", "\n".join(lines))
+                base_stem = Path(asset.uri).stem or asset.id
+                stem = base_stem
+                if stem in used_stems and used_stems[stem] != asset.id:
+                    stem = f"{base_stem}__{asset.id[:8]}"
+                used_stems[stem] = asset.id
+                label_file = f"labels/{stem}.txt"
+                zf.writestr(label_file, "\n".join(lines))
+                manifest_rows.append(f"{asset.id},{asset.uri},{label_file}")
+            zf.writestr("manifest.csv", "\n".join(manifest_rows))
         else:
             # Fall back to Datumaro for non-trivial formats
             try:
@@ -472,7 +534,12 @@ def _build_coco(
                         "id": ann_id,
                         "image_id": img_id,
                         "category_id": cls_to_id.get(a.class_name or "", 1),
-                        "bbox": [g.get("x", 0), g.get("y", 0), g.get("w", 0), g.get("h", 0)],
+                        "bbox": [
+                            g.get("x", 0),
+                            g.get("y", 0),
+                            g.get("w", 0),
+                            g.get("h", 0),
+                        ],
                         "area": g.get("w", 0) * g.get("h", 0),
                         "iscrowd": 0,
                     }
@@ -519,7 +586,13 @@ def _build_datumaro_dataset(
             label = classes.index(a.class_name) if a.class_name in classes else 0
             if a.type == "box":
                 ann_objs.append(
-                    dm.Bbox(g.get("x", 0), g.get("y", 0), g.get("w", 0), g.get("h", 0), label=label)
+                    dm.Bbox(
+                        g.get("x", 0),
+                        g.get("y", 0),
+                        g.get("w", 0),
+                        g.get("h", 0),
+                        label=label,
+                    )
                 )
             elif a.type == "polygon":
                 pts = []
@@ -532,7 +605,9 @@ def _build_datumaro_dataset(
             dm.DatasetItem(
                 id=Path(asset.uri).stem,
                 annotations=ann_objs,
-                media=dm.Image(path=asset.uri, size=(asset.height or 0, asset.width or 0)),
+                media=dm.Image(
+                    path=asset.uri, size=(asset.height or 0, asset.width or 0)
+                ),
             )
         )
     return dm.Dataset.from_iterable(items, categories={dm.AnnotationType.label: cats})
@@ -584,7 +659,9 @@ def _iter_assets_with_annotations(
 
     assets = list(db.scalars(select(Asset).where(Asset.version_id == version.id)).all())
     for asset in assets:
-        anns = list(db.scalars(select(Annotation).where(Annotation.asset_id == asset.id)).all())
+        anns = list(
+            db.scalars(select(Annotation).where(Annotation.asset_id == asset.id)).all()
+        )
         yield asset, anns
 
 

--- a/backend/src/app/services/evaluation_service.py
+++ b/backend/src/app/services/evaluation_service.py
@@ -26,7 +26,15 @@ def create_evaluation(
 ) -> tuple[Evaluation, dict[str, Any]]:
     """Create an Evaluation row and dispatch the eval Celery task.
 
-    Returns the row and the job dict for the API response.
+    Sequence:
+      1. Validate inputs (artifact + dataset version exist).
+      2. Create the Evaluation row (queued, no cluster yet).
+      3. Create the Job row so we have a real job id.
+      4. Reserve the cluster atomically with the real job id (or release on
+         failure).
+      5. Dispatch the Celery task. If dispatch fails AND a cluster was
+         reserved, release it and mark the evaluation/job as failed instead
+         of leaking capacity.
     """
     artifact = db.get(ModelArtifact, payload.artifact_id)
     if not artifact:
@@ -34,9 +42,6 @@ def create_evaluation(
     version = db.get(DatasetVersion, payload.dataset_version_id)
     if not version:
         raise EvaluationError("dataset version not found")
-
-    if payload.cluster_id:
-        cluster_service.reserve_cluster(db, payload.cluster_id, job_id="pending", kind="eval")
 
     eval_row = Evaluation(
         project_id=artifact.project_id,
@@ -49,7 +54,7 @@ def create_evaluation(
     db.commit()
     db.refresh(eval_row)
 
-    task_payload = {
+    task_payload: dict[str, Any] = {
         "evaluationId": eval_row.id,
         "artifactId": artifact.id,
         "datasetVersionId": version.id,
@@ -65,31 +70,68 @@ def create_evaluation(
     db.add(eval_row)
     db.commit()
     db.refresh(eval_row)
-
-    if payload.cluster_id:
-        cluster = cluster_service.get_cluster(db, payload.cluster_id)
-        if cluster:
-            cluster.active_job_id = job_row.id
-            db.add(cluster)
-            db.commit()
-
     task_payload["jobId"] = job_row.id
+
+    # Reserve the cluster with the real job id. If reservation fails, the
+    # error propagates and the caller turns it into a 409.
+    if payload.cluster_id:
+        try:
+            cluster_service.reserve_cluster(
+                db, payload.cluster_id, job_id=job_row.id, kind="eval"
+            )
+        except Exception:
+            # Mark the queued rows as failed so the dashboard doesn't show a
+            # phantom queued evaluation.
+            from app.services.jobs_service import update_job_status
+
+            write_result(
+                db,
+                eval_row.id,
+                status="failed",
+                error_message="cluster reservation failed",
+            )
+            try:
+                update_job_status(db, job_row.id, status="failed", progress=0.0)
+            except Exception:
+                pass
+            raise
+
     queue = f"cluster.{payload.cluster_id}" if payload.cluster_id else None
     try:
         send_kwargs: dict[str, Any] = {"args": [task_payload]}
         if queue:
             send_kwargs["queue"] = queue
         celery_app.send_task("app.jobs.tasks.evaluation.evaluate_task", **send_kwargs)
-    except Exception:
-        # Broker may not be available in some envs (tests); the row is the
-        # contract — the worker will pick it up when the broker is online.
-        pass
+    except Exception as exc:
+        # Broker may not be available. If we already reserved a cluster, the
+        # worker will never pick the task up — release the cluster and mark
+        # the evaluation failed instead of holding capacity indefinitely.
+        if payload.cluster_id:
+            try:
+                cluster_service.release_cluster(db, payload.cluster_id)
+            except Exception:
+                pass
+            from app.services.jobs_service import update_job_status
+
+            write_result(
+                db,
+                eval_row.id,
+                status="failed",
+                error_message=f"task dispatch failed: {exc}",
+            )
+            try:
+                update_job_status(db, job_row.id, status="failed", progress=0.0)
+            except Exception:
+                pass
+            raise EvaluationError(f"failed to dispatch evaluation task: {exc}") from exc
+        # No cluster reserved — the row is the contract; a worker can still
+        # pick it up when the broker is back. Leave it queued.
 
     job_dict = {
         "id": job_row.id,
         "jobId": job_row.id,
         "type": "evaluation",
-        "status": "queued",
+        "status": eval_row.status,
         "progress": 0.0,
         "evaluationId": eval_row.id,
         "clusterId": payload.cluster_id,

--- a/backend/src/app/services/evaluation_service.py
+++ b/backend/src/app/services/evaluation_service.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.jobs.celery_app import celery_app
+from app.models.artifact import ModelArtifact
+from app.models.dataset_version import DatasetVersion
+from app.models.evaluation import Evaluation
+from app.schemas.evaluation import EvaluationCreate
+from app.services import cluster_service
+from app.services.jobs_service import create_job
+
+
+class EvaluationError(Exception):
+    pass
+
+
+def create_evaluation(
+    db: Session,
+    payload: EvaluationCreate,
+) -> tuple[Evaluation, dict[str, Any]]:
+    """Create an Evaluation row and dispatch the eval Celery task.
+
+    Returns the row and the job dict for the API response.
+    """
+    artifact = db.get(ModelArtifact, payload.artifact_id)
+    if not artifact:
+        raise EvaluationError("artifact not found")
+    version = db.get(DatasetVersion, payload.dataset_version_id)
+    if not version:
+        raise EvaluationError("dataset version not found")
+
+    if payload.cluster_id:
+        cluster_service.reserve_cluster(db, payload.cluster_id, job_id="pending", kind="eval")
+
+    eval_row = Evaluation(
+        project_id=artifact.project_id,
+        artifact_id=artifact.id,
+        dataset_version_id=version.id,
+        cluster_id=payload.cluster_id,
+        status="queued",
+    )
+    db.add(eval_row)
+    db.commit()
+    db.refresh(eval_row)
+
+    task_payload = {
+        "evaluationId": eval_row.id,
+        "artifactId": artifact.id,
+        "datasetVersionId": version.id,
+        "split": payload.split,
+        "iouThreshold": payload.iou_threshold,
+        "scoreThreshold": payload.score_threshold,
+        "maxSamples": payload.max_samples,
+        "sampleFpFnCount": payload.sample_fpfn_count,
+        "clusterId": payload.cluster_id,
+    }
+    job_row = create_job(db, "evaluation", task_payload)
+    eval_row.job_id = job_row.id
+    db.add(eval_row)
+    db.commit()
+    db.refresh(eval_row)
+
+    if payload.cluster_id:
+        cluster = cluster_service.get_cluster(db, payload.cluster_id)
+        if cluster:
+            cluster.active_job_id = job_row.id
+            db.add(cluster)
+            db.commit()
+
+    task_payload["jobId"] = job_row.id
+    queue = f"cluster.{payload.cluster_id}" if payload.cluster_id else None
+    try:
+        send_kwargs: dict[str, Any] = {"args": [task_payload]}
+        if queue:
+            send_kwargs["queue"] = queue
+        celery_app.send_task("app.jobs.tasks.evaluation.evaluate_task", **send_kwargs)
+    except Exception:
+        # Broker may not be available in some envs (tests); the row is the
+        # contract — the worker will pick it up when the broker is online.
+        pass
+
+    job_dict = {
+        "id": job_row.id,
+        "jobId": job_row.id,
+        "type": "evaluation",
+        "status": "queued",
+        "progress": 0.0,
+        "evaluationId": eval_row.id,
+        "clusterId": payload.cluster_id,
+    }
+    return eval_row, job_dict
+
+
+def list_evaluations(
+    db: Session,
+    *,
+    artifact_id: str | None = None,
+    dataset_version_id: str | None = None,
+    project_id: str | None = None,
+) -> list[Evaluation]:
+    q = select(Evaluation).order_by(Evaluation.created_at.desc())
+    if artifact_id:
+        q = q.where(Evaluation.artifact_id == artifact_id)
+    if dataset_version_id:
+        q = q.where(Evaluation.dataset_version_id == dataset_version_id)
+    if project_id:
+        q = q.where(Evaluation.project_id == project_id)
+    return list(db.scalars(q).all())
+
+
+def get_evaluation(db: Session, eval_id: str) -> Evaluation | None:
+    return db.get(Evaluation, eval_id)
+
+
+def to_dict(eval_row: Evaluation) -> dict[str, Any]:
+    def parse(s: str | None, default: Any) -> Any:
+        if not s:
+            return default
+        try:
+            return json.loads(s)
+        except Exception:
+            return default
+
+    return {
+        "id": eval_row.id,
+        "project_id": eval_row.project_id,
+        "artifact_id": eval_row.artifact_id,
+        "dataset_version_id": eval_row.dataset_version_id,
+        "cluster_id": eval_row.cluster_id,
+        "job_id": eval_row.job_id,
+        "status": eval_row.status,
+        "metrics": parse(eval_row.metrics_json, None),
+        "per_class": parse(eval_row.per_class_json, None),
+        "confusion": parse(eval_row.confusion_json, None),
+        "classes": parse(eval_row.classes_json, None),
+        "samples": parse(eval_row.samples_json, None),
+        "error_message": eval_row.error_message,
+        "started_at": eval_row.started_at,
+        "completed_at": eval_row.completed_at,
+        "created_at": eval_row.created_at,
+    }
+
+
+def summarize(eval_row: Evaluation) -> dict[str, Any]:
+    metrics: dict[str, Any] = {}
+    if eval_row.metrics_json:
+        try:
+            metrics = json.loads(eval_row.metrics_json) or {}
+        except Exception:
+            metrics = {}
+    primary_name: str | None = None
+    primary: float | None = None
+    for name in ("mAP50", "accuracy", "precision", "recall", "f1"):
+        if name in metrics and isinstance(metrics[name], (int, float)):
+            primary_name = name
+            primary = float(metrics[name])
+            break
+    return {
+        "id": eval_row.id,
+        "artifact_id": eval_row.artifact_id,
+        "dataset_version_id": eval_row.dataset_version_id,
+        "status": eval_row.status,
+        "primary_metric_name": primary_name,
+        "primary_metric": primary,
+        "created_at": eval_row.created_at,
+        "completed_at": eval_row.completed_at,
+    }
+
+
+def write_result(
+    db: Session,
+    eval_id: str,
+    *,
+    status: str,
+    metrics: dict[str, Any] | None = None,
+    per_class: dict[str, Any] | None = None,
+    confusion: list[list[int]] | None = None,
+    classes: list[str] | None = None,
+    samples: list[dict[str, Any]] | None = None,
+    error_message: str | None = None,
+) -> Evaluation | None:
+    """Worker-side helper to persist eval results."""
+    row = db.get(Evaluation, eval_id)
+    if not row:
+        return None
+    row.status = status
+    if metrics is not None:
+        row.metrics_json = json.dumps(metrics)
+    if per_class is not None:
+        row.per_class_json = json.dumps(per_class)
+    if confusion is not None:
+        row.confusion_json = json.dumps(confusion)
+    if classes is not None:
+        row.classes_json = json.dumps(classes)
+    if samples is not None:
+        row.samples_json = json.dumps(samples)
+    if error_message is not None:
+        row.error_message = error_message
+    if status in ("succeeded", "failed"):
+        row.completed_at = datetime.now(timezone.utc)
+    if status == "running" and row.started_at is None:
+        row.started_at = datetime.now(timezone.utc)
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/src/app/services/inference_service.py
+++ b/backend/src/app/services/inference_service.py
@@ -8,9 +8,11 @@ fronted by Triton in a later phase.
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 import threading
 from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -24,32 +26,45 @@ class InferenceError(Exception):
     pass
 
 
+@dataclass
+class _CacheEntry:
+    kind: str
+    model: Any
+    scratch_dir: Path  # the tempdir holding the downloaded weights
+
+
 class _ModelCache:
     """LRU cache keyed by artifact id. Thread-safe."""
 
     def __init__(self, max_size: int = MAX_MODELS) -> None:
         self.max_size = max_size
-        self._cache: OrderedDict[str, tuple[str, Any]] = OrderedDict()
+        self._cache: OrderedDict[str, _CacheEntry] = OrderedDict()
         self._lock = threading.RLock()
 
     def get_or_load(self, artifact: ModelArtifact) -> tuple[str, Any]:
         with self._lock:
             key = artifact.id
-            if key in self._cache:
+            entry = self._cache.get(key)
+            if entry is not None:
                 self._cache.move_to_end(key)
-                return self._cache[key]
-            loaded = _load_artifact(artifact)
-            self._cache[key] = loaded
+                return (entry.kind, entry.model)
+            kind, model, scratch = _load_artifact(artifact)
+            self._cache[key] = _CacheEntry(kind=kind, model=model, scratch_dir=scratch)
             while len(self._cache) > self.max_size:
-                self._cache.popitem(last=False)
-            return loaded
+                _, dropped = self._cache.popitem(last=False)
+                _safe_rmtree(dropped.scratch_dir)
+            return (kind, model)
 
     def evict(self, artifact_id: str) -> None:
         with self._lock:
-            self._cache.pop(artifact_id, None)
+            entry = self._cache.pop(artifact_id, None)
+            if entry is not None:
+                _safe_rmtree(entry.scratch_dir)
 
     def clear(self) -> None:
         with self._lock:
+            for entry in self._cache.values():
+                _safe_rmtree(entry.scratch_dir)
             self._cache.clear()
 
     def stats(self) -> dict[str, Any]:
@@ -59,6 +74,13 @@ class _ModelCache:
                 "max_size": self.max_size,
                 "loaded": list(self._cache.keys()),
             }
+
+
+def _safe_rmtree(path: Path) -> None:
+    try:
+        shutil.rmtree(path, ignore_errors=True)
+    except Exception:
+        pass
 
 
 _cache = _ModelCache()
@@ -102,13 +124,16 @@ def predict(
 # ----------------------------------------------------------------------------
 
 
-def _load_artifact(artifact: ModelArtifact) -> tuple[str, Any]:
+def _load_artifact(artifact: ModelArtifact) -> tuple[str, Any, Path]:
+    """Returns (kind, model, scratch_dir). Caller owns cleanup of scratch_dir."""
     storage_path = artifact.storage_path
     if not storage_path:
         raise InferenceError("artifact has no storage_path")
 
-    local = Path(tempfile.mkdtemp()) / Path(storage_path).name
+    scratch = Path(tempfile.mkdtemp(prefix="vf-model-"))
+    local = scratch / Path(storage_path).name
     if not _download_to(storage_path, local):
+        _safe_rmtree(scratch)
         raise InferenceError(f"could not fetch artifact at {storage_path}")
 
     fmt = (artifact.format or artifact.type or "").lower()
@@ -116,14 +141,20 @@ def _load_artifact(artifact: ModelArtifact) -> tuple[str, Any]:
         try:
             import onnxruntime as ort  # type: ignore
         except Exception as exc:  # pragma: no cover
+            _safe_rmtree(scratch)
             raise InferenceError("onnxruntime not installed") from exc
-        return ("onnx", ort.InferenceSession(str(local), providers=["CPUExecutionProvider"]))
+        return (
+            "onnx",
+            ort.InferenceSession(str(local), providers=["CPUExecutionProvider"]),
+            scratch,
+        )
 
     try:
         from ultralytics import YOLO  # type: ignore
     except Exception as exc:  # pragma: no cover
+        _safe_rmtree(scratch)
         raise InferenceError("ultralytics not installed") from exc
-    return ("yolo", YOLO(str(local)))
+    return ("yolo", YOLO(str(local)), scratch)
 
 
 def _download_to(uri: str, dest: Path) -> bool:

--- a/backend/src/app/services/inference_service.py
+++ b/backend/src/app/services/inference_service.py
@@ -1,0 +1,214 @@
+"""In-process model serving with a small LRU cache.
+
+A first cut: load Ultralytics YOLO or ONNX models from MinIO/HTTP/local on
+demand, keep up to N in memory. Good for prototyping and low-RPS use; will be
+fronted by Triton in a later phase.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+from app.models.artifact import ModelArtifact
+
+# Cap on how many models live in memory simultaneously.
+MAX_MODELS = int(os.getenv("VF_INFERENCE_CACHE_SIZE", "3"))
+
+
+class InferenceError(Exception):
+    pass
+
+
+class _ModelCache:
+    """LRU cache keyed by artifact id. Thread-safe."""
+
+    def __init__(self, max_size: int = MAX_MODELS) -> None:
+        self.max_size = max_size
+        self._cache: OrderedDict[str, tuple[str, Any]] = OrderedDict()
+        self._lock = threading.RLock()
+
+    def get_or_load(self, artifact: ModelArtifact) -> tuple[str, Any]:
+        with self._lock:
+            key = artifact.id
+            if key in self._cache:
+                self._cache.move_to_end(key)
+                return self._cache[key]
+            loaded = _load_artifact(artifact)
+            self._cache[key] = loaded
+            while len(self._cache) > self.max_size:
+                self._cache.popitem(last=False)
+            return loaded
+
+    def evict(self, artifact_id: str) -> None:
+        with self._lock:
+            self._cache.pop(artifact_id, None)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._cache.clear()
+
+    def stats(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "size": len(self._cache),
+                "max_size": self.max_size,
+                "loaded": list(self._cache.keys()),
+            }
+
+
+_cache = _ModelCache()
+
+
+def cache_stats() -> dict[str, Any]:
+    return _cache.stats()
+
+
+def evict(artifact_id: str) -> None:
+    _cache.evict(artifact_id)
+
+
+def predict(
+    artifact: ModelArtifact,
+    image_bytes: bytes,
+    *,
+    score_threshold: float = 0.25,
+) -> dict[str, Any]:
+    """Run the cached model on a single image (raw bytes). Returns predictions dict."""
+    kind, model = _cache.get_or_load(artifact)
+
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        f.write(image_bytes)
+        img_path = f.name
+    try:
+        if kind == "yolo":
+            return _yolo_predict(model, img_path, score_threshold)
+        if kind == "onnx":
+            return _onnx_predict(model, img_path, score_threshold)
+        raise InferenceError(f"unsupported model kind: {kind}")
+    finally:
+        try:
+            os.unlink(img_path)
+        except Exception:
+            pass
+
+
+# ----------------------------------------------------------------------------
+# Loaders / runners (lazy ML imports)
+# ----------------------------------------------------------------------------
+
+
+def _load_artifact(artifact: ModelArtifact) -> tuple[str, Any]:
+    storage_path = artifact.storage_path
+    if not storage_path:
+        raise InferenceError("artifact has no storage_path")
+
+    local = Path(tempfile.mkdtemp()) / Path(storage_path).name
+    if not _download_to(storage_path, local):
+        raise InferenceError(f"could not fetch artifact at {storage_path}")
+
+    fmt = (artifact.format or artifact.type or "").lower()
+    if fmt == "onnx" or str(local).endswith(".onnx"):
+        try:
+            import onnxruntime as ort  # type: ignore
+        except Exception as exc:  # pragma: no cover
+            raise InferenceError("onnxruntime not installed") from exc
+        return ("onnx", ort.InferenceSession(str(local), providers=["CPUExecutionProvider"]))
+
+    try:
+        from ultralytics import YOLO  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        raise InferenceError("ultralytics not installed") from exc
+    return ("yolo", YOLO(str(local)))
+
+
+def _download_to(uri: str, dest: Path) -> bool:
+    try:
+        if uri.startswith(("http://", "https://")):
+            import urllib.request
+
+            urllib.request.urlretrieve(uri, str(dest))  # noqa: S310
+            return True
+        if os.path.exists(uri):
+            import shutil
+
+            shutil.copy(uri, dest)
+            return True
+        from app.services.storage import get_minio_client
+
+        bucket = os.getenv("MINIO_BUCKET", os.getenv("S3_BUCKET", "visionforge"))
+        client = get_minio_client()
+        client.fget_object(bucket, uri, str(dest))
+        return True
+    except Exception:
+        return False
+
+
+def _yolo_predict(model: Any, img_path: str, score_threshold: float) -> dict[str, Any]:
+    results = model.predict(img_path, conf=score_threshold, verbose=False)
+    detections: list[dict[str, Any]] = []
+    classification: dict[str, Any] | None = None
+    for r in results:
+        names = getattr(r, "names", {}) or {}
+        boxes = getattr(r, "boxes", None)
+        if boxes is not None:
+            for box in boxes:
+                cls_idx = int(box.cls.item()) if hasattr(box, "cls") else 0
+                xy = box.xywh[0].tolist() if hasattr(box, "xywh") else [0, 0, 0, 0]
+                cx, cy, w, h = xy
+                detections.append(
+                    {
+                        "class": names.get(cls_idx, str(cls_idx)),
+                        "bbox": [cx - w / 2, cy - h / 2, w, h],
+                        "score": float(box.conf.item()) if hasattr(box, "conf") else 0.0,
+                    }
+                )
+        probs = getattr(r, "probs", None)
+        if probs is not None:
+            top = int(probs.top1)
+            classification = {
+                "class": names.get(top, str(top)),
+                "score": float(probs.top1conf.item()),
+            }
+    out: dict[str, Any] = {"detections": detections}
+    if classification:
+        out["classification"] = classification
+    return out
+
+
+def _onnx_predict(session: Any, img_path: str, score_threshold: float) -> dict[str, Any]:
+    """Generic ONNX runner — assumes a single image input. Returns raw logits."""
+    try:
+        import numpy as np  # type: ignore
+        from PIL import Image  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        raise InferenceError("numpy/Pillow not installed") from exc
+
+    inputs = session.get_inputs()
+    if not inputs:
+        return {"raw": []}
+    input_name = inputs[0].name
+    shape = inputs[0].shape
+    h = shape[2] if len(shape) >= 3 and isinstance(shape[2], int) else 224
+    w = shape[3] if len(shape) >= 4 and isinstance(shape[3], int) else 224
+
+    img = Image.open(img_path).convert("RGB").resize((w, h))
+    arr = np.asarray(img, dtype="float32").transpose(2, 0, 1) / 255.0
+    arr = arr[np.newaxis, ...]
+    outputs = session.run(None, {input_name: arr})
+    # Best-effort softmax of first output if it looks like logits
+    logits = outputs[0]
+    flat = logits.reshape(-1)
+    exp = np.exp(flat - np.max(flat))
+    probs = (exp / exp.sum()).tolist()
+    top_idx = int(np.argmax(flat))
+    return {
+        "raw_shape": list(logits.shape),
+        "top_class_index": top_idx,
+        "top_score": float(probs[top_idx]) if probs else 0.0,
+        "score_threshold": score_threshold,
+    }

--- a/backend/src/app/services/notification_service.py
+++ b/backend/src/app/services/notification_service.py
@@ -1,21 +1,19 @@
 from typing import List
 
+
 class NotificationService:
     def __init__(self):
         self.notifications = []
 
     def add_notification(self, user_id: str, type: str, title: str, body: str = None):
         # Placeholder: in real impl, save to DB and push to UI
-        self.notifications.append({
-            'user_id': user_id,
-            'type': type,
-            'title': title,
-            'body': body,
-            'read': False
-        })
+        self.notifications.append(
+            {"user_id": user_id, "type": type, "title": title, "body": body, "read": False}
+        )
 
     def get_notifications(self, user_id: str) -> List[dict]:
-        return [n for n in self.notifications if n['user_id'] == user_id]
+        return [n for n in self.notifications if n["user_id"] == user_id]
+
 
 # Global instance
 notification_service = NotificationService()

--- a/backend/src/app/services/project_dataset_service.py
+++ b/backend/src/app/services/project_dataset_service.py
@@ -8,7 +8,7 @@ from app.models.project import Project
 
 
 def create_project(db: Session, name: str, description: str | None) -> Project:
-    # For now, use a dummy workspace_id. In a real implementation, 
+    # For now, use a dummy workspace_id. In a real implementation,
     # we'd get this from the authenticated user's workspace
     dummy_workspace_id = "00000000-0000-0000-0000-000000000000"
     slug = name.lower().replace(" ", "-")
@@ -19,12 +19,14 @@ def create_project(db: Session, name: str, description: str | None) -> Project:
     return p
 
 
-def create_dataset(db: Session, project_id: str, name: str, description: str | None = None) -> tuple[Dataset, DatasetVersion]:
+def create_dataset(
+    db: Session, project_id: str, name: str, description: str | None = None
+) -> tuple[Dataset, DatasetVersion]:
     """Create a dataset and its initial version"""
     d = Dataset(project_id=project_id, name=name, description=description)
     db.add(d)
     db.flush()  # Get the dataset ID without committing
-    
+
     # Create initial version
     v = DatasetVersion(dataset_id=d.id, version=1)
     db.add(v)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -39,9 +39,10 @@ Base.metadata.create_all(bind=engine)
 
 # Seed a demo user for auth contract tests
 try:
-    from app.services.auth import register
     from sqlalchemy import select
+
     from app.models.user import User
+    from app.services.auth import register
 
     with TestingSessionLocal() as _db:
         exists = _db.scalar(select(User).where(User.email == "demo@example.com"))
@@ -51,12 +52,14 @@ except Exception:
     # Keep tests running even if seeding fails; auth tests may handle absence
     pass
 
+
 def override_get_db() -> Generator:
     db = TestingSessionLocal()
     try:
         yield db
     finally:
         db.close()
+
 
 app.dependency_overrides[get_db] = override_get_db
 client = TestClient(app)

--- a/backend/tests/contract/test_auth_contract.py
+++ b/backend/tests/contract/test_auth_contract.py
@@ -2,7 +2,6 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 
-
 client = TestClient(app)
 
 

--- a/backend/tests/contract/test_auth_login_post.py
+++ b/backend/tests/contract/test_auth_login_post.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from fastapi.testclient import TestClient
 
 CURRENT_DIR = os.path.dirname(__file__)
@@ -10,6 +11,7 @@ if SRC_PATH not in sys.path:
 from app.main import app
 
 client = TestClient(app)
+
 
 def test_login_invalid_returns_401():
     r = client.post("/auth/login", json={"email": "nobody@example.com", "password": "bad"})

--- a/backend/tests/contract/test_auth_signup_post.py
+++ b/backend/tests/contract/test_auth_signup_post.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from fastapi.testclient import TestClient
 
 CURRENT_DIR = os.path.dirname(__file__)
@@ -11,13 +12,19 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_signup_requires_name_email_password_and_accept_terms():
     # Missing fields should fail validation
     r = client.post("/auth/signup", json={})
     assert r.status_code in (400, 422)
 
     # Minimal valid payload
-    payload = {"name": "Demo User", "email": "demo@example.com", "password": "password123", "acceptTerms": True}
+    payload = {
+        "name": "Demo User",
+        "email": "demo@example.com",
+        "password": "password123",
+        "acceptTerms": True,
+    }
     r2 = client.post("/auth/signup", json=payload)
     # Accept 201 for created; some apps return 200 with token. Contract specifies 201.
     assert r2.status_code in (200, 201)

--- a/backend/tests/contract/test_dataset_uploads_post.py
+++ b/backend/tests/contract/test_dataset_uploads_post.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from fastapi.testclient import TestClient
 
 CURRENT_DIR = os.path.dirname(__file__)

--- a/backend/tests/contract/test_datasets_post.py
+++ b/backend/tests/contract/test_datasets_post.py
@@ -4,6 +4,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_create_dataset_contract():
     r = client.post("/api/datasets/demo-project", json={"name": "set"})
     assert r.status_code == 201

--- a/backend/tests/contract/test_export_onnx_post.py
+++ b/backend/tests/contract/test_export_onnx_post.py
@@ -4,6 +4,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_export_onnx_contract():
     r = client.post("/api/export/onnx", json={"experimentId": "e1", "dynamicAxes": True})
     assert r.status_code == 202

--- a/backend/tests/contract/test_ingest_upload_url_post.py
+++ b/backend/tests/contract/test_ingest_upload_url_post.py
@@ -4,6 +4,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_ingest_upload_url_contract():
     r = client.post(
         "/api/ingest/upload-url",

--- a/backend/tests/contract/test_jobs_get.py
+++ b/backend/tests/contract/test_jobs_get.py
@@ -19,7 +19,9 @@ def test_get_job_returns_status():
     client = TestClient(app)
 
     # Create a job in the DB
-    db: Session = next(app.dependency_overrides[get_db]()) if get_db in app.dependency_overrides else None
+    db: Session = (
+        next(app.dependency_overrides[get_db]()) if get_db in app.dependency_overrides else None
+    )
     if db is None:
         # Fallback to building a Session like conftest does is unnecessary here; tests set override
         raise RuntimeError("DB override not set for tests")

--- a/backend/tests/contract/test_projects_get.py
+++ b/backend/tests/contract/test_projects_get.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from fastapi.testclient import TestClient
 
 CURRENT_DIR = os.path.dirname(__file__)

--- a/backend/tests/contract/test_projects_post.py
+++ b/backend/tests/contract/test_projects_post.py
@@ -4,6 +4,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_create_project_contract():
     payload = {"name": "Demo", "description": "Test"}
     r = client.post("/api/projects", json=payload)

--- a/backend/tests/contract/test_run_detail_get.py
+++ b/backend/tests/contract/test_run_detail_get.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+
 from app.main import app
 
 client = TestClient(app)

--- a/backend/tests/contract/test_runs_get.py
+++ b/backend/tests/contract/test_runs_get.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+
 from app.main import app
 
 client = TestClient(app)

--- a/backend/tests/contract/test_train_post.py
+++ b/backend/tests/contract/test_train_post.py
@@ -4,6 +4,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_train_contract():
     r = client.post(
         "/api/train",

--- a/backend/tests/integration/test_active_learning_flow.py
+++ b/backend/tests/integration/test_active_learning_flow.py
@@ -4,6 +4,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_active_learning_flow_minimal():
     # Create project & dataset
     r = client.post("/api/projects", json={"name": "AL", "description": "flow"})

--- a/backend/tests/integration/test_auth_api.py
+++ b/backend/tests/integration/test_auth_api.py
@@ -1,6 +1,6 @@
 from fastapi.testclient import TestClient
-from app.main import app
 
+from app.main import app
 
 client = TestClient(app)
 

--- a/backend/tests/integration/test_evaluations_api.py
+++ b/backend/tests/integration/test_evaluations_api.py
@@ -1,0 +1,105 @@
+"""Integration tests for /api/evaluations.
+
+We bypass `get_current_user` for these tests so the focus stays on evaluation
+behavior, mirroring the cluster integration tests.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.db.deps import get_current_user
+from app.main import app
+from app.models.user import User
+
+
+def _fake_user() -> User:
+    return User(id="test-user", email="t@x.com", name="Tester", password_hash="$2b$x")
+
+
+app.dependency_overrides[get_current_user] = _fake_user
+client = TestClient(app)
+
+
+def _u(p: str) -> str:
+    return f"{p}-{uuid.uuid4().hex[:8]}"
+
+
+def test_evaluation_with_unknown_artifact_returns_400():
+    r = client.post(
+        "/api/evaluations",
+        json={
+            "artifact_id": "missing",
+            "dataset_version_id": "missing-too",
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_create_evaluation_returns_job():
+    # Create a project, dataset, version, and artifact directly via the ORM
+    from app.db.session import SessionLocal
+    from app.models.artifact import ModelArtifact
+    from app.models.dataset import Dataset
+    from app.models.dataset_version import DatasetVersion
+    from app.models.project import Project
+    from app.models.user import User as UserModel
+    from app.models.workspace import Workspace
+
+    artifact_id: str
+    version_id: str
+    with SessionLocal() as db:
+        # Ensure the fake current user exists for downstream FKs
+        if not db.get(UserModel, "test-user"):
+            db.add(UserModel(id="test-user", email="t@x.com", name="Tester", password_hash="$2b$x"))
+            db.commit()
+        ws = Workspace(id=_u("ws"), name="W", region="us", created_by="test-user")
+        db.add(ws)
+        db.commit()
+        proj_id = _u("proj")
+        proj = Project(id=proj_id, workspace_id=ws.id, name="P", slug=proj_id)
+        db.add(proj)
+        db.commit()
+        ds = Dataset(id=_u("ds"), project_id=proj_id, name="D", description="")
+        db.add(ds)
+        db.commit()
+        version_id = _u("v")
+        v = DatasetVersion(id=version_id, dataset_id=ds.id, version=1)
+        db.add(v)
+        db.commit()
+        artifact_id = _u("a")
+        art = ModelArtifact(
+            id=artifact_id,
+            project_id=proj_id,
+            run_id=None,
+            name="m",
+            version="1",
+            type="yolo",
+            format="pytorch",
+            storage_path="datasets/x/y.pt",
+        )
+        db.add(art)
+        db.commit()
+
+    r = client.post(
+        "/api/evaluations",
+        json={
+            "artifact_id": artifact_id,
+            "dataset_version_id": version_id,
+            "split": "test",
+            "iou_threshold": 0.5,
+            "score_threshold": 0.25,
+            "sample_fpfn_count": 10,
+        },
+    )
+    assert r.status_code == 202, r.text
+    body = r.json()
+    assert body["type"] == "evaluation"
+    assert body["status"] == "queued"
+
+
+def test_get_unknown_evaluation_404():
+    r = client.get("/api/evaluations/does-not-exist")
+    assert r.status_code == 404

--- a/backend/tests/integration/test_ingest_flow.py
+++ b/backend/tests/integration/test_ingest_flow.py
@@ -4,6 +4,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_ingest_flow_e2e():
     # Create project
     r = client.post("/api/projects", json={"name": "E2E", "description": "flow"})
@@ -18,7 +19,11 @@ def test_ingest_flow_e2e():
     # Request upload URL for dataset version
     r = client.post(
         "/api/ingest/upload-url",
-        json={"datasetVersionId": ds["activeVersionId"], "filename": "a.jpg", "contentType": "image/jpeg"},
+        json={
+            "datasetVersionId": ds["activeVersionId"],
+            "filename": "a.jpg",
+            "contentType": "image/jpeg",
+        },
     )
     assert r.status_code == 200
     body = r.json()

--- a/backend/tests/integration/test_onnx_export.py
+++ b/backend/tests/integration/test_onnx_export.py
@@ -4,6 +4,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_onnx_export_flow_e2e():
     # Request ONNX export
     r = client.post("/api/export/onnx", json={"experimentId": "e1", "dynamicAxes": True})

--- a/backend/tests/integration/test_training_flow.py
+++ b/backend/tests/integration/test_training_flow.py
@@ -4,6 +4,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_training_flow_e2e():
     # Create project
     r = client.post("/api/projects", json={"name": "Train", "description": "flow"})
@@ -16,7 +17,12 @@ def test_training_flow_e2e():
 
     r = client.post(
         "/api/train",
-        json={"projectId": proj["id"], "datasetVersionId": "v1", "task": "classification", "params": {}},
+        json={
+            "projectId": proj["id"],
+            "datasetVersionId": "v1",
+            "task": "classification",
+            "params": {},
+        },
     )
     assert r.status_code == 202
     body = r.json()

--- a/backend/tests/perf/test_api_perf.py
+++ b/backend/tests/perf/test_api_perf.py
@@ -14,11 +14,13 @@ ROUTES = [
     ),
 ]
 
+
 def p95(latencies):
     latencies = sorted(latencies)
     idx = int(len(latencies) * 0.95) - 1
-    idx = max(0, min(idx, len(latencies)-1))
+    idx = max(0, min(idx, len(latencies) - 1))
     return latencies[idx]
+
 
 def test_core_api_p95_under_200ms():
     latencies = []

--- a/backend/tests/unit/test_annotation_service.py
+++ b/backend/tests/unit/test_annotation_service.py
@@ -1,7 +1,9 @@
 """Unit tests for annotation service using SQLite in-memory DB."""
+
 from __future__ import annotations
 
 import json
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -22,9 +24,9 @@ def db():
 
 def _make_asset(db, dataset_id: str = "ds-1") -> str:
     from app.models.asset import Asset
-    from app.models.workspace import Workspace
-    from app.models.project import Project
     from app.models.dataset import Dataset
+    from app.models.project import Project
+    from app.models.workspace import Workspace
 
     ws = Workspace(id="ws-1", name="Test WS", created_by="user-1")
     db.add(ws)
@@ -32,8 +34,13 @@ def _make_asset(db, dataset_id: str = "ds-1") -> str:
     db.add(proj)
     ds = Dataset(id=dataset_id, project_id="proj-1", name="DS")
     db.add(ds)
-    asset = Asset(id="asset-1", dataset_id=dataset_id, uri="datasets/v1/img.jpg",
-                  mime_type="image/jpeg", label_status="unlabeled")
+    asset = Asset(
+        id="asset-1",
+        dataset_id=dataset_id,
+        uri="datasets/v1/img.jpg",
+        mime_type="image/jpeg",
+        label_status="unlabeled",
+    )
     db.add(asset)
     db.commit()
     return "asset-1"
@@ -41,8 +48,10 @@ def _make_asset(db, dataset_id: str = "ds-1") -> str:
 
 def test_create_annotation(db):
     from app.services.annotation_service import create_annotation
+
     asset_id = _make_asset(db)
     from app.models.user import User
+
     user = User(id="user-1", name="Tester", email="t@t.com")
     db.add(user)
     db.commit()
@@ -63,16 +72,24 @@ def test_create_annotation(db):
 
 def test_update_annotation_stores_history(db):
     from app.services.annotation_service import create_annotation, update_annotation
+
     _make_asset(db)
     from app.models.user import User
+
     db.add(User(id="user-1", name="T", email="t@t.com"))
     db.commit()
 
-    ann = create_annotation(db, asset_id="asset-1", author_id="user-1",
-                             type="box", geometry={"x": 0, "y": 0, "w": 10, "h": 10},
-                             class_name="dog")
-    updated = update_annotation(db, ann.id, geometry={"x": 5, "y": 5, "w": 20, "h": 20},
-                                class_name="cat")
+    ann = create_annotation(
+        db,
+        asset_id="asset-1",
+        author_id="user-1",
+        type="box",
+        geometry={"x": 0, "y": 0, "w": 10, "h": 10},
+        class_name="dog",
+    )
+    updated = update_annotation(
+        db, ann.id, geometry={"x": 5, "y": 5, "w": 20, "h": 20}, class_name="cat"
+    )
     assert updated is not None
     assert updated.class_name == "cat"
     history = json.loads(updated.history)
@@ -81,15 +98,26 @@ def test_update_annotation_stores_history(db):
 
 
 def test_delete_annotation(db):
-    from app.services.annotation_service import create_annotation, delete_annotation, get_asset_annotations
+    from app.services.annotation_service import (
+        create_annotation,
+        delete_annotation,
+        get_asset_annotations,
+    )
+
     _make_asset(db)
     from app.models.user import User
+
     db.add(User(id="user-1", name="T", email="t@t.com"))
     db.commit()
 
-    ann = create_annotation(db, asset_id="asset-1", author_id="user-1",
-                             type="classification", geometry={"class": "cat"},
-                             class_name="cat")
+    ann = create_annotation(
+        db,
+        asset_id="asset-1",
+        author_id="user-1",
+        type="classification",
+        geometry={"class": "cat"},
+        class_name="cat",
+    )
     assert len(get_asset_annotations(db, "asset-1")) == 1
     result = delete_annotation(db, ann.id)
     assert result is True

--- a/backend/tests/unit/test_annotation_versioning.py
+++ b/backend/tests/unit/test_annotation_versioning.py
@@ -1,0 +1,158 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app import models as _models  # noqa: F401
+from app.db.base import Base
+from app.models.asset import Asset
+from app.models.dataset import Dataset
+from app.models.dataset_version import DatasetVersion
+from app.models.user import User
+from app.services.annotation_service import (
+    AnnotationError,
+    VersionConflictError,
+    create_annotation,
+    delete_annotation,
+    get_history,
+    update_annotation,
+)
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, future=True)
+    s = Session()
+    user = User(id="u1", email="u@example.com", name="U", password_hash="$2b$x")
+    s.add(user)
+    ds = Dataset(id="ds1", project_id="p1", name="d", description="")
+    s.add(ds)
+    s.commit()
+    v = DatasetVersion(id="dv1", dataset_id="ds1", version=1)
+    s.add(v)
+    s.commit()
+    asset = Asset(
+        id="a1",
+        dataset_id="ds1",
+        version_id="dv1",
+        uri="x",
+        mime_type="image/jpeg",
+        label_status="unlabelled",
+    )
+    s.add(asset)
+    s.commit()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def test_create_box(db):
+    a = create_annotation(
+        db,
+        asset_id="a1",
+        author_id="u1",
+        type="box",
+        geometry={"x": 1, "y": 2, "w": 3, "h": 4},
+        class_name="car",
+    )
+    assert a.id and a.version == 1
+    assert a.updated_at is not None
+
+
+def test_create_polygon_requires_three_points(db):
+    with pytest.raises(AnnotationError):
+        create_annotation(
+            db,
+            asset_id="a1",
+            author_id="u1",
+            type="polygon",
+            geometry={"points": [{"x": 0, "y": 0}, {"x": 1, "y": 0}]},
+            class_name="x",
+        )
+
+    a = create_annotation(
+        db,
+        asset_id="a1",
+        author_id="u1",
+        type="polygon",
+        geometry={"points": [{"x": 0, "y": 0}, {"x": 1, "y": 0}, {"x": 0, "y": 1}]},
+        class_name="x",
+    )
+    assert a.type == "polygon"
+
+
+def test_create_keypoint(db):
+    a = create_annotation(
+        db,
+        asset_id="a1",
+        author_id="u1",
+        type="keypoint",
+        geometry={"points": [{"x": 5, "y": 5}]},
+        class_name="nose",
+    )
+    assert a.type == "keypoint"
+
+
+def test_unsupported_type_rejected(db):
+    with pytest.raises(AnnotationError):
+        create_annotation(
+            db,
+            asset_id="a1",
+            author_id="u1",
+            type="cuboid",
+            geometry={},
+            class_name=None,
+        )
+
+
+def test_update_bumps_version_and_writes_history(db):
+    a = create_annotation(
+        db,
+        asset_id="a1",
+        author_id="u1",
+        type="box",
+        geometry={"x": 1, "y": 1, "w": 2, "h": 2},
+        class_name="car",
+    )
+    updated = update_annotation(
+        db,
+        a.id,
+        geometry={"x": 5, "y": 5, "w": 2, "h": 2},
+        expected_version=1,
+    )
+    assert updated.version == 2
+    history = get_history(db, a.id)
+    assert len(history) == 1
+
+
+def test_update_with_wrong_version_raises_409(db):
+    a = create_annotation(
+        db,
+        asset_id="a1",
+        author_id="u1",
+        type="box",
+        geometry={"x": 1, "y": 1, "w": 2, "h": 2},
+        class_name="car",
+    )
+    with pytest.raises(VersionConflictError):
+        update_annotation(
+            db,
+            a.id,
+            geometry={"x": 5, "y": 5, "w": 2, "h": 2},
+            expected_version=99,
+        )
+
+
+def test_delete(db):
+    a = create_annotation(
+        db,
+        asset_id="a1",
+        author_id="u1",
+        type="box",
+        geometry={"x": 1, "y": 1, "w": 2, "h": 2},
+        class_name="car",
+    )
+    assert delete_annotation(db, a.id) is True
+    assert delete_annotation(db, a.id) is False

--- a/backend/tests/unit/test_auth_bcrypt_only.py
+++ b/backend/tests/unit/test_auth_bcrypt_only.py
@@ -1,0 +1,56 @@
+"""Authentication must reject any non-bcrypt stored hash (no SHA256 fallback)."""
+
+import hashlib
+
+from sqlalchemy import select
+
+from app.db.session import SessionLocal
+from app.models.user import User
+from app.services import auth
+
+
+def test_legacy_sha256_hash_does_not_authenticate():
+    email = "legacy@example.com"
+    password = "supersecret"
+    sha = hashlib.sha256(password.encode()).hexdigest()
+    # Skip if bcrypt env is broken — the test would mask its real intent.
+    try:
+        auth._hash_password("probe")
+    except Exception:
+        return
+
+    with SessionLocal() as db:
+        existing = db.scalar(select(User).where(User.email == email))
+        if existing:
+            existing.password_hash = sha
+            db.add(existing)
+        else:
+            db.add(User(id="legacy-1", email=email, name="L", password_hash=sha))
+        db.commit()
+
+    assert auth.authenticate(email, password) is None
+
+
+def test_bcrypt_hash_authenticates():
+    email = "modern@example.com"
+    password = "topsecret"
+    try:
+        hashed = auth._hash_password(password)
+    except Exception:
+        # Env without working bcrypt; the assertion can't be evaluated.
+        return
+
+    with SessionLocal() as db:
+        existing = db.scalar(select(User).where(User.email == email))
+        if existing:
+            existing.password_hash = hashed
+            db.add(existing)
+        else:
+            db.add(User(id="modern-1", email=email, name="M", password_hash=hashed))
+        db.commit()
+
+    out = auth.authenticate(email, password)
+    assert out is not None
+    access, refresh, user = out
+    assert access and refresh
+    assert user["email"] == email

--- a/backend/tests/unit/test_datumaro_import.py
+++ b/backend/tests/unit/test_datumaro_import.py
@@ -1,0 +1,134 @@
+import io
+import json
+import zipfile
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app import models as _models  # noqa: F401
+from app.db.base import Base
+from app.models.dataset import Dataset
+from app.models.dataset_version import DatasetVersion
+from app.services.datumaro_service import (
+    DatumaroError,
+    export_archive,
+    import_archive,
+)
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine, future=True)
+    s = Session()
+    s.add(Dataset(id="d1", project_id="p1", name="d", description=""))
+    s.commit()
+    s.add(DatasetVersion(id="v1", dataset_id="d1", version=1))
+    s.commit()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+def _zip_files(files: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in files.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+def test_unsupported_format_raises(db):
+    with pytest.raises(DatumaroError):
+        import_archive(
+            db,
+            dataset_id="d1",
+            version_id="v1",
+            archive_bytes=b"",
+            fmt="parquet",
+        )
+
+
+def test_coco_import_creates_assets_and_annotations(db):
+    coco = {
+        "images": [
+            {"id": 1, "file_name": "a.jpg", "width": 100, "height": 100},
+            {"id": 2, "file_name": "b.jpg", "width": 100, "height": 100},
+        ],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [10, 10, 20, 20]},
+            {"id": 2, "image_id": 2, "category_id": 2, "bbox": [5, 5, 30, 30]},
+        ],
+        "categories": [{"id": 1, "name": "cat"}, {"id": 2, "name": "dog"}],
+    }
+    archive = _zip_files({"annotations.json": json.dumps(coco).encode()})
+    summary = import_archive(
+        db,
+        dataset_id="d1",
+        version_id="v1",
+        archive_bytes=archive,
+        fmt="coco",
+        image_uri_base="datasets/d1/imported",
+    )
+    assert summary.asset_count == 2
+    assert summary.annotation_count == 2
+    assert "cat" in summary.classes and "dog" in summary.classes
+
+
+def test_yolo_import_with_classes(db):
+    archive = _zip_files(
+        {
+            "classes.txt": b"car\nbike\n",
+            "images/img1.jpg": b"\xff\xd8\xff\xe0",  # not a valid jpeg, but enough to be detected
+            "labels/img1.txt": b"0 0.5 0.5 0.4 0.4\n1 0.2 0.2 0.1 0.1\n",
+        }
+    )
+    summary = import_archive(
+        db,
+        dataset_id="d1",
+        version_id="v1",
+        archive_bytes=archive,
+        fmt="yolo",
+    )
+    assert summary.asset_count == 1
+    assert summary.annotation_count == 2
+    assert summary.classes == ["car", "bike"]
+
+
+def test_export_roundtrip_coco(db):
+    # First import a small COCO so we have data to export
+    coco = {
+        "images": [{"id": 1, "file_name": "a.jpg", "width": 100, "height": 100}],
+        "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [1, 2, 3, 4]}],
+        "categories": [{"id": 1, "name": "car"}],
+    }
+    archive = _zip_files({"annotations.json": json.dumps(coco).encode()})
+    import_archive(db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco")
+    blob = export_archive(db, dataset_id="d1", version_id="v1", fmt="coco")
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        names = zf.namelist()
+        assert "annotations.json" in names
+        data = json.loads(zf.read("annotations.json"))
+        assert len(data["images"]) == 1
+        assert len(data["annotations"]) == 1
+        assert data["categories"][0]["name"] == "car"
+
+
+def test_export_yolo_writes_labels_and_classes(db):
+    coco = {
+        "images": [{"id": 1, "file_name": "a.jpg", "width": 100, "height": 100}],
+        "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [10, 20, 30, 40]}],
+        "categories": [{"id": 1, "name": "car"}],
+    }
+    archive = _zip_files({"annotations.json": json.dumps(coco).encode()})
+    import_archive(db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco")
+    blob = export_archive(db, dataset_id="d1", version_id="v1", fmt="yolo")
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        names = zf.namelist()
+        assert "classes.txt" in names
+        assert any(n.startswith("labels/") for n in names)
+        cls = zf.read("classes.txt").decode().strip()
+        assert "car" in cls

--- a/backend/tests/unit/test_datumaro_import.py
+++ b/backend/tests/unit/test_datumaro_import.py
@@ -102,11 +102,15 @@ def test_export_roundtrip_coco(db):
     # First import a small COCO so we have data to export
     coco = {
         "images": [{"id": 1, "file_name": "a.jpg", "width": 100, "height": 100}],
-        "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [1, 2, 3, 4]}],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [1, 2, 3, 4]}
+        ],
         "categories": [{"id": 1, "name": "car"}],
     }
     archive = _zip_files({"annotations.json": json.dumps(coco).encode()})
-    import_archive(db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco")
+    import_archive(
+        db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco"
+    )
     blob = export_archive(db, dataset_id="d1", version_id="v1", fmt="coco")
     with zipfile.ZipFile(io.BytesIO(blob)) as zf:
         names = zf.namelist()
@@ -120,11 +124,15 @@ def test_export_roundtrip_coco(db):
 def test_export_yolo_writes_labels_and_classes(db):
     coco = {
         "images": [{"id": 1, "file_name": "a.jpg", "width": 100, "height": 100}],
-        "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [10, 20, 30, 40]}],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [10, 20, 30, 40]}
+        ],
         "categories": [{"id": 1, "name": "car"}],
     }
     archive = _zip_files({"annotations.json": json.dumps(coco).encode()})
-    import_archive(db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco")
+    import_archive(
+        db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco"
+    )
     blob = export_archive(db, dataset_id="d1", version_id="v1", fmt="yolo")
     with zipfile.ZipFile(io.BytesIO(blob)) as zf:
         names = zf.namelist()
@@ -132,3 +140,34 @@ def test_export_yolo_writes_labels_and_classes(db):
         assert any(n.startswith("labels/") for n in names)
         cls = zf.read("classes.txt").decode().strip()
         assert "car" in cls
+
+
+def test_export_yolo_disambiguates_colliding_stems(db):
+    """Two assets with the same filename stem must produce distinct label files."""
+    # Import two images that share the same basename in different folders.
+    coco = {
+        "images": [
+            {"id": 1, "file_name": "train/img.jpg", "width": 100, "height": 100},
+            {"id": 2, "file_name": "val/img.jpg", "width": 100, "height": 100},
+        ],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [1, 2, 3, 4]},
+            {"id": 2, "image_id": 2, "category_id": 1, "bbox": [5, 6, 7, 8]},
+        ],
+        "categories": [{"id": 1, "name": "car"}],
+    }
+    archive = _zip_files({"annotations.json": json.dumps(coco).encode()})
+    import_archive(
+        db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco"
+    )
+
+    blob = export_archive(db, dataset_id="d1", version_id="v1", fmt="yolo")
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        label_files = [n for n in zf.namelist() if n.startswith("labels/")]
+        # Both labels must be present — neither must overwrite the other.
+        assert len(label_files) == 2
+        assert len(set(label_files)) == 2
+        # Manifest carries the asset → label mapping for reconstruction.
+        manifest = zf.read("manifest.csv").decode().splitlines()
+        assert manifest[0] == "asset_id,uri,label_file"
+        assert len(manifest) == 3

--- a/backend/tests/unit/test_evaluation_metrics.py
+++ b/backend/tests/unit/test_evaluation_metrics.py
@@ -89,3 +89,22 @@ def test_detection_iou_below_threshold_is_fp():
     # Pred doesn't match → FP and FN (no match)
     assert pc["precision"] == 0.0
     assert pc["recall"] == 0.0
+
+
+def test_detection_confusion_records_cross_class_match():
+    """Wrong-class predictions that match a GT by IoU must populate off-diagonal."""
+    items = [
+        {
+            "asset_id": "a",
+            "gt": [{"class": "car", "bbox": (0, 0, 10, 10)}],
+            "pred": [{"class": "truck", "bbox": (0, 0, 10, 10), "score": 0.9}],
+        }
+    ]
+    out = compute_detection_metrics(items, ["car", "truck"], iou_threshold=0.5)
+    cm = out["confusion"]
+    # rows = GT, cols = pred. GT was car (idx 0), pred was truck (idx 1).
+    assert cm[0][1] == 1
+    assert cm[0][0] == 0
+    # Class-strict pass: it's still an FP for truck and an FN for car.
+    assert out["per_class"]["car"]["recall"] == 0.0
+    assert out["per_class"]["truck"]["precision"] == 0.0

--- a/backend/tests/unit/test_evaluation_metrics.py
+++ b/backend/tests/unit/test_evaluation_metrics.py
@@ -1,0 +1,91 @@
+"""Unit tests for the metrics computations in the evaluation Celery task."""
+
+from app.jobs.tasks.evaluation import (
+    compute_classification_metrics,
+    compute_detection_metrics,
+)
+
+
+def test_classification_perfect_prediction():
+    pairs = [("cat", "cat"), ("dog", "dog"), ("cat", "cat")]
+    out = compute_classification_metrics(pairs, ["cat", "dog"])
+    assert out["metrics"]["accuracy"] == 1.0
+    assert out["per_class"]["cat"]["precision"] == 1.0
+    assert out["per_class"]["cat"]["recall"] == 1.0
+    assert out["confusion"][0][0] == 2  # cat,cat
+    assert out["confusion"][1][1] == 1  # dog,dog
+
+
+def test_classification_with_errors():
+    pairs = [
+        ("cat", "cat"),
+        ("dog", "cat"),  # FP for dog, FN for cat
+        ("dog", "dog"),
+        ("cat", "dog"),  # FP for cat, FN for dog
+    ]
+    out = compute_classification_metrics(pairs, ["cat", "dog"])
+    assert out["metrics"]["accuracy"] == 0.5
+    assert out["per_class"]["cat"]["support"] == 2
+    assert out["per_class"]["dog"]["support"] == 2
+    # confusion: row=gt, col=pred
+    # cat,cat=1; cat,dog=1; dog,dog=1; dog,cat=1
+    cm = out["confusion"]
+    assert cm[0][0] == 1
+    assert cm[0][1] == 1
+    assert cm[1][0] == 1
+    assert cm[1][1] == 1
+
+
+def test_detection_perfect_match():
+    items = [
+        {
+            "asset_id": "a",
+            "gt": [{"class": "car", "bbox": (10, 10, 20, 20)}],
+            "pred": [{"class": "car", "bbox": (10, 10, 20, 20), "score": 0.9}],
+        }
+    ]
+    out = compute_detection_metrics(items, ["car"], iou_threshold=0.5)
+    assert out["per_class"]["car"]["precision"] == 1.0
+    assert out["per_class"]["car"]["recall"] == 1.0
+    assert out["per_class"]["car"]["ap50"] > 0.9
+
+
+def test_detection_misses_and_false_positives():
+    items = [
+        # 1 GT car, no pred → 1 FN
+        {"asset_id": "a", "gt": [{"class": "car", "bbox": (0, 0, 10, 10)}], "pred": []},
+        # 1 pred car with no GT → 1 FP
+        {
+            "asset_id": "b",
+            "gt": [],
+            "pred": [{"class": "car", "bbox": (0, 0, 10, 10), "score": 0.6}],
+        },
+        # match
+        {
+            "asset_id": "c",
+            "gt": [{"class": "car", "bbox": (5, 5, 10, 10)}],
+            "pred": [{"class": "car", "bbox": (5, 5, 10, 10), "score": 0.8}],
+        },
+    ]
+    out = compute_detection_metrics(items, ["car"], iou_threshold=0.5)
+    pc = out["per_class"]["car"]
+    # 1 TP, 1 FP, 1 FN
+    assert pc["precision"] == 0.5
+    assert pc["recall"] == 0.5
+    assert 0.0 < pc["ap50"] < 1.0
+
+
+def test_detection_iou_below_threshold_is_fp():
+    # GT and pred barely overlap
+    items = [
+        {
+            "asset_id": "a",
+            "gt": [{"class": "car", "bbox": (0, 0, 10, 10)}],
+            "pred": [{"class": "car", "bbox": (8, 8, 10, 10), "score": 0.7}],
+        }
+    ]
+    out = compute_detection_metrics(items, ["car"], iou_threshold=0.5)
+    pc = out["per_class"]["car"]
+    # Pred doesn't match → FP and FN (no match)
+    assert pc["precision"] == 0.0
+    assert pc["recall"] == 0.0

--- a/backend/tests/unit/test_inference_cache.py
+++ b/backend/tests/unit/test_inference_cache.py
@@ -1,0 +1,52 @@
+"""Tests for the in-process inference LRU cache.
+
+We don't load a real model — just exercise the cache plumbing with stubs.
+"""
+
+from app.services import inference_service
+
+
+class _Artifact:
+    def __init__(self, id_: str):
+        self.id = id_
+        self.storage_path = f"/tmp/{id_}.pt"
+        self.format = "pytorch"
+        self.type = "yolo"
+
+
+def test_evict_and_clear_dont_raise():
+    inference_service.evict("missing")
+    inference_service._cache.clear()  # type: ignore[attr-defined]
+    assert inference_service.cache_stats()["size"] == 0
+
+
+def test_lru_eviction_when_full(monkeypatch):
+    loaded: list[str] = []
+
+    def fake_load(artifact):
+        loaded.append(artifact.id)
+        return ("yolo", object())
+
+    monkeypatch.setattr(inference_service, "_load_artifact", fake_load)
+    monkeypatch.setattr(inference_service._cache, "max_size", 2)
+    inference_service._cache.clear()  # type: ignore[attr-defined]
+
+    inference_service._cache.get_or_load(_Artifact("a"))
+    inference_service._cache.get_or_load(_Artifact("b"))
+    inference_service._cache.get_or_load(_Artifact("c"))
+
+    stats = inference_service.cache_stats()
+    assert stats["size"] == 2
+    # 'a' should be evicted; 'b' + 'c' remain
+    assert "a" not in stats["loaded"]
+
+
+def test_get_returns_same_instance_within_capacity(monkeypatch):
+    inference_service._cache.clear()  # type: ignore[attr-defined]
+    monkeypatch.setattr(inference_service._cache, "max_size", 4)
+    sentinel = object()
+    monkeypatch.setattr(inference_service, "_load_artifact", lambda art: ("yolo", sentinel))
+    a = _Artifact("x")
+    first = inference_service._cache.get_or_load(a)
+    second = inference_service._cache.get_or_load(a)
+    assert first is second

--- a/backend/tests/unit/test_inference_cache.py
+++ b/backend/tests/unit/test_inference_cache.py
@@ -3,6 +3,9 @@
 We don't load a real model — just exercise the cache plumbing with stubs.
 """
 
+import tempfile
+from pathlib import Path
+
 from app.services import inference_service
 
 
@@ -14,6 +17,12 @@ class _Artifact:
         self.type = "yolo"
 
 
+def _stub_load(artifact):
+    """Pretend to load: returns (kind, model, scratch_dir) like the real loader."""
+    scratch = Path(tempfile.mkdtemp(prefix="vf-test-model-"))
+    return ("yolo", object(), scratch)
+
+
 def test_evict_and_clear_dont_raise():
     inference_service.evict("missing")
     inference_service._cache.clear()  # type: ignore[attr-defined]
@@ -21,13 +30,7 @@ def test_evict_and_clear_dont_raise():
 
 
 def test_lru_eviction_when_full(monkeypatch):
-    loaded: list[str] = []
-
-    def fake_load(artifact):
-        loaded.append(artifact.id)
-        return ("yolo", object())
-
-    monkeypatch.setattr(inference_service, "_load_artifact", fake_load)
+    monkeypatch.setattr(inference_service, "_load_artifact", _stub_load)
     monkeypatch.setattr(inference_service._cache, "max_size", 2)
     inference_service._cache.clear()  # type: ignore[attr-defined]
 
@@ -45,8 +48,33 @@ def test_get_returns_same_instance_within_capacity(monkeypatch):
     inference_service._cache.clear()  # type: ignore[attr-defined]
     monkeypatch.setattr(inference_service._cache, "max_size", 4)
     sentinel = object()
-    monkeypatch.setattr(inference_service, "_load_artifact", lambda art: ("yolo", sentinel))
+    sentinel_scratch = Path(tempfile.mkdtemp(prefix="vf-test-model-"))
+    monkeypatch.setattr(
+        inference_service, "_load_artifact", lambda art: ("yolo", sentinel, sentinel_scratch)
+    )
     a = _Artifact("x")
-    first = inference_service._cache.get_or_load(a)
-    second = inference_service._cache.get_or_load(a)
-    assert first is second
+    first_kind, first_model = inference_service._cache.get_or_load(a)
+    second_kind, second_model = inference_service._cache.get_or_load(a)
+    assert first_kind == second_kind == "yolo"
+    assert first_model is second_model is sentinel
+
+
+def test_evict_cleans_scratch_dir(monkeypatch, tmp_path):
+    """Evicting a cached entry must remove its on-disk scratch dir."""
+    inference_service._cache.clear()  # type: ignore[attr-defined]
+    monkeypatch.setattr(inference_service._cache, "max_size", 2)
+
+    created: list[Path] = []
+
+    def stub(artifact):
+        d = Path(tempfile.mkdtemp(prefix="vf-test-evict-", dir=tmp_path))
+        # Drop a file so the dir isn't empty
+        (d / "weights.pt").write_bytes(b"x")
+        created.append(d)
+        return ("yolo", object(), d)
+
+    monkeypatch.setattr(inference_service, "_load_artifact", stub)
+    inference_service._cache.get_or_load(_Artifact("e1"))
+    assert created[-1].exists()
+    inference_service.evict("e1")
+    assert not created[-1].exists()

--- a/backend/tests/unit/test_jobs_service.py
+++ b/backend/tests/unit/test_jobs_service.py
@@ -19,7 +19,9 @@ def test_create_and_update_job(tmp_path):
 
     # SQLite DB for unit test
     db_path = tmp_path / "jobs.db"
-    engine = create_engine(f"sqlite+pysqlite:///{db_path}", connect_args={"check_same_thread": False})
+    engine = create_engine(
+        f"sqlite+pysqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
     Base.metadata.create_all(bind=engine)
     Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     db = Session()
@@ -37,7 +39,9 @@ def test_create_and_update_job(tmp_path):
         assert job2.status == "running"
         assert job2.progress == 0.5
 
-        job3 = update_job_status(db, job.id, status="succeeded", progress=1.0, logs_uri="s3://bucket/logs.txt")
+        job3 = update_job_status(
+            db, job.id, status="succeeded", progress=1.0, logs_uri="s3://bucket/logs.txt"
+        )
         assert job3.status == "succeeded"
         assert job3.progress == 1.0
         assert job3.logs_uri is not None

--- a/backend/tests/unit/test_models_tables.py
+++ b/backend/tests/unit/test_models_tables.py
@@ -46,5 +46,5 @@ def test_tables_exist(tmp_path):
     }
 
     actual_tables = set(insp.get_table_names())
-    
+
     assert expected.issubset(actual_tables)

--- a/backend/tests/unit/test_services_auth.py
+++ b/backend/tests/unit/test_services_auth.py
@@ -1,7 +1,7 @@
 """Unit tests for auth service — bcrypt hashing and JWT token functions."""
+
 from __future__ import annotations
 
-import pytest
 from app.services import auth
 
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,11 @@ import ActiveLearningNew from "./pages/active-learning/new";
 import ALRunDetail from "./pages/active-learning/[alRunId]";
 import ClustersIndex from "./pages/clusters/index";
 import ClustersNew from "./pages/clusters/new";
+import EvaluationsIndex from "./pages/evaluations/index";
+import EvaluationsNew from "./pages/evaluations/new";
+import EvaluationDetail from "./pages/evaluations/[evalId]";
+import ArtifactsPredict from "./pages/artifacts/predict";
+import DatasetImport from "./pages/datasets/import";
 import { apiGet } from "@/services/api";
 import Spinner from "@/components/ui/Spinner";
 
@@ -196,6 +201,13 @@ export default function App() {
             {/* Clusters */}
             <Route path="/clusters" element={<ProtectedRoute><ClustersIndex /></ProtectedRoute>} />
             <Route path="/clusters/new" element={<ProtectedRoute><ClustersNew /></ProtectedRoute>} />
+            {/* Evaluations */}
+            <Route path="/evaluations" element={<ProtectedRoute><EvaluationsIndex /></ProtectedRoute>} />
+            <Route path="/evaluations/new" element={<ProtectedRoute><EvaluationsNew /></ProtectedRoute>} />
+            <Route path="/evaluations/:evalId" element={<ProtectedRoute><EvaluationDetail /></ProtectedRoute>} />
+            {/* Predict + import */}
+            <Route path="/artifacts/predict/:modelId" element={<ProtectedRoute><ArtifactsPredict /></ProtectedRoute>} />
+            <Route path="/datasets/import" element={<ProtectedRoute><DatasetImport /></ProtectedRoute>} />
             {/* Annotate */}
             <Route path="/annotate/:assetId" element={<ProtectedRoute><AnnotatorPage /></ProtectedRoute>} />
             {/* Admin */}

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -7,6 +7,7 @@ const NAV_LINKS = [
   { to: '/datasets',         label: 'DATASETS'    },
   { to: '/experiments',      label: 'EXPERIMENTS' },
   { to: '/artifacts',        label: 'ARTIFACTS'   },
+  { to: '/evaluations',      label: 'EVALUATIONS' },
   { to: '/active-learning',  label: 'ACTIVE LEARN'},
   { to: '/clusters',         label: 'CLUSTERS'    },
   { to: '/admin/users',      label: 'ADMIN'       },

--- a/frontend/src/pages/annotate/Annotator.jsx
+++ b/frontend/src/pages/annotate/Annotator.jsx
@@ -1,72 +1,36 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { apiGet, apiPost, apiUrl } from '../../services/api';
+import { apiGet, apiPost, apiPut, apiDelete, apiUrl } from '@/services/api';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-// Muted HUD palette: no pure neon, no gaming colors
 const CLASS_COLORS = [
-  'oklch(0.72 0.10 82)',   // amber/olive (accent)
-  'oklch(0.60 0.10 155)', // muted green
-  'oklch(0.68 0.16 20)',  // brick red
-  'oklch(0.72 0.08 230)', // slate blue
-  'oklch(0.70 0.10 75)',  // warm amber
-  'oklch(0.65 0.10 200)', // teal
-  'oklch(0.62 0.10 100)', // yellow-green
-  'oklch(0.58 0.12 310)', // muted purple
-  'oklch(0.68 0.10 40)',  // orange
-  'oklch(0.60 0.08 180)', // cyan
+  'oklch(0.72 0.10 82)',
+  'oklch(0.60 0.10 155)',
+  'oklch(0.68 0.16 20)',
+  'oklch(0.72 0.08 230)',
+  'oklch(0.70 0.10 75)',
+  'oklch(0.65 0.10 200)',
+  'oklch(0.62 0.10 100)',
+  'oklch(0.58 0.12 310)',
+  'oklch(0.68 0.10 40)',
+  'oklch(0.60 0.08 180)',
 ];
 
-const MAX_CANVAS_W = 800;
-const MAX_CANVAS_H = 600;
+const MAX_CANVAS_W = 900;
+const MAX_CANVAS_H = 700;
+const HISTORY_LIMIT = 50;
 
-// HUD color tokens as canvas-compatible values
 const HUD = {
-  base:         'oklch(0.10 0.008 240)',
-  surface:      'oklch(0.14 0.008 240)',
-  elevated:     'oklch(0.18 0.008 240)',
-  inset:        'oklch(0.09 0.008 240)',
-  borderSubtle: 'oklch(0.20 0.006 240)',
-  borderDefault:'oklch(0.26 0.006 240)',
-  textMuted:    'oklch(0.42 0.008 240)',
-  textSecondary:'oklch(0.65 0.008 240)',
-  textData:     'oklch(0.96 0.003 240)',
-  accent:       'oklch(0.72 0.10 82)',
-  success:      'oklch(0.60 0.10 155)',
-  danger:       'oklch(0.52 0.16 20)',
+  base: 'oklch(0.10 0.008 240)',
+  surface: 'oklch(0.14 0.008 240)',
+  inset: 'oklch(0.09 0.008 240)',
+  textMuted: 'oklch(0.42 0.008 240)',
+  textData: 'oklch(0.96 0.003 240)',
+  accent: 'oklch(0.72 0.10 82)',
 };
-
-// ---------------------------------------------------------------------------
-// Small API helpers
-// ---------------------------------------------------------------------------
-
-async function apiPut(path, body) {
-  const res = await fetch(apiUrl(path), {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  if (!res.ok) {
-    let detail;
-    try { detail = await res.json(); } catch { detail = undefined; }
-    throw new Error(detail?.detail || `Request failed with ${res.status}`);
-  }
-  return res.json();
-}
-
-async function apiDelete(path) {
-  const res = await fetch(apiUrl(path), { method: 'DELETE' });
-  if (!res.ok) {
-    let detail;
-    try { detail = await res.json(); } catch { detail = undefined; }
-    throw new Error(detail?.detail || `Request failed with ${res.status}`);
-  }
-  if (res.status === 204) return null;
-  return res.json();
-}
 
 // ---------------------------------------------------------------------------
 // Utility
@@ -75,6 +39,31 @@ async function apiDelete(path) {
 function classColor(className, classes) {
   const idx = classes.indexOf(className);
   return CLASS_COLORS[(idx === -1 ? 0 : idx) % CLASS_COLORS.length];
+}
+
+function deepClone(value) {
+  if (typeof structuredClone === 'function') return structuredClone(value);
+  return JSON.parse(JSON.stringify(value));
+}
+
+function distSq(a, b) {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return dx * dx + dy * dy;
+}
+
+function pointInPolygon(px, py, points) {
+  let inside = false;
+  for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
+    const xi = points[i].x;
+    const yi = points[i].y;
+    const xj = points[j].x;
+    const yj = points[j].y;
+    const intersect =
+      yi > py !== yj > py && px < ((xj - xi) * (py - yi)) / (yj - yi + 1e-9) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
 }
 
 // ---------------------------------------------------------------------------
@@ -90,12 +79,20 @@ export default function AnnotatorPage() {
   const [classes, setClasses] = useState(['object']);
   const [selectedClass, setSelectedClass] = useState('object');
   const [selectedAnnotationIdx, setSelectedAnnotationIdx] = useState(null);
+  // mode: 'box' | 'polygon' | 'keypoint' | 'classify' | 'select'
   const [mode, setMode] = useState('box');
   const [dirty, setDirty] = useState(false);
   const [status, setStatus] = useState('Loading…');
   const [newClassName, setNewClassName] = useState('');
   const [imageError, setImageError] = useState(false);
   const [scaleFactor, setScaleFactor] = useState(1);
+  const [neighbors, setNeighbors] = useState({ prev: null, next: null, index: null, total: 0 });
+  // In-progress polygon: array of points (image coordinates)
+  const [polygonInProgress, setPolygonInProgress] = useState([]);
+
+  // Undo/redo stacks. Each entry is a snapshot of the annotations array.
+  const undoStack = useRef([]);
+  const redoStack = useRef([]);
 
   const drawingRef = useRef({ active: false, startX: 0, startY: 0, currentX: 0, currentY: 0 });
   const canvasRef = useRef(null);
@@ -106,17 +103,66 @@ export default function AnnotatorPage() {
   const classesRef = useRef(classes);
   const selectedClassRef = useRef(selectedClass);
   const modeRef = useRef(mode);
+  const polygonInProgressRef = useRef(polygonInProgress);
 
-  useEffect(() => { annotationsRef.current = annotations; }, [annotations]);
-  useEffect(() => { selectedIdxRef.current = selectedAnnotationIdx; }, [selectedAnnotationIdx]);
-  useEffect(() => { scaleRef.current = scaleFactor; }, [scaleFactor]);
-  useEffect(() => { classesRef.current = classes; }, [classes]);
-  useEffect(() => { selectedClassRef.current = selectedClass; }, [selectedClass]);
-  useEffect(() => { modeRef.current = mode; }, [mode]);
+  useEffect(() => {
+    annotationsRef.current = annotations;
+  }, [annotations]);
+  useEffect(() => {
+    selectedIdxRef.current = selectedAnnotationIdx;
+  }, [selectedAnnotationIdx]);
+  useEffect(() => {
+    scaleRef.current = scaleFactor;
+  }, [scaleFactor]);
+  useEffect(() => {
+    classesRef.current = classes;
+  }, [classes]);
+  useEffect(() => {
+    selectedClassRef.current = selectedClass;
+  }, [selectedClass]);
+  useEffect(() => {
+    modeRef.current = mode;
+  }, [mode]);
+  useEffect(() => {
+    polygonInProgressRef.current = polygonInProgress;
+  }, [polygonInProgress]);
 
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // History (undo/redo)
+  // -------------------------------------------------------------------------
+
+  function pushHistory() {
+    undoStack.current.push(deepClone(annotationsRef.current));
+    if (undoStack.current.length > HISTORY_LIMIT) undoStack.current.shift();
+    redoStack.current = [];
+  }
+
+  function applySnapshot(snapshot) {
+    annotationsRef.current = snapshot;
+    setAnnotations(snapshot);
+    setSelectedAnnotationIdx(null);
+    setDirty(true);
+  }
+
+  function undo() {
+    if (undoStack.current.length === 0) return;
+    redoStack.current.push(deepClone(annotationsRef.current));
+    const prev = undoStack.current.pop();
+    applySnapshot(prev);
+    setStatus('Undid');
+  }
+
+  function redo() {
+    if (redoStack.current.length === 0) return;
+    undoStack.current.push(deepClone(annotationsRef.current));
+    const next = redoStack.current.pop();
+    applySnapshot(next);
+    setStatus('Redid');
+  }
+
+  // -------------------------------------------------------------------------
   // Canvas drawing
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
 
   const redraw = useCallback(() => {
     const canvas = canvasRef.current;
@@ -128,6 +174,7 @@ export default function AnnotatorPage() {
     const selIdx = selectedIdxRef.current;
     const cls = classesRef.current;
     const drawing = drawingRef.current;
+    const polyInProgress = polygonInProgressRef.current;
 
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
@@ -144,46 +191,65 @@ export default function AnnotatorPage() {
     }
 
     anns.forEach((ann, idx) => {
-      if (ann.type !== 'box') return;
-      const { x, y, w, h } = ann.geometry;
       const color = classColor(ann.class_name, cls);
-      const cx = x * sf, cy = y * sf, cw = w * sf, ch = h * sf;
-
+      const isSel = idx === selIdx;
       ctx.strokeStyle = color;
-      ctx.lineWidth = idx === selIdx ? 2 : 1.5;
+      ctx.lineWidth = isSel ? 2 : 1.5;
       ctx.setLineDash([]);
-      ctx.strokeRect(cx, cy, cw, ch);
 
-      // Label
-      const label = ann.class_name;
-      ctx.font = '10px monospace';
-      const textW = ctx.measureText(label).width + 8;
-      ctx.fillStyle = color;
-      ctx.globalAlpha = 0.9;
-      ctx.fillRect(cx, cy - 14, textW, 14);
-      ctx.globalAlpha = 1;
-      ctx.fillStyle = HUD.base;
-      ctx.fillText(label, cx + 4, cy - 3);
-
-      // Selection handles
-      if (idx === selIdx) {
-        const handles = [
-          [cx, cy], [cx + cw / 2, cy], [cx + cw, cy],
-          [cx + cw, cy + ch / 2], [cx + cw, cy + ch],
-          [cx + cw / 2, cy + ch], [cx, cy + ch], [cx, cy + ch / 2],
-        ];
-        ctx.fillStyle = HUD.textData;
-        ctx.strokeStyle = color;
-        ctx.lineWidth = 1;
-        handles.forEach(([hx, hy]) => {
+      if (ann.type === 'box') {
+        const { x, y, w, h } = ann.geometry;
+        ctx.strokeRect(x * sf, y * sf, w * sf, h * sf);
+        labelTag(ctx, ann.class_name || '', x * sf, y * sf, color);
+        if (isSel) drawHandlesForBox(ctx, x * sf, y * sf, w * sf, h * sf, color);
+      } else if (ann.type === 'polygon') {
+        const pts = ann.geometry.points || [];
+        if (pts.length > 1) {
           ctx.beginPath();
-          ctx.rect(hx - 3, hy - 3, 6, 6);
+          ctx.moveTo(pts[0].x * sf, pts[0].y * sf);
+          for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x * sf, pts[i].y * sf);
+          ctx.closePath();
+          ctx.fillStyle = color;
+          ctx.globalAlpha = 0.15;
           ctx.fill();
+          ctx.globalAlpha = 1;
           ctx.stroke();
+          labelTag(
+            ctx,
+            ann.class_name || '',
+            pts[0].x * sf,
+            pts[0].y * sf,
+            color
+          );
+          if (isSel) pts.forEach((p) => drawPointHandle(ctx, p.x * sf, p.y * sf, color));
+        }
+      } else if (ann.type === 'keypoint') {
+        const pts = ann.geometry.points || [];
+        pts.forEach((p, i) => {
+          drawPointHandle(ctx, p.x * sf, p.y * sf, color, isSel ? 6 : 4);
+          if (i === 0)
+            labelTag(ctx, ann.class_name || '', p.x * sf - 2, p.y * sf, color);
         });
       }
     });
 
+    // In-progress polygon
+    if (modeRef.current === 'polygon' && polyInProgress.length > 0) {
+      ctx.strokeStyle = HUD.accent;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath();
+      ctx.moveTo(polyInProgress[0].x * sf, polyInProgress[0].y * sf);
+      for (let i = 1; i < polyInProgress.length; i++)
+        ctx.lineTo(polyInProgress[i].x * sf, polyInProgress[i].y * sf);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      polyInProgress.forEach((p) =>
+        drawPointHandle(ctx, p.x * sf, p.y * sf, HUD.accent, 4)
+      );
+    }
+
+    // In-progress box drag
     if (drawing.active) {
       const { startX, startY, currentX, currentY } = drawing;
       ctx.strokeStyle = HUD.accent;
@@ -194,15 +260,57 @@ export default function AnnotatorPage() {
     }
   }, []);
 
-  // ---------------------------------------------------------------------------
-  // Load asset
-  // ---------------------------------------------------------------------------
+  function labelTag(ctx, label, x, y, color) {
+    if (!label) return;
+    ctx.font = '10px monospace';
+    const w = ctx.measureText(label).width + 8;
+    ctx.fillStyle = color;
+    ctx.globalAlpha = 0.9;
+    ctx.fillRect(x, y - 14, w, 14);
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = HUD.base;
+    ctx.fillText(label, x + 4, y - 3);
+  }
+
+  function drawPointHandle(ctx, x, y, color, size = 5) {
+    ctx.fillStyle = HUD.textData;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.rect(x - size / 2, y - size / 2, size, size);
+    ctx.fill();
+    ctx.stroke();
+  }
+
+  function drawHandlesForBox(ctx, cx, cy, cw, ch, color) {
+    const handles = [
+      [cx, cy],
+      [cx + cw / 2, cy],
+      [cx + cw, cy],
+      [cx + cw, cy + ch / 2],
+      [cx + cw, cy + ch],
+      [cx + cw / 2, cy + ch],
+      [cx, cy + ch],
+      [cx, cy + ch / 2],
+    ];
+    handles.forEach(([hx, hy]) => drawPointHandle(ctx, hx, hy, color, 6));
+  }
+
+  // -------------------------------------------------------------------------
+  // Load asset + neighbors
+  // -------------------------------------------------------------------------
 
   useEffect(() => {
-    if (!assetId) { setStatus('No asset selected.'); return; }
+    if (!assetId) {
+      setStatus('No asset selected.');
+      return;
+    }
     setStatus('Loading…');
     setAnnotations([]);
     setSelectedAnnotationIdx(null);
+    setPolygonInProgress([]);
+    undoStack.current = [];
+    redoStack.current = [];
     setDirty(false);
     setImageError(false);
 
@@ -212,21 +320,35 @@ export default function AnnotatorPage() {
         setAsset(assetData);
         try {
           const annsData = await apiGet(`/api/assets/${assetId}/annotations`);
-          const loaded = Array.isArray(annsData) ? annsData : (annsData.items ?? []);
-          setAnnotations(loaded.map((a) => ({ ...a, isNew: false })));
+          const loaded = Array.isArray(annsData) ? annsData : annsData.items ?? [];
+          setAnnotations(loaded.map((a) => ({ ...a, isNew: false, dirty: false })));
           const existingClasses = loaded.map((a) => a.class_name).filter(Boolean);
           if (existingClasses.length > 0) {
             setClasses((prev) => Array.from(new Set([...prev, ...existingClasses])));
           }
-        } catch { setAnnotations([]); }
+        } catch {
+          setAnnotations([]);
+        }
+
+        try {
+          const n = await apiGet(`/api/assets/${assetId}/neighbors`);
+          setNeighbors(n);
+        } catch {
+          setNeighbors({ prev: null, next: null, index: null, total: 0 });
+        }
+
         setStatus('Ready');
         const img = imageRef.current;
         img.crossOrigin = 'anonymous';
         img.onload = () => {
           const canvas = canvasRef.current;
           if (!canvas) return;
-          const sf = Math.min(MAX_CANVAS_W / img.naturalWidth, MAX_CANVAS_H / img.naturalHeight, 1);
-          canvas.width  = Math.round(img.naturalWidth * sf);
+          const sf = Math.min(
+            MAX_CANVAS_W / img.naturalWidth,
+            MAX_CANVAS_H / img.naturalHeight,
+            1
+          );
+          canvas.width = Math.round(img.naturalWidth * sf);
           canvas.height = Math.round(img.naturalHeight * sf);
           setScaleFactor(sf);
           scaleRef.current = sf;
@@ -241,7 +363,8 @@ export default function AnnotatorPage() {
           canvas.height = MAX_CANVAS_H;
           redraw();
         };
-        img.src = assetData.uri || apiUrl(`/api/assets/${assetId}/file`);
+        img.src =
+          assetData.download_url || assetData.uri || apiUrl(`/api/assets/${assetId}/file`);
       } catch (err) {
         setStatus(`Error: ${err.message}`);
       }
@@ -249,11 +372,13 @@ export default function AnnotatorPage() {
     load();
   }, [assetId, redraw]);
 
-  useEffect(() => { redraw(); }, [annotations, selectedAnnotationIdx, scaleFactor, redraw]);
+  useEffect(() => {
+    redraw();
+  }, [annotations, selectedAnnotationIdx, scaleFactor, polygonInProgress, redraw]);
 
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
   // Mouse handlers
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
 
   function canvasCoords(e) {
     const canvas = canvasRef.current;
@@ -261,24 +386,75 @@ export default function AnnotatorPage() {
     return { x: e.clientX - rect.left, y: e.clientY - rect.top };
   }
 
-  function hitTestAnnotation(cx, cy) {
+  function imageCoords(canvasX, canvasY) {
+    const sf = scaleRef.current;
+    return { x: canvasX / sf, y: canvasY / sf };
+  }
+
+  function hitTestAnnotation(canvasX, canvasY) {
     const anns = annotationsRef.current;
     const sf = scaleRef.current;
+    const { x: ix, y: iy } = imageCoords(canvasX, canvasY);
     for (let i = anns.length - 1; i >= 0; i--) {
       const ann = anns[i];
-      if (ann.type !== 'box') continue;
-      const { x, y, w, h } = ann.geometry;
-      if (cx >= x * sf && cx <= (x + w) * sf && cy >= y * sf && cy <= (y + h) * sf) return i;
+      if (ann.type === 'box') {
+        const { x, y, w, h } = ann.geometry;
+        if (ix >= x && ix <= x + w && iy >= y && iy <= y + h) return i;
+      } else if (ann.type === 'polygon') {
+        if (pointInPolygon(ix, iy, ann.geometry.points || [])) return i;
+      } else if (ann.type === 'keypoint') {
+        const pts = ann.geometry.points || [];
+        for (const p of pts) {
+          if (Math.sqrt(distSq({ x: p.x * sf, y: p.y * sf }, { x: canvasX, y: canvasY })) < 8)
+            return i;
+        }
+      }
     }
     return null;
   }
 
   function handleMouseDown(e) {
     const { x, y } = canvasCoords(e);
-    if (modeRef.current === 'box') {
+    const m = modeRef.current;
+    if (m === 'box') {
       drawingRef.current = { active: true, startX: x, startY: y, currentX: x, currentY: y };
       redraw();
-    } else if (modeRef.current === 'select') {
+    } else if (m === 'polygon') {
+      const ip = imageCoords(x, y);
+      const pts = polygonInProgressRef.current;
+      // double-click logic: finalize when clicking near the first point with >=3 pts
+      if (
+        pts.length >= 3 &&
+        Math.sqrt(distSq({ x: pts[0].x * scaleRef.current, y: pts[0].y * scaleRef.current }, { x, y })) < 10
+      ) {
+        finalizePolygon();
+        return;
+      }
+      const next = [...pts, ip];
+      polygonInProgressRef.current = next;
+      setPolygonInProgress(next);
+      redraw();
+    } else if (m === 'keypoint') {
+      const ip = imageCoords(x, y);
+      pushHistory();
+      const newAnn = {
+        id: null,
+        type: 'keypoint',
+        class_name: selectedClassRef.current,
+        geometry: { points: [ip] },
+        isNew: true,
+        dirty: true,
+        version: 0,
+      };
+      setAnnotations((prev) => {
+        const updated = [...prev, newAnn];
+        annotationsRef.current = updated;
+        return updated;
+      });
+      setSelectedAnnotationIdx(annotationsRef.current.length);
+      setDirty(true);
+      redraw();
+    } else if (m === 'select') {
       setSelectedAnnotationIdx(hitTestAnnotation(x, y));
     }
   }
@@ -295,11 +471,28 @@ export default function AnnotatorPage() {
     const { startX, startY, currentX, currentY } = drawingRef.current;
     drawingRef.current = { active: false, startX: 0, startY: 0, currentX: 0, currentY: 0 };
     const sf = scaleRef.current;
-    const rawX = Math.min(startX, currentX), rawY = Math.min(startY, currentY);
-    const rawW = Math.abs(currentX - startX), rawH = Math.abs(currentY - startY);
-    const imgX = rawX / sf, imgY = rawY / sf, imgW = rawW / sf, imgH = rawH / sf;
-    if (imgW < 10 || imgH < 10) { redraw(); return; }
-    const newAnn = { id: null, type: 'box', class_name: selectedClassRef.current, geometry: { x: imgX, y: imgY, w: imgW, h: imgH }, isNew: true };
+    const rawX = Math.min(startX, currentX);
+    const rawY = Math.min(startY, currentY);
+    const rawW = Math.abs(currentX - startX);
+    const rawH = Math.abs(currentY - startY);
+    const imgX = rawX / sf;
+    const imgY = rawY / sf;
+    const imgW = rawW / sf;
+    const imgH = rawH / sf;
+    if (imgW < 5 || imgH < 5) {
+      redraw();
+      return;
+    }
+    pushHistory();
+    const newAnn = {
+      id: null,
+      type: 'box',
+      class_name: selectedClassRef.current,
+      geometry: { x: imgX, y: imgY, w: imgW, h: imgH },
+      isNew: true,
+      dirty: true,
+      version: 0,
+    };
     setAnnotations((prev) => {
       const updated = [...prev, newAnn];
       annotationsRef.current = updated;
@@ -310,31 +503,87 @@ export default function AnnotatorPage() {
     redraw();
   }
 
-  // ---------------------------------------------------------------------------
+  function finalizePolygon() {
+    const pts = polygonInProgressRef.current;
+    if (pts.length < 3) {
+      setStatus('Polygon needs at least 3 points');
+      return;
+    }
+    pushHistory();
+    const newAnn = {
+      id: null,
+      type: 'polygon',
+      class_name: selectedClassRef.current,
+      geometry: { points: pts.slice() },
+      isNew: true,
+      dirty: true,
+      version: 0,
+    };
+    setAnnotations((prev) => {
+      const updated = [...prev, newAnn];
+      annotationsRef.current = updated;
+      return updated;
+    });
+    polygonInProgressRef.current = [];
+    setPolygonInProgress([]);
+    setSelectedAnnotationIdx(annotationsRef.current.length);
+    setDirty(true);
+    setStatus('Polygon finalized');
+  }
+
+  // -------------------------------------------------------------------------
   // Keyboard
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
 
   useEffect(() => {
     function onKeyDown(e) {
+      if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        if (e.shiftKey) redo();
+        else undo();
+        return;
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'y') {
+        e.preventDefault();
+        redo();
+        return;
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        handleSave();
+        return;
+      }
       if (e.key === 'Delete' || e.key === 'Backspace') {
-        if (e.target.tagName === 'INPUT') return;
         const idx = selectedIdxRef.current;
         if (idx !== null) deleteAnnotation(idx);
       } else if (e.key === 'Escape') {
         drawingRef.current = { active: false, startX: 0, startY: 0, currentX: 0, currentY: 0 };
+        polygonInProgressRef.current = [];
+        setPolygonInProgress([]);
         setSelectedAnnotationIdx(null);
         redraw();
-      }
+      } else if (e.key === 'Enter' && modeRef.current === 'polygon') {
+        finalizePolygon();
+      } else if (e.key === 'b' || e.key === 'B') setMode('box');
+      else if (e.key === 'p' || e.key === 'P') setMode('polygon');
+      else if (e.key === 'k' || e.key === 'K') setMode('keypoint');
+      else if (e.key === 'v' || e.key === 'V') setMode('select');
+      else if (e.key === 'c' || e.key === 'C') setMode('classify');
+      else if (e.key === 'ArrowLeft' && neighbors.prev) navigateAsset(-1);
+      else if (e.key === 'ArrowRight' && neighbors.next) navigateAsset(1);
     }
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [redraw]); // eslint-disable-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [neighbors.prev, neighbors.next]);
 
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
   // Annotation CRUD
-  // ---------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
 
   function deleteAnnotation(idx) {
+    pushHistory();
     setAnnotations((prev) => {
       const ann = prev[idx];
       if (!ann) return prev;
@@ -348,8 +597,11 @@ export default function AnnotatorPage() {
   }
 
   function setAnnotationClass(idx, className) {
+    pushHistory();
     setAnnotations((prev) => {
-      const updated = prev.map((a, i) => (i === idx ? { ...a, class_name: className, isNew: a.isNew || !a.id } : a));
+      const updated = prev.map((a, i) =>
+        i === idx ? { ...a, class_name: className, dirty: true } : a
+      );
       annotationsRef.current = updated;
       return updated;
     });
@@ -357,9 +609,18 @@ export default function AnnotatorPage() {
   }
 
   function applyClassification(className) {
+    pushHistory();
     setAnnotations((prev) => {
       const withoutClassify = prev.filter((a) => a.type !== 'classification');
-      const newAnn = { id: null, type: 'classification', class_name: className, geometry: { class: className }, isNew: true };
+      const newAnn = {
+        id: null,
+        type: 'classification',
+        class_name: className,
+        geometry: { class: className },
+        isNew: true,
+        dirty: true,
+        version: 0,
+      };
       const updated = [...withoutClassify, newAnn];
       annotationsRef.current = updated;
       return updated;
@@ -376,14 +637,33 @@ export default function AnnotatorPage() {
       const saved = [];
       for (const ann of annotationsRef.current) {
         if (ann.isNew || !ann.id) {
-          const result = await apiPost('/api/annotations', { asset_id: assetId, type: ann.type, class_name: ann.class_name, geometry: ann.geometry });
-          saved.push({ ...ann, id: result.id, isNew: false });
+          const result = await apiPost('/api/annotations', {
+            asset_id: assetId,
+            type: ann.type,
+            class_name: ann.class_name,
+            geometry: ann.geometry,
+          });
+          saved.push({ ...ann, id: result.id, version: result.version, isNew: false, dirty: false });
+        } else if (ann.dirty) {
+          try {
+            const result = await apiPut(`/api/annotations/${ann.id}`, {
+              class_name: ann.class_name,
+              geometry: ann.geometry,
+              expected_version: ann.version,
+            });
+            saved.push({ ...ann, version: result.version, dirty: false });
+          } catch (err) {
+            if (String(err.message).includes('version mismatch')) {
+              setStatus(`Conflict on ${ann.id}: another editor changed it`);
+              saved.push(ann);
+            } else {
+              throw err;
+            }
+          }
         } else {
-          await apiPut(`/api/annotations/${ann.id}`, { class_name: ann.class_name, geometry: ann.geometry });
-          saved.push({ ...ann, isNew: false });
+          saved.push(ann);
         }
       }
-      try { await apiPut(`/api/assets/${assetId}`, { label_status: 'labeled' }); } catch { /* non-fatal */ }
       setAnnotations(saved);
       annotationsRef.current = saved;
       setDirty(false);
@@ -402,30 +682,32 @@ export default function AnnotatorPage() {
   }
 
   function navigateAsset(direction) {
-    if (!asset) return;
     if (dirty && !window.confirm('You have unsaved changes. Leave anyway?')) return;
-    const datasetId = asset.dataset_id;
-    if (datasetId) { navigate(`/datasets/${datasetId}`); }
-    else { setStatus(`Navigate ${direction === 1 ? 'next' : 'previous'} from the dataset view.`); }
+    const target = direction === 1 ? neighbors.next : neighbors.prev;
+    if (target) {
+      navigate(`/annotate/${target}`);
+    } else if (asset?.dataset_id) {
+      navigate(`/datasets/${asset.dataset_id}`);
+    }
   }
 
   if (!assetId) {
     return (
-      <div className="flex items-center justify-center h-64 text-[var(--hud-text-muted)] font-mono text-sm" data-testid="annotator-container">
+      <div className="flex items-center justify-center h-64 text-[var(--hud-text-muted)] font-mono text-sm">
         No asset selected. Navigate here from the dataset view.
       </div>
     );
   }
 
   const classificationAnn = annotations.find((a) => a.type === 'classification');
-  const boxAnnotations    = annotations.filter((a) => a.type === 'box');
+  const visibleAnns = annotations.filter((a) => a.type !== 'classification');
 
-  // Toolbar button helper
-  const toolBtn = (label, active, onClick, ariaLabel, ariaPressed) => (
+  const toolBtn = (label, active, onClick, ariaLabel, hint) => (
     <button
       onClick={onClick}
-      aria-pressed={ariaPressed !== undefined ? ariaPressed : active}
+      aria-pressed={active}
       aria-label={ariaLabel}
+      title={hint}
       className={[
         'px-3 h-6 text-[0.6875rem] font-mono tracking-widest border transition-colors',
         active
@@ -454,17 +736,23 @@ export default function AnnotatorPage() {
           background: 'var(--hud-surface)',
         }}
       >
-        {/* Mode tools */}
-        {toolBtn('BOX',      mode === 'box',      () => setMode('box'),      'Box mode')}
-        {toolBtn('CLASSIFY', mode === 'classify', () => setMode('classify'), 'Classify mode')}
-        {toolBtn('SELECT',   mode === 'select',   () => setMode('select'),   'Select mode')}
+        {toolBtn('BOX', mode === 'box', () => setMode('box'), 'Box mode', 'B')}
+        {toolBtn('POLYGON', mode === 'polygon', () => setMode('polygon'), 'Polygon mode', 'P (Enter to finalize)')}
+        {toolBtn('KEYPOINT', mode === 'keypoint', () => setMode('keypoint'), 'Keypoint mode', 'K')}
+        {toolBtn('CLASSIFY', mode === 'classify', () => setMode('classify'), 'Classify mode', 'C')}
+        {toolBtn('SELECT', mode === 'select', () => setMode('select'), 'Select mode', 'V')}
 
         <div className="w-px h-4 mx-1" style={{ background: 'var(--hud-border-strong)' }} />
 
-        {/* Save */}
+        {toolBtn('UNDO', false, undo, 'Undo', 'Ctrl/Cmd+Z')}
+        {toolBtn('REDO', false, redo, 'Redo', 'Ctrl/Cmd+Shift+Z')}
+
+        <div className="w-px h-4 mx-1" style={{ background: 'var(--hud-border-strong)' }} />
+
         <button
           onClick={handleSave}
           disabled={!dirty}
+          title="Ctrl/Cmd+S"
           className={[
             'px-3 h-6 text-[0.6875rem] font-mono tracking-widest border transition-colors',
             dirty
@@ -477,15 +765,30 @@ export default function AnnotatorPage() {
 
         <div className="w-px h-4 mx-1" style={{ background: 'var(--hud-border-strong)' }} />
 
-        {toolBtn('← PREV', false, () => navigateAsset(-1), 'Previous asset')}
-        {toolBtn('NEXT →', false, () => navigateAsset(1),  'Next asset')}
+        {toolBtn('← PREV', false, () => navigateAsset(-1), 'Previous asset', '←')}
+        {toolBtn('NEXT →', false, () => navigateAsset(1), 'Next asset', '→')}
 
         <span className="ml-2 text-[0.6875rem] font-mono text-[var(--hud-text-muted)]">
-          ASSET <span data-testid="asset-id" style={{ color: 'var(--hud-text-data)' }}>{assetId}</span>
+          {neighbors.total > 0 && (
+            <>
+              FRAME{' '}
+              <span data-testid="frame-pos" style={{ color: 'var(--hud-text-data)' }}>
+                {(neighbors.index ?? 0) + 1}/{neighbors.total}
+              </span>
+              {' · '}
+            </>
+          )}
+          ASSET{' '}
+          <span data-testid="asset-id" style={{ color: 'var(--hud-text-data)' }}>
+            {assetId}
+          </span>
         </span>
 
         {dirty && (
-          <span className="ml-auto text-[0.6875rem] font-mono pulse-active" style={{ color: 'var(--hud-warning-text)' }}>
+          <span
+            className="ml-auto text-[0.6875rem] font-mono pulse-active"
+            style={{ color: 'var(--hud-warning-text)' }}
+          >
             ● UNSAVED
           </span>
         )}
@@ -496,19 +799,26 @@ export default function AnnotatorPage() {
         {/* Left sidebar — Classes */}
         <div
           className="flex-shrink-0 flex flex-col gap-1 p-2 overflow-y-auto border-r"
-          style={{ width: '152px', background: 'var(--hud-surface)', borderColor: 'var(--hud-border-default)' }}
+          style={{
+            width: '160px',
+            background: 'var(--hud-surface)',
+            borderColor: 'var(--hud-border-default)',
+          }}
         >
           <p className="label-overline mb-1">Classes</p>
-
           {classes.map((cls, i) => (
             <button
               key={cls}
               onClick={() => setSelectedClass(cls)}
               className="flex items-center gap-2 px-2 py-1 text-[0.75rem] text-left w-full border transition-colors"
               style={{
-                borderColor: selectedClass === cls ? CLASS_COLORS[i % CLASS_COLORS.length] : 'var(--hud-border-default)',
+                borderColor:
+                  selectedClass === cls
+                    ? CLASS_COLORS[i % CLASS_COLORS.length]
+                    : 'var(--hud-border-default)',
                 background: selectedClass === cls ? 'var(--hud-elevated)' : 'transparent',
-                color: selectedClass === cls ? 'var(--hud-text-primary)' : 'var(--hud-text-muted)',
+                color:
+                  selectedClass === cls ? 'var(--hud-text-primary)' : 'var(--hud-text-muted)',
               }}
               aria-pressed={selectedClass === cls}
             >
@@ -519,8 +829,6 @@ export default function AnnotatorPage() {
               <span className="truncate font-mono text-xs">{cls}</span>
             </button>
           ))}
-
-          {/* Add class */}
           <div className="mt-2 space-y-1">
             <input
               type="text"
@@ -550,9 +858,11 @@ export default function AnnotatorPage() {
             </button>
           </div>
 
-          {/* Classification mode */}
           {mode === 'classify' && (
-            <div className="mt-3 border-t pt-2" style={{ borderColor: 'var(--hud-border-default)' }}>
+            <div
+              className="mt-3 border-t pt-2"
+              style={{ borderColor: 'var(--hud-border-default)' }}
+            >
               <p className="label-overline mb-1">Set class:</p>
               {classes.map((cls, i) => (
                 <button
@@ -560,8 +870,14 @@ export default function AnnotatorPage() {
                   onClick={() => applyClassification(cls)}
                   className="flex items-center gap-2 px-2 py-1 text-xs font-mono text-left w-full mb-1 border transition-colors"
                   style={{
-                    borderColor: classificationAnn?.class_name === cls ? CLASS_COLORS[i % CLASS_COLORS.length] : 'var(--hud-border-default)',
-                    background: classificationAnn?.class_name === cls ? 'var(--hud-elevated)' : 'transparent',
+                    borderColor:
+                      classificationAnn?.class_name === cls
+                        ? CLASS_COLORS[i % CLASS_COLORS.length]
+                        : 'var(--hud-border-default)',
+                    background:
+                      classificationAnn?.class_name === cls
+                        ? 'var(--hud-elevated)'
+                        : 'transparent',
                     color: 'var(--hud-text-secondary)',
                     borderLeft: `2px solid ${CLASS_COLORS[i % CLASS_COLORS.length]}`,
                   }}
@@ -570,12 +886,30 @@ export default function AnnotatorPage() {
                 </button>
               ))}
               {classificationAnn && (
-                <p className="text-[0.6875rem] font-mono mt-1" style={{ color: 'var(--hud-success-text)' }}>
+                <p
+                  className="text-[0.6875rem] font-mono mt-1"
+                  style={{ color: 'var(--hud-success-text)' }}
+                >
                   ✓ {classificationAnn.class_name}
                 </p>
               )}
             </div>
           )}
+
+          <div
+            className="mt-3 border-t pt-2 text-[0.6875rem] font-mono"
+            style={{ borderColor: 'var(--hud-border-default)', color: 'var(--hud-text-muted)' }}
+          >
+            <p className="label-overline mb-1">Hotkeys</p>
+            <div>B — box</div>
+            <div>P — polygon (Enter)</div>
+            <div>K — keypoint</div>
+            <div>C — classify</div>
+            <div>V — select</div>
+            <div>← / → — frames</div>
+            <div>Ctrl+Z / Y — undo/redo</div>
+            <div>Del — remove</div>
+          </div>
         </div>
 
         {/* Canvas area */}
@@ -584,32 +918,55 @@ export default function AnnotatorPage() {
           style={{ background: 'var(--hud-inset)' }}
         >
           {imageError ? (
-            <div className="flex flex-col items-center gap-2" style={{ color: 'var(--hud-text-muted)' }}>
+            <div
+              className="flex flex-col items-center gap-2"
+              style={{ color: 'var(--hud-text-muted)' }}
+            >
               <div
                 className="w-24 h-24 flex items-center justify-center text-3xl font-mono border"
-                style={{ background: 'var(--hud-surface)', borderColor: 'var(--hud-border-default)' }}
+                style={{
+                  background: 'var(--hud-surface)',
+                  borderColor: 'var(--hud-border-default)',
+                }}
               >
                 ?
               </div>
               <p className="text-xs font-mono">Image could not be loaded</p>
-              <p className="text-[0.6875rem] font-mono" style={{ color: 'var(--hud-text-muted)' }}>{assetId}</p>
+              <p
+                className="text-[0.6875rem] font-mono"
+                style={{ color: 'var(--hud-text-muted)' }}
+              >
+                {assetId}
+              </p>
             </div>
           ) : (
             <canvas
               ref={canvasRef}
-              className={mode === 'box' ? 'cursor-crosshair' : mode === 'select' ? 'cursor-pointer' : 'cursor-default'}
+              className={
+                mode === 'box' || mode === 'polygon' || mode === 'keypoint'
+                  ? 'cursor-crosshair'
+                  : mode === 'select'
+                    ? 'cursor-pointer'
+                    : 'cursor-default'
+              }
               style={{
                 display: 'block',
                 maxWidth: '100%',
                 maxHeight: '100%',
-                border: `1px solid var(--hud-border-default)`,
+                border: '1px solid var(--hud-border-default)',
               }}
               onMouseDown={handleMouseDown}
               onMouseMove={handleMouseMove}
               onMouseUp={handleMouseUp}
               onMouseLeave={() => {
                 if (drawingRef.current.active) {
-                  drawingRef.current = { active: false, startX: 0, startY: 0, currentX: 0, currentY: 0 };
+                  drawingRef.current = {
+                    active: false,
+                    startX: 0,
+                    startY: 0,
+                    currentX: 0,
+                    currentY: 0,
+                  };
                   redraw();
                 }
               }}
@@ -621,14 +978,21 @@ export default function AnnotatorPage() {
         {/* Right sidebar — Annotation list */}
         <div
           className="flex-shrink-0 flex flex-col gap-0.5 p-2 overflow-y-auto border-l"
-          style={{ width: '176px', background: 'var(--hud-surface)', borderColor: 'var(--hud-border-default)' }}
+          style={{
+            width: '200px',
+            background: 'var(--hud-surface)',
+            borderColor: 'var(--hud-border-default)',
+          }}
         >
           <p className="label-overline mb-1">
             Annotations <span className="text-[var(--hud-accent)]">{annotations.length}</span>
           </p>
 
           {annotations.length === 0 && (
-            <p className="text-[0.6875rem] font-mono" style={{ color: 'var(--hud-text-muted)' }}>
+            <p
+              className="text-[0.6875rem] font-mono"
+              style={{ color: 'var(--hud-text-muted)' }}
+            >
               No annotations yet.
             </p>
           )}
@@ -636,11 +1000,16 @@ export default function AnnotatorPage() {
           {annotations.map((ann, idx) => (
             <div
               key={idx}
-              onClick={() => { if (ann.type === 'box') setSelectedAnnotationIdx(idx === selectedAnnotationIdx ? null : idx); }}
+              onClick={() => {
+                if (ann.type !== 'classification')
+                  setSelectedAnnotationIdx(idx === selectedAnnotationIdx ? null : idx);
+              }}
               className="flex items-center gap-1 px-2 py-1 text-xs cursor-pointer group border transition-colors"
               style={{
-                borderColor: idx === selectedAnnotationIdx ? 'var(--hud-accent)' : 'transparent',
-                background: idx === selectedAnnotationIdx ? 'var(--hud-elevated)' : 'transparent',
+                borderColor:
+                  idx === selectedAnnotationIdx ? 'var(--hud-accent)' : 'transparent',
+                background:
+                  idx === selectedAnnotationIdx ? 'var(--hud-elevated)' : 'transparent',
               }}
               role="option"
               aria-selected={idx === selectedAnnotationIdx}
@@ -649,27 +1018,37 @@ export default function AnnotatorPage() {
                 className="inline-block w-2 h-2 flex-shrink-0"
                 style={{ background: classColor(ann.class_name, classes) }}
               />
-              <span className="flex-1 truncate font-mono text-[0.6875rem]" style={{ color: 'var(--hud-text-secondary)' }}>
-                {ann.type === 'classification' ? 'CLS' : 'BOX'}: {ann.class_name}
+              <span
+                className="flex-1 truncate font-mono text-[0.6875rem]"
+                style={{ color: 'var(--hud-text-secondary)' }}
+              >
+                {ann.type.toUpperCase().slice(0, 3)}: {ann.class_name}
               </span>
-              {ann.type === 'box' && idx === selectedAnnotationIdx && (
+              {ann.type !== 'classification' && idx === selectedAnnotationIdx && (
                 <select
                   value={ann.class_name}
                   onChange={(e) => setAnnotationClass(idx, e.target.value)}
                   onClick={(e) => e.stopPropagation()}
                   aria-label="Change class"
-                  className="text-[0.6875rem] font-mono max-w-[60px] border focus:outline-none"
+                  className="text-[0.6875rem] font-mono max-w-[80px] border focus:outline-none"
                   style={{
                     background: 'var(--hud-inset)',
                     borderColor: 'var(--hud-border-default)',
                     color: 'var(--hud-text-primary)',
                   }}
                 >
-                  {classes.map((c) => <option key={c} value={c}>{c}</option>)}
+                  {classes.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
                 </select>
               )}
               <button
-                onClick={(e) => { e.stopPropagation(); deleteAnnotation(idx); }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  deleteAnnotation(idx);
+                }}
                 className="ml-auto text-[0.6875rem] font-mono opacity-0 group-hover:opacity-100 transition-opacity px-1"
                 style={{ color: 'var(--hud-danger-text)' }}
                 aria-label={`Delete annotation ${idx}`}
@@ -699,16 +1078,32 @@ export default function AnnotatorPage() {
         >
           {status}
         </span>
-        <span className="ml-auto text-[0.6875rem] font-mono" style={{ color: 'var(--hud-text-muted)' }}>
-          MODE <span data-testid="mode" style={{ color: 'var(--hud-text-data)' }}>{mode.toUpperCase()}</span>
+        <span
+          className="ml-auto text-[0.6875rem] font-mono"
+          style={{ color: 'var(--hud-text-muted)' }}
+        >
+          MODE{' '}
+          <span data-testid="mode" style={{ color: 'var(--hud-text-data)' }}>
+            {mode.toUpperCase()}
+          </span>
         </span>
         {scaleFactor !== 1 && (
-          <span className="text-[0.6875rem] font-mono" style={{ color: 'var(--hud-text-muted)' }}>
-            SCALE <span style={{ color: 'var(--hud-text-data)' }}>{Math.round(scaleFactor * 100)}%</span>
+          <span
+            className="text-[0.6875rem] font-mono"
+            style={{ color: 'var(--hud-text-muted)' }}
+          >
+            SCALE{' '}
+            <span style={{ color: 'var(--hud-text-data)' }}>
+              {Math.round(scaleFactor * 100)}%
+            </span>
           </span>
         )}
-        <span className="text-[0.6875rem] font-mono" style={{ color: 'var(--hud-text-muted)' }}>
-          <span style={{ color: 'var(--hud-text-data)' }}>{boxAnnotations.length}</span> box{boxAnnotations.length !== 1 ? 'es' : ''}
+        <span
+          className="text-[0.6875rem] font-mono"
+          style={{ color: 'var(--hud-text-muted)' }}
+        >
+          <span style={{ color: 'var(--hud-text-data)' }}>{visibleAnns.length}</span>{' '}
+          shape{visibleAnns.length !== 1 ? 's' : ''}
           {classificationAnn && (
             <span className="ml-2" style={{ color: 'var(--hud-success-text)' }}>
               ✓ {classificationAnn.class_name}

--- a/frontend/src/pages/annotate/Annotator.jsx
+++ b/frontend/src/pages/annotate/Annotator.jsx
@@ -446,12 +446,14 @@ export default function AnnotatorPage() {
         dirty: true,
         version: 0,
       };
+      let newIdx = 0;
       setAnnotations((prev) => {
+        newIdx = prev.length; // index of the appended item in the new array
         const updated = [...prev, newAnn];
         annotationsRef.current = updated;
         return updated;
       });
-      setSelectedAnnotationIdx(annotationsRef.current.length);
+      setSelectedAnnotationIdx(newIdx);
       setDirty(true);
       redraw();
     } else if (m === 'select') {
@@ -493,12 +495,14 @@ export default function AnnotatorPage() {
       dirty: true,
       version: 0,
     };
+    let newIdx = 0;
     setAnnotations((prev) => {
+      newIdx = prev.length;
       const updated = [...prev, newAnn];
       annotationsRef.current = updated;
       return updated;
     });
-    setSelectedAnnotationIdx(annotationsRef.current.length);
+    setSelectedAnnotationIdx(newIdx);
     setDirty(true);
     redraw();
   }
@@ -519,14 +523,16 @@ export default function AnnotatorPage() {
       dirty: true,
       version: 0,
     };
+    let newIdx = 0;
     setAnnotations((prev) => {
+      newIdx = prev.length;
       const updated = [...prev, newAnn];
       annotationsRef.current = updated;
       return updated;
     });
     polygonInProgressRef.current = [];
     setPolygonInProgress([]);
-    setSelectedAnnotationIdx(annotationsRef.current.length);
+    setSelectedAnnotationIdx(newIdx);
     setDirty(true);
     setStatus('Polygon finalized');
   }

--- a/frontend/src/pages/artifacts/index.tsx
+++ b/frontend/src/pages/artifacts/index.tsx
@@ -119,10 +119,22 @@ export default function ArtifactsIndex() {
               </div>
 
               {/* Actions */}
-              <div className="mt-auto pt-2 border-t border-[var(--hud-border-subtle)] flex gap-2">
+              <div className="mt-auto pt-2 border-t border-[var(--hud-border-subtle)] flex gap-2 flex-wrap">
+                <Link
+                  to={`/artifacts/predict/${a.id}`}
+                  className="text-[0.6875rem] font-mono text-[oklch(0.10_0.008_240)] bg-[var(--hud-accent)] border border-[var(--hud-accent)] px-2 py-0.5 hover:bg-[var(--hud-accent-hover)] transition-colors"
+                >
+                  PREDICT
+                </Link>
+                <Link
+                  to={`/evaluations/new?artifact_id=${a.id}`}
+                  className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] border border-[var(--hud-border-default)] px-2 py-0.5 hover:text-[var(--hud-accent)] hover:border-[var(--hud-accent)] transition-colors"
+                >
+                  EVALUATE
+                </Link>
                 <Link
                   to={`/artifacts/export/${a.id}`}
-                  className="text-[0.6875rem] font-mono text-[oklch(0.10_0.008_240)] bg-[var(--hud-accent)] border border-[var(--hud-accent)] px-2 py-0.5 hover:bg-[var(--hud-accent-hover)] transition-colors"
+                  className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] border border-[var(--hud-border-default)] px-2 py-0.5 hover:text-[var(--hud-accent)] hover:border-[var(--hud-accent)] transition-colors"
                 >
                   EXPORT ONNX
                 </Link>

--- a/frontend/src/pages/artifacts/predict.tsx
+++ b/frontend/src/pages/artifacts/predict.tsx
@@ -1,0 +1,222 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import Button from '@/components/ui/Button';
+import Alert from '@/components/ui/Alert';
+import Spinner from '@/components/ui/Spinner';
+import { apiGet, apiUrl } from '@/services/api';
+import { getStoredToken } from '@/services/token-store';
+
+interface ModelArtifact {
+  id: string;
+  name: string;
+  version: string;
+  type: string;
+  format: string;
+}
+
+interface PredictResponse {
+  model_id: string;
+  model_name: string;
+  model_version: string;
+  result: {
+    detections?: Array<{ class: string; bbox: [number, number, number, number]; score: number }>;
+    classification?: { class: string; score: number };
+    raw_shape?: number[];
+    top_class_index?: number;
+    top_score?: number;
+  };
+}
+
+export default function ArtifactsPredict() {
+  const { modelId } = useParams();
+  const [model, setModel] = useState<ModelArtifact | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [result, setResult] = useState<PredictResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const imgRef = useRef<HTMLImageElement | null>(null);
+
+  useEffect(() => {
+    if (!modelId) return;
+    apiGet<ModelArtifact>(`/api/artifacts/models/${modelId}`).then(setModel).catch(() => {});
+  }, [modelId]);
+
+  useEffect(() => {
+    if (!file) {
+      setPreviewUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  useEffect(() => {
+    if (!previewUrl || !canvasRef.current) return;
+    const img = new Image();
+    img.onload = () => {
+      const canvas = canvasRef.current!;
+      const w = Math.min(800, img.naturalWidth);
+      const scale = w / img.naturalWidth;
+      canvas.width = w;
+      canvas.height = img.naturalHeight * scale;
+      const ctx = canvas.getContext('2d')!;
+      ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+      imgRef.current = img;
+      drawDetections(scale);
+    };
+    img.src = previewUrl;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [previewUrl, result]);
+
+  function drawDetections(scale: number) {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d')!;
+    const detections = result?.result?.detections || [];
+    detections.forEach((d, i) => {
+      const [x, y, w, h] = d.bbox;
+      const color = `oklch(0.72 0.10 ${(i * 47) % 360})`;
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 2;
+      ctx.strokeRect(x * scale, y * scale, w * scale, h * scale);
+      const label = `${d.class} ${(d.score * 100).toFixed(0)}%`;
+      ctx.font = '12px monospace';
+      const tw = ctx.measureText(label).width + 8;
+      ctx.fillStyle = color;
+      ctx.fillRect(x * scale, y * scale - 16, tw, 16);
+      ctx.fillStyle = '#000';
+      ctx.fillText(label, x * scale + 4, y * scale - 4);
+    });
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!file || !modelId) {
+      setError('Pick an image');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      fd.append('score_threshold', '0.25');
+      const token = getStoredToken();
+      const res = await fetch(apiUrl(`/api/artifacts/models/${modelId}/predict`), {
+        method: 'POST',
+        body: fd,
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!res.ok) {
+        const detail = await res.json().catch(() => null);
+        throw new Error(detail?.detail || `HTTP ${res.status}`);
+      }
+      const json = (await res.json()) as PredictResponse;
+      setResult(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Prediction failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
+        <div>
+          <div className="label-overline mb-0.5">// Artifacts / Predict</div>
+          <h1>Predict with model</h1>
+          {model && (
+            <p className="text-xs font-mono text-[var(--hud-text-muted)] mt-1">
+              {model.name} v{model.version} · {model.format}
+            </p>
+          )}
+        </div>
+        <Link
+          to="/artifacts"
+          className="text-xs font-mono text-[var(--hud-accent)] hover:underline"
+        >
+          ← ARTIFACTS
+        </Link>
+      </div>
+
+      <form onSubmit={onSubmit} className="space-y-3">
+        <div>
+          <label className="label-overline block mb-1">Image</label>
+          <input
+            type="file"
+            accept="image/*"
+            onChange={(e) => setFile(e.target.files?.[0] || null)}
+            className="text-xs font-mono"
+          />
+        </div>
+        {error && <Alert variant="error">{error}</Alert>}
+        <Button type="submit" disabled={loading || !file}>
+          {loading ? (
+            <span className="flex items-center gap-2">
+              <Spinner size={12} /> Running…
+            </span>
+          ) : (
+            'Run prediction'
+          )}
+        </Button>
+      </form>
+
+      {previewUrl && (
+        <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)] p-3">
+          <canvas ref={canvasRef} style={{ maxWidth: '100%', display: 'block' }} />
+        </div>
+      )}
+
+      {result && (
+        <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)] p-3 space-y-2">
+          <div className="label-overline">Predictions</div>
+          {result.result.classification && (
+            <div className="text-sm font-mono">
+              <span className="text-[var(--hud-text-muted)]">Top class:</span>{' '}
+              <span className="text-[var(--hud-text-data)]">
+                {result.result.classification.class}
+              </span>{' '}
+              ({(result.result.classification.score * 100).toFixed(1)}%)
+            </div>
+          )}
+          {result.result.detections && result.result.detections.length > 0 && (
+            <table className="w-full text-xs font-mono">
+              <thead>
+                <tr className="text-[var(--hud-text-muted)]">
+                  <th className="text-left p-1">CLASS</th>
+                  <th className="text-left p-1">SCORE</th>
+                  <th className="text-left p-1">BBOX</th>
+                </tr>
+              </thead>
+              <tbody>
+                {result.result.detections.map((d, i) => (
+                  <tr key={i} className="border-t border-[var(--hud-border-subtle)]">
+                    <td className="p-1 text-[var(--hud-text-data)]">{d.class}</td>
+                    <td className="p-1">{(d.score * 100).toFixed(1)}%</td>
+                    <td className="p-1 text-[var(--hud-text-muted)]">
+                      [{d.bbox.map((v) => v.toFixed(0)).join(', ')}]
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+          {result.result.top_class_index != null && (
+            <div className="text-sm font-mono">
+              <span className="text-[var(--hud-text-muted)]">Top index:</span>{' '}
+              <span className="text-[var(--hud-text-data)]">
+                {result.result.top_class_index}
+              </span>{' '}
+              ({((result.result.top_score || 0) * 100).toFixed(1)}%)
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/datasets/import.tsx
+++ b/frontend/src/pages/datasets/import.tsx
@@ -1,0 +1,188 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import Select from '@/components/ui/Select';
+import Input from '@/components/ui/Input';
+import Button from '@/components/ui/Button';
+import Alert from '@/components/ui/Alert';
+import Spinner from '@/components/ui/Spinner';
+import { apiGet, apiUrl } from '@/services/api';
+import { getStoredToken } from '@/services/token-store';
+
+interface DatasetSummary {
+  id: string;
+  name: string;
+  latest_version_id?: string | null;
+}
+
+interface ImportResult {
+  dataset_id: string;
+  version_id: string;
+  format: string;
+  asset_count: number;
+  annotation_count: number;
+  classes: string[];
+  warnings: string[];
+}
+
+export default function DatasetImport() {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const [datasets, setDatasets] = useState<DatasetSummary[]>([]);
+  const [formats, setFormats] = useState<string[]>([
+    'coco',
+    'yolo',
+    'pascal_voc',
+    'cvat',
+    'labelme',
+    'datumaro',
+  ]);
+  const [datasetId, setDatasetId] = useState(params.get('datasetId') || '');
+  const [fmt, setFmt] = useState('coco');
+  const [versionId, setVersionId] = useState('');
+  const [imageUriBase, setImageUriBase] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const [result, setResult] = useState<ImportResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    apiGet<DatasetSummary[]>('/api/datasets').then(setDatasets).catch(() => {});
+    apiGet<{ formats: string[] }>('/api/datasets/formats')
+      .then((r) => setFormats(r.formats))
+      .catch(() => {});
+  }, []);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!datasetId || !file) {
+      setError('Pick a dataset and an archive');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const fd = new FormData();
+      fd.append('file', file);
+      fd.append('fmt', fmt);
+      if (versionId) fd.append('version_id', versionId);
+      if (imageUriBase) fd.append('image_uri_base', imageUriBase);
+      const token = getStoredToken();
+      const res = await fetch(apiUrl(`/api/datasets/${datasetId}/import`), {
+        method: 'POST',
+        body: fd,
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!res.ok) {
+        const detail = await res.json().catch(() => null);
+        throw new Error(detail?.detail || `HTTP ${res.status}`);
+      }
+      const json = (await res.json()) as ImportResult;
+      setResult(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Import failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="max-w-xl space-y-4">
+      <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
+        <div>
+          <div className="label-overline mb-0.5">// Datasets / Import</div>
+          <h1>Import dataset archive</h1>
+          <p className="text-xs text-[var(--hud-text-muted)] mt-1">
+            Upload a zip in COCO, YOLO, Pascal VOC, CVAT, LabelMe, or Datumaro format.
+          </p>
+        </div>
+        <Link
+          to="/datasets"
+          className="text-xs font-mono text-[var(--hud-accent)] hover:underline"
+        >
+          ← DATASETS
+        </Link>
+      </div>
+
+      {result ? (
+        <Alert variant="success">
+          Imported {result.asset_count} assets and {result.annotation_count} annotations
+          ({result.classes.length} classes) into version{' '}
+          <span className="font-mono">{result.version_id.slice(0, 8)}</span>.
+          {result.warnings.length > 0 && (
+            <div className="mt-2 text-[0.6875rem] font-mono">
+              {result.warnings.length} warning{result.warnings.length !== 1 ? 's' : ''}
+            </div>
+          )}
+          <div className="mt-3 flex gap-2">
+            <Button onClick={() => navigate(`/datasets/${result.dataset_id}`)}>
+              Open dataset
+            </Button>
+            <Button variant="outline" onClick={() => setResult(null)}>
+              Import another
+            </Button>
+          </div>
+        </Alert>
+      ) : (
+        <form onSubmit={onSubmit} className="space-y-3">
+          <div>
+            <label className="label-overline block mb-1">Target dataset</label>
+            <Select value={datasetId} onChange={(e) => setDatasetId(e.target.value)}>
+              <option value="">— select —</option>
+              {datasets.map((d) => (
+                <option key={d.id} value={d.id}>
+                  {d.name}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div>
+            <label className="label-overline block mb-1">Format</label>
+            <Select value={fmt} onChange={(e) => setFmt(e.target.value)}>
+              {formats.map((f) => (
+                <option key={f} value={f}>
+                  {f.toUpperCase()}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div>
+            <label className="label-overline block mb-1">Existing version ID (optional)</label>
+            <Input
+              value={versionId}
+              onChange={(e) => setVersionId(e.target.value)}
+              placeholder="leave blank to create a new version"
+            />
+          </div>
+          <div>
+            <label className="label-overline block mb-1">Image URI base (optional)</label>
+            <Input
+              value={imageUriBase}
+              onChange={(e) => setImageUriBase(e.target.value)}
+              placeholder="e.g. datasets/<id>/imported/"
+            />
+          </div>
+          <div>
+            <label className="label-overline block mb-1">Archive (zip)</label>
+            <input
+              type="file"
+              accept=".zip,application/zip"
+              onChange={(e) => setFile(e.target.files?.[0] || null)}
+              className="text-xs font-mono"
+            />
+          </div>
+          {error && <Alert variant="error">{error}</Alert>}
+          <Button type="submit" disabled={loading || !file || !datasetId}>
+            {loading ? (
+              <span className="flex items-center gap-2">
+                <Spinner size={12} /> Importing…
+              </span>
+            ) : (
+              'Import'
+            )}
+          </Button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/datasets/index.tsx
+++ b/frontend/src/pages/datasets/index.tsx
@@ -58,12 +58,20 @@ export default function DatasetsIndex() {
             )}
           </h1>
         </div>
-        <Link
-          to={uploadTo}
-          className="inline-flex items-center h-8 px-3 text-xs font-mono font-medium border border-[var(--hud-accent)] bg-[var(--hud-accent)] text-[oklch(0.10_0.008_240)] hover:bg-[var(--hud-accent-hover)] transition-colors tracking-wide"
-        >
-          + UPLOAD DATASET
-        </Link>
+        <div className="flex items-center gap-2">
+          <Link
+            to="/datasets/import"
+            className="inline-flex items-center h-8 px-3 text-xs font-mono text-[var(--hud-text-secondary)] border border-[var(--hud-border-strong)] hover:border-[var(--hud-border-accent)] hover:bg-[var(--hud-elevated)] transition-colors tracking-wide"
+          >
+            IMPORT (COCO/YOLO/...)
+          </Link>
+          <Link
+            to={uploadTo}
+            className="inline-flex items-center h-8 px-3 text-xs font-mono font-medium border border-[var(--hud-accent)] bg-[var(--hud-accent)] text-[oklch(0.10_0.008_240)] hover:bg-[var(--hud-accent-hover)] transition-colors tracking-wide"
+          >
+            + UPLOAD DATASET
+          </Link>
+        </div>
       </div>
 
       {datasets.length === 0 ? (

--- a/frontend/src/pages/evaluations/[evalId].tsx
+++ b/frontend/src/pages/evaluations/[evalId].tsx
@@ -1,0 +1,276 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import Badge from '@/components/ui/Badge';
+import Spinner from '@/components/ui/Spinner';
+import ErrorState from '@/components/common/ErrorState';
+import { apiGet } from '@/services/api';
+
+interface PerClass {
+  precision: number;
+  recall: number;
+  f1: number;
+  support: number;
+  ap50?: number;
+}
+
+interface FpFn {
+  asset_id: string;
+  predicted: string | null;
+  ground_truth: string | null;
+  score: number | null;
+  kind: string;
+}
+
+interface Evaluation {
+  id: string;
+  artifact_id: string;
+  dataset_version_id: string;
+  status: string;
+  metrics: Record<string, number> | null;
+  per_class: Record<string, PerClass> | null;
+  confusion: number[][] | null;
+  classes: string[] | null;
+  samples: FpFn[] | null;
+  error_message: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  created_at: string | null;
+}
+
+function pct(v: number | null | undefined) {
+  if (v == null) return '—';
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+function statusBadge(status: string) {
+  if (status === 'succeeded') return <Badge variant="success">DONE</Badge>;
+  if (status === 'running') return <Badge variant="info">RUNNING</Badge>;
+  if (status === 'failed') return <Badge variant="danger">FAILED</Badge>;
+  return <Badge variant="default">{status.toUpperCase()}</Badge>;
+}
+
+export default function EvaluationDetail() {
+  const { evalId } = useParams();
+  const [data, setData] = useState<Evaluation | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!evalId) return;
+    let cancelled = false;
+    function load() {
+      apiGet<Evaluation>(`/api/evaluations/${evalId}`)
+        .then((d) => {
+          if (!cancelled) setData(d);
+        })
+        .catch((err) => {
+          if (!cancelled)
+            setError(err instanceof Error ? err.message : 'Failed to load');
+        });
+    }
+    load();
+    const t = setInterval(() => {
+      if (data && data.status !== 'queued' && data.status !== 'running') return;
+      load();
+    }, 3000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [evalId]);
+
+  if (error) return <ErrorState description={error} />;
+  if (!data)
+    return (
+      <div className="flex items-center gap-2 text-xs font-mono text-[var(--hud-text-muted)]">
+        <Spinner size={14} /> Loading…
+      </div>
+    );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
+        <div>
+          <div className="label-overline mb-0.5">// Evaluations / Detail</div>
+          <h1>Evaluation {data.id.slice(0, 8)}</h1>
+          <div className="text-xs font-mono text-[var(--hud-text-muted)] flex items-center gap-2 mt-1">
+            {statusBadge(data.status)}
+            <span>
+              ARTIFACT{' '}
+              <Link
+                to={`/artifacts`}
+                className="text-[var(--hud-accent)] hover:underline"
+              >
+                {data.artifact_id.slice(0, 8)}
+              </Link>
+            </span>
+            <span>·</span>
+            <span>
+              DATASET VERSION{' '}
+              <span style={{ color: 'var(--hud-text-data)' }}>
+                {data.dataset_version_id.slice(0, 8)}
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {data.error_message && (
+        <ErrorState title="Evaluation failed" description={data.error_message} />
+      )}
+
+      {/* Top metrics */}
+      {data.metrics && (
+        <div className="grid grid-cols-4 gap-px bg-[var(--hud-border-default)]">
+          {Object.entries(data.metrics).map(([k, v]) => (
+            <div key={k} className="bg-[var(--hud-surface)] p-3">
+              <div className="label-overline">{k}</div>
+              <div className="text-2xl font-semibold font-mono text-[var(--hud-text-data)]">
+                {typeof v === 'number'
+                  ? k === 'samples' || k === 'count'
+                    ? v
+                    : pct(v)
+                  : String(v)}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Per-class table */}
+      {data.per_class && Object.keys(data.per_class).length > 0 && (
+        <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)]">
+          <div className="label-overline px-3 py-2 border-b border-[var(--hud-border-subtle)]">
+            Per-class metrics
+          </div>
+          <table className="w-full text-xs font-mono">
+            <thead className="bg-[var(--hud-inset)] text-[var(--hud-text-muted)]">
+              <tr className="text-left">
+                <th className="p-2">CLASS</th>
+                <th className="p-2">P</th>
+                <th className="p-2">R</th>
+                <th className="p-2">F1</th>
+                <th className="p-2">AP@50</th>
+                <th className="p-2">SUPPORT</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(data.per_class).map(([cls, pc]) => (
+                <tr
+                  key={cls}
+                  className="border-t border-[var(--hud-border-subtle)] hover:bg-[var(--hud-elevated)]"
+                >
+                  <td className="p-2 text-[var(--hud-text-data)]">{cls}</td>
+                  <td className="p-2">{pct(pc.precision)}</td>
+                  <td className="p-2">{pct(pc.recall)}</td>
+                  <td className="p-2">{pct(pc.f1)}</td>
+                  <td className="p-2">{pc.ap50 != null ? pct(pc.ap50) : '—'}</td>
+                  <td className="p-2 text-[var(--hud-text-muted)]">{pc.support}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Confusion matrix */}
+      {data.confusion && data.classes && data.confusion.length > 0 && (
+        <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)]">
+          <div className="label-overline px-3 py-2 border-b border-[var(--hud-border-subtle)]">
+            Confusion matrix (rows = ground truth, cols = predicted)
+          </div>
+          <div className="overflow-auto p-3">
+            <table className="text-[0.6875rem] font-mono">
+              <thead>
+                <tr>
+                  <th className="p-1"></th>
+                  {data.classes.map((c) => (
+                    <th
+                      key={c}
+                      className="p-1 text-[var(--hud-text-muted)] text-center"
+                    >
+                      {c}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {data.confusion.map((row, i) => {
+                  const max = Math.max(...row, 1);
+                  return (
+                    <tr key={i}>
+                      <th className="p-1 text-[var(--hud-text-muted)] text-right">
+                        {data.classes![i]}
+                      </th>
+                      {row.map((v, j) => {
+                        const intensity = v / max;
+                        const bg = `oklch(${0.18 + intensity * 0.4} 0.10 ${
+                          i === j ? 155 : 20
+                        })`;
+                        return (
+                          <td
+                            key={j}
+                            className="border border-[var(--hud-border-subtle)] text-center"
+                            style={{
+                              background: v > 0 ? bg : 'transparent',
+                              color:
+                                v > 0
+                                  ? 'var(--hud-text-data)'
+                                  : 'var(--hud-text-muted)',
+                              minWidth: '36px',
+                              padding: '4px 8px',
+                            }}
+                          >
+                            {v}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* FP / FN samples */}
+      {data.samples && data.samples.length > 0 && (
+        <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)]">
+          <div className="label-overline px-3 py-2 border-b border-[var(--hud-border-subtle)]">
+            False positives / false negatives ({data.samples.length})
+          </div>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-px bg-[var(--hud-border-subtle)]">
+            {data.samples.map((s, i) => (
+              <Link
+                key={i}
+                to={`/annotate/${s.asset_id}`}
+                className="bg-[var(--hud-surface)] hover:bg-[var(--hud-elevated)] p-3"
+              >
+                <div className="flex items-center justify-between">
+                  <Badge variant={s.kind === 'fp' ? 'danger' : 'warning'}>
+                    {s.kind.toUpperCase()}
+                  </Badge>
+                  {s.score != null && (
+                    <span className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)]">
+                      {pct(s.score)}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-2 text-[0.6875rem] font-mono text-[var(--hud-text-muted)]">
+                  ASSET {s.asset_id.slice(0, 8)}
+                </div>
+                <div className="mt-1 text-xs font-mono text-[var(--hud-text-data)]">
+                  {s.predicted ? `pred: ${s.predicted}` : 'no prediction'}
+                </div>
+                <div className="text-xs font-mono text-[var(--hud-text-muted)]">
+                  {s.ground_truth ? `gt: ${s.ground_truth}` : 'no ground truth'}
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/evaluations/[evalId].tsx
+++ b/frontend/src/pages/evaluations/[evalId].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import Badge from '@/components/ui/Badge';
 import Spinner from '@/components/ui/Spinner';
@@ -53,6 +53,13 @@ export default function EvaluationDetail() {
   const { evalId } = useParams();
   const [data, setData] = useState<Evaluation | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Mirror the live status into a ref so the polling closure can see the
+  // latest value without re-creating the interval each render.
+  const statusRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    statusRef.current = data?.status ?? null;
+  }, [data?.status]);
 
   useEffect(() => {
     if (!evalId) return;
@@ -63,20 +70,22 @@ export default function EvaluationDetail() {
           if (!cancelled) setData(d);
         })
         .catch((err) => {
-          if (!cancelled)
-            setError(err instanceof Error ? err.message : 'Failed to load');
+          if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load');
         });
     }
     load();
     const t = setInterval(() => {
-      if (data && data.status !== 'queued' && data.status !== 'running') return;
+      const s = statusRef.current;
+      if (s && s !== 'queued' && s !== 'running') {
+        clearInterval(t);
+        return;
+      }
       load();
     }, 3000);
     return () => {
       cancelled = true;
       clearInterval(t);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [evalId]);
 
   if (error) return <ErrorState description={error} />;

--- a/frontend/src/pages/evaluations/index.tsx
+++ b/frontend/src/pages/evaluations/index.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import Badge from '@/components/ui/Badge';
+import Spinner from '@/components/ui/Spinner';
+import EmptyState from '@/components/common/EmptyState';
+import ErrorState from '@/components/common/ErrorState';
+import { apiGet } from '@/services/api';
+
+interface EvaluationSummary {
+  id: string;
+  artifact_id: string;
+  dataset_version_id: string;
+  status: string;
+  primary_metric_name: string | null;
+  primary_metric: number | null;
+  created_at: string | null;
+  completed_at: string | null;
+}
+
+function statusBadge(status: string) {
+  if (status === 'succeeded') return <Badge variant="success">DONE</Badge>;
+  if (status === 'running') return <Badge variant="info">RUNNING</Badge>;
+  if (status === 'failed') return <Badge variant="danger">FAILED</Badge>;
+  return <Badge variant="default">{status.toUpperCase()}</Badge>;
+}
+
+export default function EvaluationsIndex() {
+  const [params] = useSearchParams();
+  const [rows, setRows] = useState<EvaluationSummary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const qp = new URLSearchParams();
+    const artifact = params.get('artifact_id');
+    if (artifact) qp.set('artifact_id', artifact);
+    const dsv = params.get('dataset_version_id');
+    if (dsv) qp.set('dataset_version_id', dsv);
+    const project = params.get('project_id');
+    if (project) qp.set('project_id', project);
+
+    apiGet<EvaluationSummary[]>(`/api/evaluations?${qp.toString()}`)
+      .then(setRows)
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load'));
+  }, [params]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
+        <div>
+          <div className="label-overline mb-0.5">// Evaluations</div>
+          <h1>Evaluations</h1>
+          <p className="text-xs text-[var(--hud-text-muted)] mt-1">
+            Run a model against a labeled dataset version. Get mAP / accuracy / per-class P/R/F1
+            and an FP/FN viewer.
+          </p>
+        </div>
+        <Link
+          to="/evaluations/new"
+          className="inline-flex items-center h-8 px-3 text-xs font-mono font-medium bg-[var(--hud-accent)] text-[oklch(0.10_0.008_240)] border border-[var(--hud-accent)]"
+        >
+          + NEW EVAL
+        </Link>
+      </div>
+
+      {error && <ErrorState description={error} />}
+
+      {rows === null && !error && (
+        <div className="flex items-center gap-2 text-xs font-mono text-[var(--hud-text-muted)]">
+          <Spinner size={14} /> Loading…
+        </div>
+      )}
+
+      {rows && rows.length === 0 && (
+        <EmptyState
+          title="No evaluations yet"
+          description="Click + NEW EVAL to score a trained model on a labeled dataset version."
+        />
+      )}
+
+      {rows && rows.length > 0 && (
+        <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)]">
+          <table className="w-full text-xs font-mono">
+            <thead className="bg-[var(--hud-inset)]">
+              <tr className="text-left">
+                <th className="p-2 label-overline">ID</th>
+                <th className="p-2 label-overline">Status</th>
+                <th className="p-2 label-overline">Metric</th>
+                <th className="p-2 label-overline">Created</th>
+                <th className="p-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr
+                  key={r.id}
+                  className="border-t border-[var(--hud-border-subtle)] hover:bg-[var(--hud-elevated)]"
+                >
+                  <td className="p-2 text-[var(--hud-text-muted)]">{r.id.slice(0, 8)}</td>
+                  <td className="p-2">{statusBadge(r.status)}</td>
+                  <td className="p-2">
+                    {r.primary_metric != null && r.primary_metric_name ? (
+                      <span className="text-[var(--hud-text-data)]">
+                        {r.primary_metric_name} {(r.primary_metric * 100).toFixed(1)}%
+                      </span>
+                    ) : (
+                      <span className="text-[var(--hud-text-muted)]">—</span>
+                    )}
+                  </td>
+                  <td className="p-2 text-[var(--hud-text-muted)]">
+                    {r.created_at ? new Date(r.created_at).toLocaleString() : '—'}
+                  </td>
+                  <td className="p-2 text-right">
+                    <Link
+                      to={`/evaluations/${r.id}`}
+                      className="text-[var(--hud-accent)] hover:underline"
+                    >
+                      VIEW →
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/evaluations/new.tsx
+++ b/frontend/src/pages/evaluations/new.tsx
@@ -49,6 +49,17 @@ export default function EvaluationsNew() {
     setForm((prev) => ({ ...prev, [key]: value }));
   }
 
+  // parseFloat with explicit NaN guard so 0 / 0.0 round-trip correctly
+  // (`parseFloat(...) || fallback` is wrong because 0 is falsy).
+  function safeFloat(raw: string, fallback: number): number {
+    const parsed = parseFloat(raw);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  function safeInt(raw: string, fallback: number): number {
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!form.artifact_id || !form.dataset_version_id) {
@@ -58,16 +69,22 @@ export default function EvaluationsNew() {
     setLoading(true);
     setError(null);
     try {
-      const job = await apiPost<{ evaluationId: string; jobId: string }>('/api/evaluations', {
-        artifact_id: form.artifact_id,
-        dataset_version_id: form.dataset_version_id,
-        split: form.split,
-        cluster_id: form.cluster_id || null,
-        iou_threshold: form.iou_threshold,
-        score_threshold: form.score_threshold,
-        sample_fpfn_count: form.sample_fpfn_count,
-      });
-      navigate(`/evaluations/${(job as any).evaluationId || (job as any).id}`);
+      const job = await apiPost<{ evaluationId: string; jobId: string; id: string }>(
+        '/api/evaluations',
+        {
+          artifact_id: form.artifact_id,
+          dataset_version_id: form.dataset_version_id,
+          split: form.split,
+          cluster_id: form.cluster_id || null,
+          iou_threshold: form.iou_threshold,
+          score_threshold: form.score_threshold,
+          sample_fpfn_count: form.sample_fpfn_count,
+        }
+      );
+      if (!job.evaluationId) {
+        throw new Error('server response missing evaluationId');
+      }
+      navigate(`/evaluations/${job.evaluationId}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to start evaluation');
     } finally {
@@ -128,9 +145,7 @@ export default function EvaluationsNew() {
               max={1}
               step={0.05}
               value={form.iou_threshold}
-              onChange={(e) =>
-                setField('iou_threshold', parseFloat(e.target.value) || 0.5)
-              }
+              onChange={(e) => setField('iou_threshold', safeFloat(e.target.value, 0.5))}
             />
           </div>
           <div>
@@ -141,9 +156,7 @@ export default function EvaluationsNew() {
               max={1}
               step={0.05}
               value={form.score_threshold}
-              onChange={(e) =>
-                setField('score_threshold', parseFloat(e.target.value) || 0.25)
-              }
+              onChange={(e) => setField('score_threshold', safeFloat(e.target.value, 0.25))}
             />
           </div>
           <div>
@@ -153,9 +166,7 @@ export default function EvaluationsNew() {
               min={0}
               max={500}
               value={form.sample_fpfn_count}
-              onChange={(e) =>
-                setField('sample_fpfn_count', parseInt(e.target.value) || 0)
-              }
+              onChange={(e) => setField('sample_fpfn_count', safeInt(e.target.value, 0))}
             />
           </div>
           <div>

--- a/frontend/src/pages/evaluations/new.tsx
+++ b/frontend/src/pages/evaluations/new.tsx
@@ -130,8 +130,13 @@ export default function EvaluationsNew() {
           >
             <option value="">— select —</option>
             {datasets.map((d) => (
-              <option key={d.id} value={d.latest_version_id || d.id}>
+              <option
+                key={d.id}
+                value={d.latest_version_id || ''}
+                disabled={!d.latest_version_id}
+              >
                 {d.name}
+                {!d.latest_version_id ? ' (no versions yet)' : ''}
               </option>
             ))}
           </Select>

--- a/frontend/src/pages/evaluations/new.tsx
+++ b/frontend/src/pages/evaluations/new.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import Input from '@/components/ui/Input';
+import Select from '@/components/ui/Select';
+import Button from '@/components/ui/Button';
+import Alert from '@/components/ui/Alert';
+import ClusterSelect from '@/components/common/ClusterSelect';
+import { apiGet, apiPost } from '@/services/api';
+
+interface ModelArtifact {
+  id: string;
+  name: string;
+  version: string;
+  type: string;
+  format: string;
+  projectId: string;
+  runId?: string | null;
+}
+
+interface DatasetSummary {
+  id: string;
+  name: string;
+  latest_version_id?: string | null;
+}
+
+export default function EvaluationsNew() {
+  const navigate = useNavigate();
+  const [params] = useSearchParams();
+  const [models, setModels] = useState<ModelArtifact[]>([]);
+  const [datasets, setDatasets] = useState<DatasetSummary[]>([]);
+  const [form, setForm] = useState({
+    artifact_id: params.get('artifact_id') || '',
+    dataset_version_id: params.get('dataset_version_id') || '',
+    split: 'test',
+    cluster_id: '',
+    iou_threshold: 0.5,
+    score_threshold: 0.25,
+    sample_fpfn_count: 50,
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiGet<ModelArtifact[]>('/api/artifacts/models').then(setModels).catch(() => {});
+    apiGet<DatasetSummary[]>('/api/datasets').then(setDatasets).catch(() => {});
+  }, []);
+
+  function setField<K extends keyof typeof form>(key: K, value: (typeof form)[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.artifact_id || !form.dataset_version_id) {
+      setError('Pick a model and a dataset version');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const job = await apiPost<{ evaluationId: string; jobId: string }>('/api/evaluations', {
+        artifact_id: form.artifact_id,
+        dataset_version_id: form.dataset_version_id,
+        split: form.split,
+        cluster_id: form.cluster_id || null,
+        iou_threshold: form.iou_threshold,
+        score_threshold: form.score_threshold,
+        sample_fpfn_count: form.sample_fpfn_count,
+      });
+      navigate(`/evaluations/${(job as any).evaluationId || (job as any).id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start evaluation');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="max-w-xl space-y-4">
+      <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
+        <div>
+          <div className="label-overline mb-0.5">// Evaluations / New</div>
+          <h1>Evaluate a model</h1>
+        </div>
+        <Link
+          to="/evaluations"
+          className="text-xs font-mono text-[var(--hud-accent)] hover:underline"
+        >
+          ← EVALUATIONS
+        </Link>
+      </div>
+
+      <form onSubmit={onSubmit} className="space-y-3">
+        <div>
+          <label className="label-overline block mb-1">Model artifact</label>
+          <Select
+            value={form.artifact_id}
+            onChange={(e) => setField('artifact_id', e.target.value)}
+          >
+            <option value="">— select —</option>
+            {models.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name} v{m.version} ({m.format})
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div>
+          <label className="label-overline block mb-1">Dataset version</label>
+          <Select
+            value={form.dataset_version_id}
+            onChange={(e) => setField('dataset_version_id', e.target.value)}
+          >
+            <option value="">— select —</option>
+            {datasets.map((d) => (
+              <option key={d.id} value={d.latest_version_id || d.id}>
+                {d.name}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="label-overline block mb-1">IoU threshold</label>
+            <Input
+              type="number"
+              min={0}
+              max={1}
+              step={0.05}
+              value={form.iou_threshold}
+              onChange={(e) =>
+                setField('iou_threshold', parseFloat(e.target.value) || 0.5)
+              }
+            />
+          </div>
+          <div>
+            <label className="label-overline block mb-1">Score threshold</label>
+            <Input
+              type="number"
+              min={0}
+              max={1}
+              step={0.05}
+              value={form.score_threshold}
+              onChange={(e) =>
+                setField('score_threshold', parseFloat(e.target.value) || 0.25)
+              }
+            />
+          </div>
+          <div>
+            <label className="label-overline block mb-1">FP/FN sample budget</label>
+            <Input
+              type="number"
+              min={0}
+              max={500}
+              value={form.sample_fpfn_count}
+              onChange={(e) =>
+                setField('sample_fpfn_count', parseInt(e.target.value) || 0)
+              }
+            />
+          </div>
+          <div>
+            <label className="label-overline block mb-1">Split</label>
+            <Select value={form.split} onChange={(e) => setField('split', e.target.value)}>
+              <option value="test">test</option>
+              <option value="val">val</option>
+              <option value="all">all labeled</option>
+            </Select>
+          </div>
+        </div>
+        <div>
+          <label className="label-overline block mb-1">Cluster</label>
+          <ClusterSelect
+            kind="eval"
+            value={form.cluster_id}
+            onChange={(v) => setField('cluster_id', v)}
+            allowAuto
+          />
+        </div>
+
+        {error && <Alert variant="error">{error}</Alert>}
+        <Button type="submit" disabled={loading}>
+          {loading ? 'Starting…' : 'Start evaluation'}
+        </Button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
Ships the "make the platform actually usable" phase identified in the post-cluster audit. The cluster-management feature from PR #9 is already merged into main; this PR is the next layer on top.

## Summary

- **Annotator** — polygon + keypoint shapes, undo/redo (Ctrl+Z / Ctrl+Shift+Z), Ctrl+S save, hotkeys (B/P/K/V/C, Del, Esc, Enter, ←/→), per-annotation optimistic locking with `expected_version` (409 on conflict), per-annotation history, and prev/next frame navigation via a new `GET /api/assets/{id}/neighbors`.
- **Evaluation as a first-class job** — new `Evaluation` model + Alembic migration, `/api/evaluations` API, Celery task that runs the artifact over labeled assets in a split and computes classification accuracy or detection mAP@iou, per-class P/R/F1, confusion matrix, and an FP/FN sample list. Frontend index / new / detail pages with confusion-matrix heat-map and clickable FP/FN cards that deep-link to the annotator.
- **Inference / serving** — `services/inference_service.py` thread-safe LRU cache (size from `VF_INFERENCE_CACHE_SIZE`) for Ultralytics + ONNX artifacts. New `POST /api/artifacts/models/{id}/predict` accepts multipart `file` or JSON `image_base64`. `/artifacts/predict/:modelId` page with image upload + bbox overlay, plus a "PREDICT" button on artifacts list.
- **Datumaro import / export** — native COCO + YOLO handlers (no extra deps) with optional Datumaro-backed Pascal VOC / CVAT / LabelMe path. `POST /api/datasets/{id}/import` and `GET /api/datasets/{id}/export?fmt=...`, plus a `/datasets/import` wizard page and "IMPORT" button on datasets list.
- **Bcrypt-only auth** — dropped the SHA256 fallback in `authenticate()`; new `admin_reset_password()` helper. Migration 0004 nulls out non-bcrypt password hashes so legacy users fail closed instead of silently working on the old algo.

## What's new at a glance

| Area | Backend | Frontend |
|---|---|---|
| Annotator | polygon/keypoint types, version column, history endpoint, /neighbors | Konva-style canvas, undo/redo, hotkeys, frame nav, optimistic-lock save |
| Evaluation | model + 0005 migration, service, Celery task, /api/evaluations | index, new, detail with confusion matrix + FP/FN viewer |
| Inference | LRU cache service, POST /predict, cache ops endpoints | /artifacts/predict/:id with bbox overlay |
| Datumaro | COCO/YOLO native + Datumaro path | /datasets/import wizard |
| Auth | bcrypt-only, 0004 migration nulls legacy hashes | n/a |

## Tests

5 new unit test files + 1 integration file:
- `test_evaluation_metrics.py` — classification & detection metrics correctness (perfect, with errors, IoU below threshold)
- `test_annotation_versioning.py` — type validation, version bump on update, 409 conflict, polygon point requirement, keypoint creation
- `test_datumaro_import.py` — COCO + YOLO import + roundtrip export
- `test_inference_cache.py` — LRU eviction + reuse semantics
- `test_auth_bcrypt_only.py` — SHA256 hashes rejected, bcrypt hashes still authenticate
- `test_evaluations_api.py` — 400 on missing artifact, 202 + queued job on valid input

`46 passed` locally on the cherry-picked branch (excluding two env-bound pre-existing failures: `test_services_auth.py` and `test_services_embeddings.py` need bcrypt/clip wheels that don't install in this sandbox).

## Test plan

- [ ] Annotator: open an asset, draw a box, draw a polygon (P then click then Enter), drop a keypoint, Ctrl+Z, Ctrl+Shift+Z, Ctrl+S, ← / → between assets.
- [ ] Two browser tabs editing the same annotation: confirm the second save returns 409 with "version mismatch".
- [ ] Datasets → IMPORT: upload a COCO zip, then export the same version as YOLO and verify `classes.txt` + `labels/*.txt`.
- [ ] Artifacts → PREDICT: upload an image to a YOLO artifact and confirm bboxes are overlaid.
- [ ] Artifacts → EVALUATE: pick a labeled dataset version and confirm the evaluation row goes queued → running → succeeded with a populated confusion matrix and FP/FN cards.
- [ ] Auth migration: a user with a SHA256 `password_hash` fails to log in after `alembic upgrade head` ran (hash is nulled).

## Caveats

- Annotator save loop still does one HTTP request per dirty annotation; bulk-save is a Phase 2 nicety.
- Detection AP uses 11-point interpolation at the requested IoU only (no mAP@[.5:.95] yet).
- Inference is in-process, no GPU bias; heavy serving will be fronted by Triton in Phase 4.
- `pascal_voc` / `cvat` / `labelme` formats need the optional `datumaro` pip package at runtime; the error message says so.

https://claude.ai/code/session_01KX1NAFNrsBd5BrCJzA88Tk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KX1NAFNrsBd5BrCJzA88Tk)_