### PR TITLE
docs: add post-Phase 1 phases roadmap (Phases 2–5)

### DIFF
--- a/backend/src/app/api/al.py
+++ b/backend/src/app/api/al.py
@@ -3,20 +3,103 @@ from __future__ import annotations
 import json
 import random
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
 from app.models.alitem import ALItem
 from app.models.alrun import ALRun
+from app.models.artifact import ModelArtifact
 from app.models.asset import Asset
 from app.models.user import User
+from app.services import inference_service
 from app.services.active_learning_service import select_diverse, select_uncertain
 from app.services.embeddings_service import EmbeddingsService
 
 router = APIRouter(prefix="/api/al", tags=["active-learning"])
+
+
+def _uncertainty_scores(db: Session, assets: list, model_id: str | None) -> list[float]:
+    """Compute uncertainty scores for ``assets`` using ``model_id`` if available.
+
+    When a model artifact is provided we run actual inference and use a margin-
+    based uncertainty proxy (``1 - top_score``). When no model is available the
+    pre-trained bootstrap path returns a uniform random score, which is still a
+    reasonable cold-start strategy.
+    """
+    if not model_id:
+        return [random.random() for _ in assets]
+    artifact = db.get(ModelArtifact, model_id)
+    if artifact is None or not artifact.storage_path:
+        return [random.random() for _ in assets]
+
+    scores: list[float] = []
+    for asset in assets:
+        try:
+            from urllib.request import urlopen
+
+            if asset.uri.startswith(("http://", "https://")):
+                with urlopen(asset.uri, timeout=10) as response:  # noqa: S310
+                    image_bytes = response.read()
+            elif asset.uri:
+                # MinIO key
+                from app.services import storage as _storage
+
+                client = _storage.get_minio_client()
+                import os as _os
+
+                bucket = _os.getenv("MINIO_BUCKET", _os.getenv("S3_BUCKET", "visionforge"))
+                resp = client.get_object(bucket, asset.uri)
+                try:
+                    image_bytes = resp.read()
+                finally:
+                    resp.close()
+                    resp.release_conn()
+            else:
+                scores.append(random.random())
+                continue
+            result = inference_service.predict(artifact, image_bytes, score_threshold=0.0)
+            top = _top_confidence(result)
+            scores.append(1.0 - float(top))
+        except Exception:
+            # Fall back to a random score for this asset rather than dropping it.
+            scores.append(random.random())
+    return scores
+
+
+def _top_confidence(result: dict | list) -> float:
+    """Pick the most confident prediction's score from an inference result."""
+    if isinstance(result, dict):
+        cls_pred = result.get("classification")
+        if isinstance(cls_pred, dict) and "score" in cls_pred:
+            try:
+                return float(cls_pred["score"])
+            except Exception:
+                pass
+        if "top_score" in result:
+            try:
+                return float(result["top_score"])
+            except Exception:
+                pass
+        boxes = result.get("detections") or result.get("predictions") or []
+    elif isinstance(result, list):
+        boxes = result
+    else:
+        boxes = []
+    if not boxes:
+        return 0.0
+    best = 0.0
+    for b in boxes:
+        score = b.get("score") or b.get("confidence") or 0.0
+        try:
+            score = float(score)
+        except Exception:
+            continue
+        if score > best:
+            best = score
+    return best
 
 
 class ALSelectRequest(BaseModel):
@@ -65,8 +148,7 @@ def select_samples(
                 embeddings.append(svc.embed_texts([a.uri])[0])
         indices = select_diverse(embeddings, k)
     else:
-        # Default: random uncertainty scores (no model available at select time)
-        scores = [random.random() for _ in assets]
+        scores = _uncertainty_scores(db, assets, body.model_id)
         indices = select_uncertain(scores, k)
 
     selected = [assets[i] for i in indices if i < len(assets)]
@@ -101,23 +183,34 @@ def select_samples(
 
 @router.get("/runs")
 def list_runs(
-    project_id: str | None = None,
+    project_id: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    q = select(ALRun)
+    base = select(ALRun)
     if project_id:
-        q = q.where(ALRun.project_id == project_id)
-    runs = list(db.scalars(q).all())
-    return [
-        {
-            "id": r.id,
-            "project_id": r.project_id,
-            "strategy": r.strategy,
-            "created_at": r.created_at.isoformat() if r.created_at else None,
-        }
-        for r in runs
-    ]
+        base = base.where(ALRun.project_id == project_id)
+    total = db.scalar(select(func.count()).select_from(base.subquery())) or 0
+    offset = (page - 1) * page_size
+    runs = list(
+        db.scalars(base.order_by(ALRun.created_at.desc()).offset(offset).limit(page_size)).all()
+    )
+    return {
+        "items": [
+            {
+                "id": r.id,
+                "project_id": r.project_id,
+                "strategy": r.strategy,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in runs
+        ],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }
 
 
 @router.get("/runs/{al_run_id}/items")

--- a/backend/src/app/api/al.py
+++ b/backend/src/app/api/al.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import random
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -16,18 +17,28 @@ from app.models.asset import Asset
 from app.models.user import User
 from app.services import inference_service
 from app.services.active_learning_service import select_diverse, select_uncertain
+from app.services.asset_fetch import fetch_asset_bytes
 from app.services.embeddings_service import EmbeddingsService
 
 router = APIRouter(prefix="/api/al", tags=["active-learning"])
+
+# Hard cap on the number of assets scored inline by the API request. Larger
+# pools fall back to random for the excess + can be scored fully via the
+# `app.jobs.tasks.al_uncertainty.score_assets` Celery task. Tunable via env.
+_INLINE_SCORE_CAP = int(os.getenv("VF_AL_INLINE_SCORE_CAP", "200"))
 
 
 def _uncertainty_scores(db: Session, assets: list, model_id: str | None) -> list[float]:
     """Compute uncertainty scores for ``assets`` using ``model_id`` if available.
 
-    When a model artifact is provided we run actual inference and use a margin-
-    based uncertainty proxy (``1 - top_score``). When no model is available the
-    pre-trained bootstrap path returns a uniform random score, which is still a
-    reasonable cold-start strategy.
+    When a model artifact is provided we run actual inference on up to
+    ``_INLINE_SCORE_CAP`` assets and use a margin-based uncertainty proxy
+    (``1 - top_score``). Anything beyond the cap (or any inference failure)
+    falls back to a random score so the request stays fast and never blocks
+    indefinitely on heavy I/O. For full-pool scoring, dispatch
+    ``app.jobs.tasks.al_uncertainty.score_assets`` as a background job — it
+    persists per-asset scores into ``Asset.meta_data["uncertainty"]`` which
+    this function will pick up on subsequent calls.
     """
     if not model_id:
         return [random.random() for _ in assets]
@@ -36,37 +47,47 @@ def _uncertainty_scores(db: Session, assets: list, model_id: str | None) -> list
         return [random.random() for _ in assets]
 
     scores: list[float] = []
+    inline_budget = _INLINE_SCORE_CAP
     for asset in assets:
+        # First try a cached score from a prior background job.
+        cached = _cached_uncertainty(asset)
+        if cached is not None:
+            scores.append(cached)
+            continue
+        if inline_budget <= 0:
+            # Exceeded the per-request cap — degrade to random rather than
+            # hold up the API thread.
+            scores.append(random.random())
+            continue
         try:
-            from urllib.request import urlopen
-
-            if asset.uri.startswith(("http://", "https://")):
-                with urlopen(asset.uri, timeout=10) as response:  # noqa: S310
-                    image_bytes = response.read()
-            elif asset.uri:
-                # MinIO key
-                from app.services import storage as _storage
-
-                client = _storage.get_minio_client()
-                import os as _os
-
-                bucket = _os.getenv("MINIO_BUCKET", _os.getenv("S3_BUCKET", "visionforge"))
-                resp = client.get_object(bucket, asset.uri)
-                try:
-                    image_bytes = resp.read()
-                finally:
-                    resp.close()
-                    resp.release_conn()
-            else:
+            image_bytes = fetch_asset_bytes(asset.uri)
+            if not image_bytes:
                 scores.append(random.random())
                 continue
             result = inference_service.predict(artifact, image_bytes, score_threshold=0.0)
             top = _top_confidence(result)
             scores.append(1.0 - float(top))
         except Exception:
-            # Fall back to a random score for this asset rather than dropping it.
             scores.append(random.random())
+        inline_budget -= 1
     return scores
+
+
+def _cached_uncertainty(asset) -> float | None:
+    """Read a previously-computed uncertainty score from ``meta_data``."""
+    md = getattr(asset, "meta_data", None)
+    if not md:
+        return None
+    try:
+        parsed = json.loads(md)
+    except Exception:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    val = parsed.get("uncertainty")
+    if isinstance(val, (int, float)):
+        return float(val)
+    return None
 
 
 def _top_confidence(result: dict | list) -> float:
@@ -108,6 +129,51 @@ class ALSelectRequest(BaseModel):
     strategy: str = "uncertainty"  # "uncertainty" or "diverse"
     k: int = 20  # number of samples to select
     model_id: str | None = None  # for uncertainty scoring
+
+
+class ALScoreRequest(BaseModel):
+    dataset_version_id: str
+    artifact_id: str
+    max_assets: int = 0  # 0 = no cap
+
+
+@router.post("/score", status_code=202)
+def queue_uncertainty_scoring(
+    body: ALScoreRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Queue a Celery job that pre-computes per-asset uncertainty scores.
+
+    Use this for full-pool scoring on large datasets so `/api/al/select`
+    can read cached scores instead of running inference inline.
+    """
+    from app.jobs.celery_app import celery_app
+    from app.models.dataset_version import DatasetVersion
+    from app.services.jobs_service import create_job, update_job_status
+
+    if not db.get(ModelArtifact, body.artifact_id):
+        raise HTTPException(status_code=400, detail="artifact not found")
+    if not db.get(DatasetVersion, body.dataset_version_id):
+        raise HTTPException(status_code=400, detail="dataset version not found")
+
+    payload = {
+        "artifactId": body.artifact_id,
+        "datasetVersionId": body.dataset_version_id,
+        "maxAssets": body.max_assets,
+    }
+    job = create_job(db, "al_uncertainty", payload)
+    payload["jobId"] = job.id
+    try:
+        celery_app.send_task("app.jobs.tasks.al_uncertainty.score_assets", args=[payload])
+    except Exception as exc:
+        # Broker unavailable — surface failure rather than leaving the row queued.
+        try:
+            update_job_status(db, job.id, status="failed", progress=0.0)
+        except Exception:
+            pass
+        raise HTTPException(status_code=503, detail=f"failed to dispatch task: {exc}") from exc
+    return {"jobId": job.id, "status": "queued"}
 
 
 @router.post("/select", status_code=201)

--- a/backend/src/app/api/annotations.py
+++ b/backend/src/app/api/annotations.py
@@ -265,7 +265,7 @@ def queue_error_mining(
     from app.jobs.celery_app import celery_app
     from app.models.artifact import ModelArtifact
     from app.models.dataset_version import DatasetVersion
-    from app.services.jobs_service import create_job
+    from app.services.jobs_service import create_job, update_job_status
 
     if not db.get(ModelArtifact, body.artifact_id):
         raise HTTPException(status_code=400, detail="artifact not found")
@@ -283,7 +283,14 @@ def queue_error_mining(
     payload["jobId"] = job.id
     try:
         celery_app.send_task("app.jobs.tasks.error_mining.mine_errors", args=[payload])
-    except Exception:
-        # Job row remains queued; a worker can still pick it up later.
-        pass
+    except Exception as exc:
+        # Don't leave a phantom queued job in the dashboard if the broker is
+        # unavailable — flip it to failed and surface 503 so the UI knows.
+        try:
+            update_job_status(db, job.id, status="failed", progress=0.0)
+        except Exception:
+            pass
+        raise HTTPException(
+            status_code=503, detail=f"failed to dispatch error-mining task: {exc}"
+        ) from exc
     return {"jobId": job.id, "status": "queued"}

--- a/backend/src/app/api/annotations.py
+++ b/backend/src/app/api/annotations.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
 
-import json
-
-from fastapi import APIRouter, Depends, HTTPException, Path
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
+from app.models.annotation import REVIEW_STATUSES
 from app.models.user import User
 from app.services.annotation_service import (
     AnnotationError,
     VersionConflictError,
+    _ann_dict,
+    bulk_save,
     create_annotation,
     delete_annotation,
     get_asset_annotations,
     get_history,
+    list_review_queue,
     mark_asset_labeled,
+    review_summary,
+    set_review,
     update_annotation,
 )
 
@@ -32,22 +36,33 @@ class AnnotationCreate(BaseModel):
 class AnnotationUpdate(BaseModel):
     geometry: dict | None = None
     class_name: str | None = None
-    # Optimistic lock — required for safe concurrent edits, optional for fire-and-forget.
     expected_version: int | None = None
 
 
-def _ann_to_dict(ann) -> dict:
-    return {
-        "id": ann.id,
-        "asset_id": ann.asset_id,
-        "type": ann.type,
-        "geometry": json.loads(ann.geometry) if isinstance(ann.geometry, str) else ann.geometry,
-        "class_name": ann.class_name,
-        "author_id": ann.author_id,
-        "version": ann.version,
-        "updated_at": ann.updated_at.isoformat() if ann.updated_at else None,
-        "created_at": ann.created_at.isoformat() if ann.created_at else None,
-    }
+class BulkCreate(BaseModel):
+    client_id: str | None = None  # client correlation id (e.g. tempId)
+    asset_id: str
+    type: str
+    geometry: dict
+    class_name: str | None = None
+
+
+class BulkUpdate(BaseModel):
+    id: str
+    geometry: dict | None = None
+    class_name: str | None = None
+    expected_version: int | None = None
+
+
+class BulkSaveRequest(BaseModel):
+    creates: list[BulkCreate] = Field(default_factory=list)
+    updates: list[BulkUpdate] = Field(default_factory=list)
+    deletes: list[str] = Field(default_factory=list)
+
+
+class ReviewRequest(BaseModel):
+    review_status: str  # "approved" | "rejected" | "unreviewed"
+    notes: str | None = None
 
 
 @router.post("", status_code=201)
@@ -67,7 +82,7 @@ def create(
         )
     except AnnotationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return _ann_to_dict(ann)
+    return _ann_dict(ann)
 
 
 @router.put("/{annotation_id}")
@@ -91,7 +106,7 @@ def update(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not ann:
         raise HTTPException(status_code=404, detail="Annotation not found")
-    return _ann_to_dict(ann)
+    return _ann_dict(ann)
 
 
 @router.delete("/{annotation_id}", status_code=204)
@@ -104,21 +119,71 @@ def delete(
         raise HTTPException(status_code=404, detail="Annotation not found")
 
 
+@router.post("/bulk")
+def bulk(
+    body: BulkSaveRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Apply many annotation mutations in one round-trip.
+
+    The annotator uses this to flush all dirty edits in a single request
+    instead of one PUT per dirty annotation. Returns per-entry status so the
+    UI can highlight conflicts (HTTP 409 equivalents) without rolling back
+    successful entries.
+    """
+    return bulk_save(
+        db,
+        author_id=current_user.id,
+        creates=[c.model_dump() for c in body.creates],
+        updates=[u.model_dump() for u in body.updates],
+        deletes=body.deletes,
+    )
+
+
+@router.post("/{annotation_id}/review")
+def review(
+    body: ReviewRequest,
+    annotation_id: str = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if body.review_status not in REVIEW_STATUSES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"review_status must be one of {list(REVIEW_STATUSES)}",
+        )
+    try:
+        ann = set_review(
+            db,
+            annotation_id,
+            review_status=body.review_status,
+            reviewer_id=current_user.id,
+            notes=body.notes,
+        )
+    except AnnotationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not ann:
+        raise HTTPException(status_code=404, detail="Annotation not found")
+    return _ann_dict(ann)
+
+
 @router.get("/{annotation_id}/history")
 def history(
     annotation_id: str = Path(...),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    import json as _json
+
     rows = get_history(db, annotation_id)
-    # geometry stored as JSON string in history; parse for clients
     out = []
     for h in rows:
         item = dict(h)
         g = item.get("geometry")
         if isinstance(g, str):
             try:
-                item["geometry"] = json.loads(g)
+                item["geometry"] = _json.loads(g)
             except Exception:
                 pass
         out.append(item)
@@ -132,7 +197,7 @@ def list_for_asset(
     current_user: User = Depends(get_current_user),
 ):
     anns = get_asset_annotations(db, asset_id)
-    return [_ann_to_dict(a) for a in anns]
+    return [_ann_dict(a) for a in anns]
 
 
 @router.post("/assets/{asset_id}/mark-labeled", status_code=200)
@@ -143,3 +208,82 @@ def mark_labeled(
 ):
     mark_asset_labeled(db, asset_id)
     return {"status": "labeled"}
+
+
+@router.get("/datasets/{dataset_id}/review")
+def review_queue(
+    dataset_id: str = Path(...),
+    version_id: str | None = Query(None),
+    review_status: str | None = Query(None),
+    flagged: bool | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """List annotations for a dataset's review queue."""
+    try:
+        items, total = list_review_queue(
+            db,
+            dataset_id=dataset_id,
+            version_id=version_id,
+            review_status=review_status,
+            flagged=flagged,
+            page=page,
+            page_size=page_size,
+        )
+    except AnnotationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
+
+
+@router.get("/datasets/{dataset_id}/review/summary")
+def review_queue_summary(
+    dataset_id: str = Path(...),
+    version_id: str | None = Query(None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return review_summary(db, dataset_id=dataset_id, version_id=version_id)
+
+
+class ErrorMineRequest(BaseModel):
+    artifact_id: str
+    dataset_version_id: str
+    iou_threshold: float = 0.5
+    score_threshold: float = 0.25
+    max_assets: int = 0
+
+
+@router.post("/error-mine", status_code=202)
+def queue_error_mining(
+    body: ErrorMineRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Queue an error-mining run that flags annotations disagreeing with predictions."""
+    from app.jobs.celery_app import celery_app
+    from app.models.artifact import ModelArtifact
+    from app.models.dataset_version import DatasetVersion
+    from app.services.jobs_service import create_job
+
+    if not db.get(ModelArtifact, body.artifact_id):
+        raise HTTPException(status_code=400, detail="artifact not found")
+    if not db.get(DatasetVersion, body.dataset_version_id):
+        raise HTTPException(status_code=400, detail="dataset version not found")
+
+    payload = {
+        "artifactId": body.artifact_id,
+        "datasetVersionId": body.dataset_version_id,
+        "iouThreshold": body.iou_threshold,
+        "scoreThreshold": body.score_threshold,
+        "maxAssets": body.max_assets,
+    }
+    job = create_job(db, "error_mining", payload)
+    payload["jobId"] = job.id
+    try:
+        celery_app.send_task("app.jobs.tasks.error_mining.mine_errors", args=[payload])
+    except Exception:
+        # Job row remains queued; a worker can still pick it up later.
+        pass
+    return {"jobId": job.id, "status": "queued"}

--- a/backend/src/app/api/artifacts.py
+++ b/backend/src/app/api/artifacts.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import base64
+import os
+from datetime import timedelta
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 from pydantic import BaseModel
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
 from app.models.artifact import ModelArtifact
 from app.models.dataset import Dataset
 from app.models.dataset_version import DatasetVersion
+from app.models.evaluation import Evaluation
 from app.models.experiment import ExperimentRun
 from app.models.user import User
 from app.schemas.common import Job
@@ -19,28 +23,46 @@ from app.services.onnx_service import export_onnx as svc_export_onnx
 router = APIRouter(prefix="/api", tags=["artifacts"])
 
 
+def _artifact_dict(a: ModelArtifact) -> dict:
+    return {
+        "id": a.id,
+        "projectId": a.project_id,
+        "runId": a.run_id,
+        "name": a.name,
+        "version": a.version,
+        "type": a.type,
+        "format": a.format,
+        "checksum": a.checksum,
+        "sizeBytes": a.size_bytes,
+        "storagePath": a.storage_path,
+        "createdAt": a.created_at.isoformat() if a.created_at else None,
+    }
+
+
 @router.get("/artifacts/models")
 def list_models(
+    project_id: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    artifacts = db.query(ModelArtifact).all()
-    return [
-        {
-            "id": a.id,
-            "projectId": a.project_id,
-            "runId": a.run_id,
-            "name": a.name,
-            "version": a.version,
-            "type": a.type,
-            "format": a.format,
-            "checksum": a.checksum,
-            "sizeBytes": a.size_bytes,
-            "storagePath": a.storage_path,
-            "createdAt": a.created_at.isoformat() if a.created_at else None,
-        }
-        for a in artifacts
-    ]
+    base = select(ModelArtifact)
+    if project_id:
+        base = base.where(ModelArtifact.project_id == project_id)
+    total = db.scalar(select(func.count()).select_from(base.subquery())) or 0
+    offset = (page - 1) * page_size
+    artifacts = list(
+        db.scalars(
+            base.order_by(ModelArtifact.created_at.desc()).offset(offset).limit(page_size)
+        ).all()
+    )
+    return {
+        "items": [_artifact_dict(a) for a in artifacts],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }
 
 
 @router.get("/artifacts/models/{model_id}")
@@ -67,19 +89,85 @@ def get_model(
     }
 
 
+class ExportRequest(BaseModel):
+    cluster_id: str | None = None
+    dynamic_axes: bool = True
+    opset: int | None = None
+
+
 @router.post("/artifacts/models/{model_id}/export", response_model=Job)
 def export_model(
     model_id: str,
+    body: ExportRequest = ExportRequest(),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    from app.services import cluster_service
+
     artifact = db.get(ModelArtifact, model_id)
     if not artifact:
         raise HTTPException(status_code=404, detail="Model not found")
     # Use the artifact's run_id as experiment_id for ONNX export
     experiment_id = artifact.run_id or model_id
-    job = svc_export_onnx(db, experiment_id, dynamic_axes=True)
+    try:
+        job = svc_export_onnx(
+            db,
+            experiment_id,
+            dynamic_axes=body.dynamic_axes,
+            opset=body.opset,
+            cluster_id=body.cluster_id,
+        )
+    except cluster_service.ClusterNotAvailableError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return Job(**job)
+
+
+@router.get("/artifacts/models/{model_id}/download")
+def download_model(
+    model_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return a presigned download URL for the artifact's stored weights.
+
+    Falls back to streaming from the local filesystem if the storage_path is
+    a local path (e.g. tests, sqlite-only environments).
+    """
+    artifact = db.get(ModelArtifact, model_id)
+    if not artifact:
+        raise HTTPException(status_code=404, detail="Model not found")
+    if not artifact.storage_path:
+        raise HTTPException(status_code=404, detail="artifact has no storage_path")
+
+    # Local filesystem path → stream the file directly.
+    if os.path.exists(artifact.storage_path):
+        from fastapi.responses import FileResponse
+
+        filename = os.path.basename(artifact.storage_path) or f"model-{model_id}"
+        return FileResponse(
+            artifact.storage_path,
+            filename=filename,
+            media_type="application/octet-stream",
+        )
+
+    # MinIO key → presigned GET.
+    try:
+        from app.services import storage as storage_module
+
+        client = storage_module.get_minio_client()
+        bucket = os.getenv("MINIO_BUCKET", os.getenv("S3_BUCKET", "visionforge"))
+        url = client.presigned_get_object(bucket, artifact.storage_path, expires=timedelta(hours=1))
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"could not presign download: {exc}") from exc
+
+    filename = os.path.basename(artifact.storage_path) or f"model-{model_id}"
+    return {
+        "url": url,
+        "filename": filename,
+        "size_bytes": artifact.size_bytes,
+        "checksum": artifact.checksum,
+        "expires_in": 3600,
+    }
 
 
 class PredictRequest(BaseModel):
@@ -164,6 +252,12 @@ def get_lineage(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    """Full lineage: training run + dataset + class map + cluster + evaluations."""
+    import json as _json
+
+    from app.models.cluster import Cluster
+    from app.models.dataset import ClassMap
+
     artifact = db.get(ModelArtifact, model_id)
     if not artifact:
         raise HTTPException(status_code=404, detail="Model not found")
@@ -172,15 +266,121 @@ def get_lineage(
         db.get(DatasetVersion, run.dataset_version_id) if run and run.dataset_version_id else None
     )
     dataset = db.get(Dataset, version.dataset_id) if version else None
+    class_map = db.get(ClassMap, dataset.class_map_id) if dataset and dataset.class_map_id else None
+    cluster = db.get(Cluster, run.cluster_id) if run and run.cluster_id else None
+
+    classes: list[str] = []
+    if class_map and class_map.classes:
+        try:
+            parsed = _json.loads(class_map.classes)
+            if isinstance(parsed, list):
+                classes = [str(c) for c in parsed]
+        except Exception:
+            classes = []
+
+    params: dict = {}
+    metrics: dict | list = {}
+    if run:
+        try:
+            params = _json.loads(run.params_json) if run.params_json else {}
+        except Exception:
+            params = {}
+        try:
+            metrics = _json.loads(run.metrics_json) if run.metrics_json else {}
+        except Exception:
+            metrics = {}
+
+    # Sibling artifacts produced by the same run (e.g. ONNX export of this .pt).
+    siblings: list[dict] = []
+    if run:
+        sib_rows = list(
+            db.scalars(
+                select(ModelArtifact).where(
+                    ModelArtifact.run_id == run.id, ModelArtifact.id != artifact.id
+                )
+            ).all()
+        )
+        siblings = [_artifact_dict(s) for s in sib_rows]
+
+    # Evaluations of this artifact.
+    evals = list(
+        db.scalars(
+            select(Evaluation)
+            .where(Evaluation.artifact_id == artifact.id)
+            .order_by(Evaluation.created_at.desc())
+        ).all()
+    )
+    eval_summaries = []
+    for e in evals:
+        primary_name = None
+        primary = None
+        if e.metrics_json:
+            try:
+                m = _json.loads(e.metrics_json) or {}
+                for name in ("mAP50", "mAP_5095", "accuracy", "precision", "recall", "f1"):
+                    if name in m and isinstance(m[name], (int, float)):
+                        primary_name = name
+                        primary = float(m[name])
+                        break
+            except Exception:
+                pass
+        eval_summaries.append(
+            {
+                "id": e.id,
+                "status": e.status,
+                "dataset_version_id": e.dataset_version_id,
+                "primary_metric_name": primary_name,
+                "primary_metric": primary,
+                "created_at": e.created_at.isoformat() if e.created_at else None,
+                "completed_at": e.completed_at.isoformat() if e.completed_at else None,
+            }
+        )
+
     return {
-        "artifact": {
-            "id": artifact.id,
-            "name": artifact.name,
-            "version": artifact.version,
-            "type": artifact.type,
-            "format": artifact.format,
-        },
-        "experiment_run": ({"id": run.id, "name": run.name, "status": run.status} if run else None),
-        "dataset_version": ({"id": version.id, "version": version.version} if version else None),
-        "dataset": ({"id": dataset.id, "name": dataset.name} if dataset else None),
+        "artifact": _artifact_dict(artifact),
+        "experiment_run": (
+            {
+                "id": run.id,
+                "name": run.name,
+                "status": run.status,
+                "params": params,
+                "metrics": metrics,
+                "started_at": run.started_at.isoformat() if run.started_at else None,
+                "completed_at": run.completed_at.isoformat() if run.completed_at else None,
+            }
+            if run
+            else None
+        ),
+        "dataset_version": (
+            {
+                "id": version.id,
+                "version": version.version,
+                "asset_count": version.asset_count,
+                "locked": version.locked,
+            }
+            if version
+            else None
+        ),
+        "dataset": (
+            {
+                "id": dataset.id,
+                "name": dataset.name,
+                "task_type": dataset.task_type,
+            }
+            if dataset
+            else None
+        ),
+        "classes": classes,
+        "cluster": (
+            {
+                "id": cluster.id,
+                "name": cluster.name,
+                "kind": cluster.kind,
+                "gpu_vendor": cluster.gpu_vendor,
+            }
+            if cluster
+            else None
+        ),
+        "siblings": siblings,
+        "evaluations": eval_summaries,
     }

--- a/backend/src/app/api/artifacts.py
+++ b/backend/src/app/api/artifacts.py
@@ -18,6 +18,7 @@ from app.models.experiment import ExperimentRun
 from app.models.user import User
 from app.schemas.common import Job
 from app.services import inference_service
+from app.services.onnx_service import OnnxDispatchError
 from app.services.onnx_service import export_onnx as svc_export_onnx
 
 router = APIRouter(prefix="/api", tags=["artifacts"])
@@ -119,6 +120,8 @@ def export_model(
         )
     except cluster_service.ClusterNotAvailableError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except OnnxDispatchError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     return Job(**job)
 
 

--- a/backend/src/app/api/auth.py
+++ b/backend/src/app/api/auth.py
@@ -92,9 +92,7 @@ def signup(req: SignupRequest, db: Session = Depends(get_db)) -> dict:
             detail="Terms must be accepted",
         )
     try:
-        user = auth_service.register(
-            db, name=req.name, email=str(req.email), password=req.password
-        )
+        user = auth_service.register(db, name=req.name, email=str(req.email), password=req.password)
     except auth_service.EmailAlreadyExistsError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/src/app/api/clusters.py
+++ b/backend/src/app/api/clusters.py
@@ -7,9 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
 from app.models.user import User
-from app.schemas.cluster import (
-    Cluster as ClusterSchema,
-)
+from app.schemas.cluster import Cluster as ClusterSchema
 from app.schemas.cluster import (
     ClusterCreate,
     ClusterHeartbeat,

--- a/backend/src/app/api/datasets.py
+++ b/backend/src/app/api/datasets.py
@@ -14,7 +14,7 @@ from fastapi import (
     UploadFile,
 )
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
@@ -32,6 +32,7 @@ class DatasetCreate(BaseModel):
     name: str
     description: str | None = None
     classes: list[str] | None = None  # initial class list
+    task_type: str | None = None  # "detect" | "classify"
 
 
 class SnapshotRequest(BaseModel):
@@ -42,17 +43,29 @@ class ClassesUpdate(BaseModel):
     classes: list[str]
 
 
+class TaskTypeUpdate(BaseModel):
+    task_type: str  # "detect" | "classify"
+
+
 @router.get("/datasets")
 def list_datasets(
     project_id: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    q = select(Dataset)
+    base = select(Dataset)
     if project_id:
-        q = q.where(Dataset.project_id == project_id)
-    datasets = list(db.scalars(q).all())
-    result = []
+        base = base.where(Dataset.project_id == project_id)
+
+    total = db.scalar(select(func.count()).select_from(base.subquery())) or 0
+    offset = (page - 1) * page_size
+    datasets = list(
+        db.scalars(base.order_by(Dataset.created_at.desc()).offset(offset).limit(page_size)).all()
+    )
+
+    items = []
     for d in datasets:
         latest_v = db.scalars(
             select(DatasetVersion)
@@ -60,19 +73,20 @@ def list_datasets(
             .order_by(DatasetVersion.version.desc())
             .limit(1)
         ).first()
-        result.append(
+        items.append(
             {
                 "id": d.id,
                 "project_id": d.project_id,
                 "name": d.name,
                 "description": d.description,
+                "task_type": d.task_type,
                 "latest_version": latest_v.version if latest_v else None,
                 "latest_version_id": latest_v.id if latest_v else None,
                 "asset_count": latest_v.asset_count if latest_v else 0,
                 "created_at": d.created_at.isoformat() if d.created_at else None,
             }
         )
-    return result
+    return {"items": items, "total": total, "page": page, "page_size": page_size}
 
 
 # NOTE: register the static `/datasets/formats` route BEFORE the dynamic
@@ -113,6 +127,7 @@ def get_dataset(
         "project_id": d.project_id,
         "name": d.name,
         "description": d.description,
+        "task_type": d.task_type,
         "classes": classes,
         "versions": [
             {
@@ -136,7 +151,16 @@ def create_dataset(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    d, v = svc_create_dataset(db, project_id, body.name, body.description)
+    try:
+        d, v = svc_create_dataset(
+            db,
+            project_id,
+            body.name,
+            body.description,
+            task_type=body.task_type,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     # Create ClassMap if classes provided
     if body.classes:
         cm = ClassMap(project_id=project_id, classes=json.dumps(body.classes))
@@ -145,7 +169,36 @@ def create_dataset(
         d.class_map_id = cm.id
         db.add(d)
         db.commit()
-    return {"id": d.id, "project_id": d.project_id, "name": d.name, "activeVersionId": v.id}
+    return {
+        "id": d.id,
+        "project_id": d.project_id,
+        "name": d.name,
+        "task_type": d.task_type,
+        "activeVersionId": v.id,
+    }
+
+
+@router.patch("/datasets/{dataset_id}/task-type")
+def update_dataset_task_type(
+    body: TaskTypeUpdate,
+    dataset_id: str = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    from app.services.project_dataset_service import VALID_TASK_TYPES
+
+    if body.task_type not in VALID_TASK_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"task_type must be one of {list(VALID_TASK_TYPES)}",
+        )
+    d = db.get(Dataset, dataset_id)
+    if not d:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    d.task_type = body.task_type
+    db.add(d)
+    db.commit()
+    return {"id": d.id, "task_type": d.task_type}
 
 
 @router.get("/datasets/{dataset_id}/versions")

--- a/backend/src/app/api/evaluations.py
+++ b/backend/src/app/api/evaluations.py
@@ -8,6 +8,7 @@ from app.models.user import User
 from app.schemas.evaluation import (
     EvaluationCreate,
     EvaluationJobResponse,
+    EvaluationListPage,
     EvaluationOut,
     EvaluationSummary,
 )
@@ -16,21 +17,31 @@ from app.services import cluster_service, evaluation_service
 router = APIRouter(prefix="/api/evaluations", tags=["evaluations"])
 
 
-@router.get("", response_model=list[EvaluationSummary])
+@router.get("", response_model=EvaluationListPage)
 def list_evaluations(
     artifact_id: str | None = Query(None),
     dataset_version_id: str | None = Query(None),
     project_id: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    rows = evaluation_service.list_evaluations(
+    rows, total = evaluation_service.list_evaluations(
         db,
         artifact_id=artifact_id,
         dataset_version_id=dataset_version_id,
         project_id=project_id,
+        page=page,
+        page_size=page_size,
+        return_total=True,
     )
-    return [EvaluationSummary(**evaluation_service.summarize(r)) for r in rows]
+    return EvaluationListPage(
+        items=[EvaluationSummary(**evaluation_service.summarize(r)) for r in rows],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
 
 
 @router.post("", response_model=EvaluationJobResponse, status_code=202)

--- a/backend/src/app/api/experiments.py
+++ b/backend/src/app/api/experiments.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import json
 
-from fastapi import APIRouter, Depends, HTTPException, Path
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
 from app.models.experiment import ExperimentRun as ExperimentModel
 from app.models.user import User
-from app.schemas.experiment import Experiment as ExperimentSchema, ExperimentCreate
+from app.schemas.experiment import Experiment as ExperimentSchema
+from app.schemas.experiment import ExperimentCreate
 
 router = APIRouter(prefix="/api/experiments", tags=["experiments"])
 
@@ -30,13 +31,30 @@ def _run_to_schema(e: ExperimentModel) -> ExperimentSchema:
     )
 
 
-@router.get("/runs", response_model=list[ExperimentSchema] | None)
+@router.get("/runs")
 def list_runs(
+    project_id: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    rows = db.scalars(select(ExperimentModel)).all()
-    return [_run_to_schema(e) for e in rows]
+    base = select(ExperimentModel)
+    if project_id:
+        base = base.where(ExperimentModel.project_id == project_id)
+    total = db.scalar(select(func.count()).select_from(base.subquery())) or 0
+    offset = (page - 1) * page_size
+    rows = list(
+        db.scalars(
+            base.order_by(ExperimentModel.created_at.desc()).offset(offset).limit(page_size)
+        ).all()
+    )
+    return {
+        "items": [_run_to_schema(e).model_dump() for e in rows],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }
 
 
 @router.get("/runs/{runId}", response_model=ExperimentSchema)

--- a/backend/src/app/api/middleware.py
+++ b/backend/src/app/api/middleware.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 import traceback
 import uuid
-from typing import Callable
+from collections.abc import Callable
 
 import structlog
 from fastapi.responses import JSONResponse
@@ -38,6 +38,7 @@ _WINDOW_SECONDS = 60
 
 def auth_rate_limit_middleware():
     """Simple in-memory rate limiter for /auth/* endpoints."""
+
     async def _mw(request, call_next: Callable):
         if request.url.path.startswith("/auth/"):
             client_ip = request.client.host if request.client else "unknown"

--- a/backend/src/app/api/ops.py
+++ b/backend/src/app/api/ops.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
@@ -14,6 +14,7 @@ from app.schemas.common import (
 )
 from app.services import cluster_service
 from app.services.ingest_service import get_presigned_upload
+from app.services.onnx_service import OnnxDispatchError
 from app.services.onnx_service import export_onnx as svc_export_onnx
 from app.services.training_service import TaskTypeMismatch, launch_training
 
@@ -72,6 +73,8 @@ def export_onnx(
         )
     except cluster_service.ClusterNotAvailableError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except OnnxDispatchError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     return Job(**job)
 
 
@@ -144,14 +147,18 @@ def _probe_storage() -> dict[str, str]:
 def trigger_frame_extraction(
     dataset_id: str,
     asset_id: str,
-    fps_interval: float = 1.0,
+    # Reject zero/negative intervals up-front: the worker uses this as a
+    # divisor when computing the frame step, so a 0 or negative value would
+    # blow up partway through. Cap at 600s so a typo can't queue a job that
+    # extracts a single frame from a 10-minute video.
+    fps_interval: float = Query(1.0, gt=0.0, le=600.0),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """Queue a frame-extraction Celery task for a video asset."""
     from app.jobs.celery_app import celery_app
     from app.models.asset import Asset
-    from app.services.jobs_service import create_job
+    from app.services.jobs_service import create_job, update_job_status
 
     asset = db.get(Asset, asset_id)
     if not asset:
@@ -173,8 +180,13 @@ def trigger_frame_extraction(
     payload["jobId"] = job.id
     try:
         celery_app.send_task("app.jobs.tasks.frame_extraction.extract_frames", args=[payload])
-    except Exception:
-        # Job row remains queued; a worker can still pick it up when broker
-        # recovers. Surface that to the caller via job status only.
-        pass
+    except Exception as exc:
+        # Don't leave the job stuck in `queued` if the broker is down.
+        try:
+            update_job_status(db, job.id, status="failed", progress=0.0)
+        except Exception:
+            pass
+        raise HTTPException(
+            status_code=503, detail=f"failed to dispatch frame extraction: {exc}"
+        ) from exc
     return {"jobId": job.id, "status": "queued", "fpsInterval": fps_interval}

--- a/backend/src/app/api/ops.py
+++ b/backend/src/app/api/ops.py
@@ -15,7 +15,7 @@ from app.schemas.common import (
 from app.services import cluster_service
 from app.services.ingest_service import get_presigned_upload
 from app.services.onnx_service import export_onnx as svc_export_onnx
-from app.services.training_service import launch_training
+from app.services.training_service import TaskTypeMismatch, launch_training
 
 router = APIRouter(prefix="/api", tags=["ops"])
 
@@ -55,6 +55,8 @@ def train(
         )
     except cluster_service.ClusterNotAvailableError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except TaskTypeMismatch as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return Job(**job)
 
 
@@ -71,3 +73,108 @@ def export_onnx(
     except cluster_service.ClusterNotAvailableError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     return Job(**job)
+
+
+@router.get("/system/status")
+def system_status(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Live health for the home-page status panel.
+
+    Probes API (always ok), DB, queue (Celery broker via ``ping`` inspect),
+    and object storage (MinIO list-buckets). Each subsystem returns one of
+    ``ok | degraded | down`` plus a short ``detail`` string.
+    """
+    components: dict[str, dict] = {}
+
+    components["api"] = {"status": "ok", "detail": "responding"}
+
+    try:
+        from sqlalchemy import text
+
+        db.execute(text("SELECT 1"))
+        components["database"] = {"status": "ok", "detail": "reachable"}
+    except Exception as exc:  # pragma: no cover - depends on environment
+        components["database"] = {"status": "down", "detail": str(exc)[:120]}
+
+    components["queue"] = _probe_queue()
+    components["storage"] = _probe_storage()
+
+    statuses = {c["status"] for c in components.values()}
+    overall = "down" if "down" in statuses else "degraded" if "degraded" in statuses else "ok"
+    return {"status": overall, "components": components}
+
+
+def _probe_queue() -> dict[str, str]:
+    """Ping Celery; degrades gracefully if the broker isn't reachable."""
+    try:
+        from app.jobs.celery_app import celery_app
+
+        replies = celery_app.control.ping(timeout=1.0) or []
+    except Exception as exc:  # pragma: no cover - depends on environment
+        return {"status": "down", "detail": f"ping failed: {exc}"[:120]}
+    if replies:
+        return {"status": "ok", "detail": f"{len(replies)} worker(s) online"}
+    return {"status": "degraded", "detail": "no workers responding"}
+
+
+def _probe_storage() -> dict[str, str]:
+    """Verify the MinIO bucket exists. Treats a missing client as 'down'."""
+    import os
+
+    if os.getenv("MINIO_DISABLED", "false").lower() == "true":
+        return {"status": "degraded", "detail": "MINIO_DISABLED=true"}
+    try:
+        from app.services import storage as storage_module
+
+        client = storage_module.get_minio_client()
+        bucket = os.getenv("MINIO_BUCKET", os.getenv("S3_BUCKET", "visionforge"))
+        if client.bucket_exists(bucket):
+            return {"status": "ok", "detail": f"bucket {bucket} reachable"}
+        return {"status": "degraded", "detail": f"bucket {bucket} missing"}
+    except Exception as exc:  # pragma: no cover - depends on environment
+        return {"status": "down", "detail": str(exc)[:120]}
+
+
+@router.post(
+    "/datasets/{dataset_id}/assets/{asset_id}/extract-frames",
+    status_code=202,
+)
+def trigger_frame_extraction(
+    dataset_id: str,
+    asset_id: str,
+    fps_interval: float = 1.0,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Queue a frame-extraction Celery task for a video asset."""
+    from app.jobs.celery_app import celery_app
+    from app.models.asset import Asset
+    from app.services.jobs_service import create_job
+
+    asset = db.get(Asset, asset_id)
+    if not asset:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    if asset.dataset_id != dataset_id:
+        raise HTTPException(status_code=400, detail="asset does not belong to dataset")
+    mime = (asset.mime_type or "").lower()
+    if not mime.startswith("video/") and not asset.uri.lower().endswith(
+        (".mp4", ".mov", ".avi", ".mkv", ".webm")
+    ):
+        raise HTTPException(status_code=400, detail="asset is not a video")
+
+    payload = {
+        "assetId": asset.id,
+        "datasetVersionId": asset.version_id,
+        "fpsInterval": float(fps_interval),
+    }
+    job = create_job(db, "frame_extraction", payload)
+    payload["jobId"] = job.id
+    try:
+        celery_app.send_task("app.jobs.tasks.frame_extraction.extract_frames", args=[payload])
+    except Exception:
+        # Job row remains queued; a worker can still pick it up when broker
+        # recovers. Surface that to the caller via job status only.
+        pass
+    return {"jobId": job.id, "status": "queued", "fpsInterval": fps_interval}

--- a/backend/src/app/api/projects.py
+++ b/backend/src/app/api/projects.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query
-from pydantic import BaseModel
-from sqlalchemy import select
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
@@ -10,6 +10,10 @@ from app.models.dataset import Dataset
 from app.models.project import Project as ProjectModel
 from app.models.user import User
 from app.models.workspace import Membership, Workspace
+from app.services.project_dataset_service import (
+    VALID_TASK_TYPES,
+)
+from app.services.project_dataset_service import create_dataset as svc_create_dataset
 from app.services.project_dataset_service import create_project as svc_create_project
 
 router = APIRouter(prefix="/api", tags=["projects"])
@@ -21,36 +25,87 @@ class ProjectCreate(BaseModel):
     name: str
     description: str | None = None
     workspace_id: str | None = None
+    task_type: str | None = Field(
+        default=None,
+        description="'detect' or 'classify'. Leave unset for legacy projects.",
+    )
+
+
+class ProjectUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    task_type: str | None = None
+
+
+class WizardClassSpec(BaseModel):
+    name: str
+    color: str | None = None
+    description: str | None = None
+
+
+class ProjectWizard(BaseModel):
+    """Single-shot endpoint that powers the multi-step new-project wizard.
+
+    Creates the project, an initial dataset with its first version, and the
+    project ClassMap in one transaction so partial state never leaks to the UI.
+    """
+
+    name: str
+    description: str | None = None
+    workspace_id: str | None = None
+    task_type: str
+    dataset_name: str = "default"
+    dataset_description: str | None = None
+    classes: list[WizardClassSpec] = Field(default_factory=list)
+
+
+def _list_class_names(items: list[WizardClassSpec]) -> list[str]:
+    return [c.name for c in items]
 
 
 @router.get("/projects")
 def list_projects(
     workspace_id: str | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    # Gather workspace IDs the user belongs to
     memberships = list(
         db.scalars(select(Membership).where(Membership.user_id == current_user.id)).all()
     )
     ws_ids = list({m.workspace_id for m in memberships} | {_DEFAULT_WORKSPACE_ID})
 
-    q = select(ProjectModel).where(ProjectModel.workspace_id.in_(ws_ids))
+    base = select(ProjectModel)
     if workspace_id:
-        q = select(ProjectModel).where(ProjectModel.workspace_id == workspace_id)
+        base = base.where(ProjectModel.workspace_id == workspace_id)
+    else:
+        base = base.where(ProjectModel.workspace_id.in_(ws_ids))
 
-    rows = list(db.scalars(q).all())
-    return [
-        {
-            "id": p.id,
-            "name": p.name,
-            "description": p.description,
-            "workspace_id": p.workspace_id,
-            "status": p.status,
-            "created_at": p.created_at.isoformat() if p.created_at else None,
-        }
-        for p in rows
-    ]
+    total = db.scalar(select(func.count()).select_from(base.subquery())) or 0
+    offset = (page - 1) * page_size
+    rows = list(
+        db.scalars(
+            base.order_by(ProjectModel.created_at.desc()).offset(offset).limit(page_size)
+        ).all()
+    )
+    return {
+        "items": [
+            {
+                "id": p.id,
+                "name": p.name,
+                "description": p.description,
+                "workspace_id": p.workspace_id,
+                "status": p.status,
+                "task_type": p.task_type,
+                "created_at": p.created_at.isoformat() if p.created_at else None,
+            }
+            for p in rows
+        ],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }
 
 
 @router.get("/projects/{project_id}")
@@ -62,15 +117,14 @@ def get_project(
     p = db.get(ProjectModel, project_id)
     if not p:
         raise HTTPException(status_code=404, detail="Project not found")
-    datasets = list(
-        db.scalars(select(Dataset).where(Dataset.project_id == project_id)).all()
-    )
+    datasets = list(db.scalars(select(Dataset).where(Dataset.project_id == project_id)).all())
     return {
         "id": p.id,
         "name": p.name,
         "description": p.description,
         "workspace_id": p.workspace_id,
         "status": p.status,
+        "task_type": p.task_type,
         "dataset_count": len(datasets),
         "created_at": p.created_at.isoformat() if p.created_at else None,
     }
@@ -82,25 +136,132 @@ def create_project(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    # Resolve workspace_id: use provided or fall back to default
     workspace_id = payload.workspace_id or _DEFAULT_WORKSPACE_ID
     ws = db.get(Workspace, workspace_id)
     if not ws:
         workspace_id = _DEFAULT_WORKSPACE_ID
 
-    p = svc_create_project(db, payload.name, payload.description)
-    # Update workspace_id if it differs from the service default
-    if p.workspace_id != workspace_id:
-        p.workspace_id = workspace_id
-        db.add(p)
-        db.commit()
-        db.refresh(p)
+    if payload.task_type is not None and payload.task_type not in VALID_TASK_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"task_type must be one of {list(VALID_TASK_TYPES)}",
+        )
+
+    try:
+        p = svc_create_project(
+            db,
+            payload.name,
+            payload.description,
+            task_type=payload.task_type,
+            workspace_id=workspace_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     return {
         "id": p.id,
         "name": p.name,
         "description": p.description,
         "workspace_id": p.workspace_id,
         "status": p.status,
+        "task_type": p.task_type,
+    }
+
+
+@router.patch("/projects/{project_id}")
+def update_project(
+    payload: ProjectUpdate,
+    project_id: str = Path(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    p = db.get(ProjectModel, project_id)
+    if not p:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if payload.task_type is not None and payload.task_type not in VALID_TASK_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"task_type must be one of {list(VALID_TASK_TYPES)}",
+        )
+    if payload.name is not None:
+        p.name = payload.name
+    if payload.description is not None:
+        p.description = payload.description
+    if payload.task_type is not None:
+        p.task_type = payload.task_type
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return {
+        "id": p.id,
+        "name": p.name,
+        "description": p.description,
+        "task_type": p.task_type,
+    }
+
+
+@router.post("/projects/wizard", status_code=201)
+def project_wizard(
+    payload: ProjectWizard,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Multi-step wizard endpoint. See ``ProjectWizard`` for fields."""
+    if payload.task_type not in VALID_TASK_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"task_type must be one of {list(VALID_TASK_TYPES)}",
+        )
+
+    workspace_id = payload.workspace_id or _DEFAULT_WORKSPACE_ID
+    ws = db.get(Workspace, workspace_id)
+    if not ws:
+        workspace_id = _DEFAULT_WORKSPACE_ID
+
+    project = svc_create_project(
+        db,
+        payload.name,
+        payload.description,
+        task_type=payload.task_type,
+        workspace_id=workspace_id,
+    )
+
+    dataset, version = svc_create_dataset(
+        db,
+        project.id,
+        payload.dataset_name or "default",
+        payload.dataset_description,
+        task_type=payload.task_type,
+    )
+
+    if payload.classes:
+        import json
+
+        from app.models.dataset import ClassMap
+
+        cm = ClassMap(
+            project_id=project.id,
+            classes=json.dumps(_list_class_names(payload.classes)),
+        )
+        db.add(cm)
+        db.flush()
+        dataset.class_map_id = cm.id
+        db.add(dataset)
+        db.commit()
+
+    return {
+        "project": {
+            "id": project.id,
+            "name": project.name,
+            "task_type": project.task_type,
+        },
+        "dataset": {
+            "id": dataset.id,
+            "name": dataset.name,
+            "task_type": dataset.task_type,
+        },
+        "version": {"id": version.id, "version": version.version},
+        "classes": _list_class_names(payload.classes),
     }
 
 
@@ -110,14 +271,13 @@ def list_project_datasets(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    datasets = list(
-        db.scalars(select(Dataset).where(Dataset.project_id == project_id)).all()
-    )
+    datasets = list(db.scalars(select(Dataset).where(Dataset.project_id == project_id)).all())
     return [
         {
             "id": d.id,
             "name": d.name,
             "description": d.description,
+            "task_type": d.task_type,
             "created_at": d.created_at.isoformat() if d.created_at else None,
         }
         for d in datasets

--- a/backend/src/app/api/projects.py
+++ b/backend/src/app/api/projects.py
@@ -206,7 +206,12 @@ def project_wizard(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Multi-step wizard endpoint. See ``ProjectWizard`` for fields."""
+    """Multi-step wizard endpoint. See ``ProjectWizard`` for fields.
+
+    All four objects (project, dataset, initial version, class map) are
+    created in a single DB transaction. If any step fails the whole thing
+    rolls back, so we never leak a half-built project to the UI.
+    """
     if payload.task_type not in VALID_TASK_TYPES:
         raise HTTPException(
             status_code=400,
@@ -218,36 +223,47 @@ def project_wizard(
     if not ws:
         workspace_id = _DEFAULT_WORKSPACE_ID
 
-    project = svc_create_project(
-        db,
-        payload.name,
-        payload.description,
-        task_type=payload.task_type,
-        workspace_id=workspace_id,
-    )
+    import json as _json
 
-    dataset, version = svc_create_dataset(
-        db,
-        project.id,
-        payload.dataset_name or "default",
-        payload.dataset_description,
-        task_type=payload.task_type,
-    )
+    from app.models.dataset import ClassMap
 
-    if payload.classes:
-        import json
-
-        from app.models.dataset import ClassMap
-
-        cm = ClassMap(
-            project_id=project.id,
-            classes=json.dumps(_list_class_names(payload.classes)),
+    try:
+        project = svc_create_project(
+            db,
+            payload.name,
+            payload.description,
+            task_type=payload.task_type,
+            workspace_id=workspace_id,
+            commit=False,
         )
-        db.add(cm)
-        db.flush()
-        dataset.class_map_id = cm.id
-        db.add(dataset)
+
+        dataset, version = svc_create_dataset(
+            db,
+            project.id,
+            payload.dataset_name or "default",
+            payload.dataset_description,
+            task_type=payload.task_type,
+            commit=False,
+        )
+
+        if payload.classes:
+            cm = ClassMap(
+                project_id=project.id,
+                classes=_json.dumps(_list_class_names(payload.classes)),
+            )
+            db.add(cm)
+            db.flush()
+            dataset.class_map_id = cm.id
+            db.add(dataset)
+            db.flush()
+
         db.commit()
+        db.refresh(project)
+        db.refresh(dataset)
+        db.refresh(version)
+    except Exception:
+        db.rollback()
+        raise
 
     return {
         "project": {

--- a/backend/src/app/api/workspaces.py
+++ b/backend/src/app/api/workspaces.py
@@ -37,9 +37,7 @@ def list_workspaces(
         else []
     )
     # Also include workspaces created by user
-    own = list(
-        db.scalars(select(Workspace).where(Workspace.created_by == current_user.id)).all()
-    )
+    own = list(db.scalars(select(Workspace).where(Workspace.created_by == current_user.id)).all())
     all_ws = {w.id: w for w in workspaces_by_membership + own}
     return [
         {
@@ -125,9 +123,7 @@ def invite_member(
     if not ws:
         raise HTTPException(status_code=404, detail="Workspace not found")
     # Look up user by email
-    invited_user = db.scalars(
-        select(User).where(User.email == body.email)
-    ).first()
+    invited_user = db.scalars(select(User).where(User.email == body.email)).first()
     if not invited_user:
         raise HTTPException(status_code=404, detail="User not found")
     # Check if already a member

--- a/backend/src/app/db/migrations/env.py
+++ b/backend/src/app/db/migrations/env.py
@@ -20,6 +20,7 @@ if config.config_file_name is not None:
 
 # Add your model's MetaData object here for 'autogenerate' support
 from app.db.base import Base
+
 target_metadata = Base.metadata
 
 # Override URL from environment: prefer DATABASE_URL, else derive from POSTGRES_* vars
@@ -30,6 +31,7 @@ if not database_url:
         f"{os.getenv('POSTGRES_HOST','localhost')}:{os.getenv('POSTGRES_PORT','5432')}/{os.getenv('POSTGRES_DB','visionforge')}"
     )
 config.set_main_option("sqlalchemy.url", database_url)
+
 
 def run_migrations_offline():
     url = config.get_main_option("sqlalchemy.url")

--- a/backend/src/app/db/migrations/versions/0001_initial_schema.py
+++ b/backend/src/app/db/migrations/versions/0001_initial_schema.py
@@ -5,8 +5,8 @@ Revises:
 Create Date: 2025-09-23
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "0001_initial_schema"

--- a/backend/src/app/db/migrations/versions/0002_add_missing_columns.py
+++ b/backend/src/app/db/migrations/versions/0002_add_missing_columns.py
@@ -5,8 +5,8 @@ Revises: 0001_initial_schema
 Create Date: 2026-03-15
 """
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = "0002_add_missing_columns"
 down_revision = "0001_initial_schema"

--- a/backend/src/app/db/migrations/versions/0007_phase2_task_type_and_review.py
+++ b/backend/src/app/db/migrations/versions/0007_phase2_task_type_and_review.py
@@ -1,0 +1,99 @@
+"""Add Project/Dataset task_type, annotation review workflow fields.
+
+Adds the columns Phase 2 needs:
+  * `projects.task_type`     — "detect" | "classify" (or NULL legacy)
+  * `datasets.task_type`     — same enum, denormalised on the dataset
+  * `annotations.review_status`   — "unreviewed" | "approved" | "rejected"
+  * `annotations.reviewer_id`     — FK to users.id
+  * `annotations.reviewed_at`     — timestamp the review was recorded
+  * `annotations.review_notes`    — free-text reviewer comment
+  * `annotations.flagged`         — bool, set by the error-mining task
+  * `annotations.flag_reason`     — short string set alongside `flagged`
+
+Revision ID: 0007_phase2_task_type_and_review
+Revises: 0006_annotation_versioning
+Create Date: 2026-05-09
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0007_phase2_task_type_and_review"
+down_revision = "0006_annotation_versioning"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "projects",
+        sa.Column("task_type", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "datasets",
+        sa.Column("task_type", sa.String(length=32), nullable=True),
+    )
+
+    op.add_column(
+        "annotations",
+        sa.Column(
+            "review_status",
+            sa.String(length=32),
+            nullable=False,
+            server_default="unreviewed",
+        ),
+    )
+    op.add_column(
+        "annotations",
+        sa.Column(
+            "reviewer_id",
+            sa.String(length=36),
+            sa.ForeignKey("users.id"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "annotations",
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "annotations",
+        sa.Column("review_notes", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "annotations",
+        sa.Column(
+            "flagged",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column(
+        "annotations",
+        sa.Column("flag_reason", sa.String(length=255), nullable=True),
+    )
+
+    op.create_index(
+        "ix_annotations_review_status",
+        "annotations",
+        ["review_status"],
+    )
+    op.create_index(
+        "ix_annotations_flagged",
+        "annotations",
+        ["flagged"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_annotations_flagged", table_name="annotations")
+    op.drop_index("ix_annotations_review_status", table_name="annotations")
+    op.drop_column("annotations", "flag_reason")
+    op.drop_column("annotations", "flagged")
+    op.drop_column("annotations", "review_notes")
+    op.drop_column("annotations", "reviewed_at")
+    op.drop_column("annotations", "reviewer_id")
+    op.drop_column("annotations", "review_status")
+    op.drop_column("datasets", "task_type")
+    op.drop_column("projects", "task_type")

--- a/backend/src/app/db/session.py
+++ b/backend/src/app/db/session.py
@@ -22,6 +22,7 @@ def _db_url() -> str:
     db = os.getenv("POSTGRES_DB", "visionforge")
     return f"postgresql+psycopg2://{user}:{pwd}@{host}:{port}/{db}"
 
+
 url = _db_url()
 connect_args = {"check_same_thread": False} if url.startswith("sqlite") else {}
 engine = create_engine(url, pool_pre_ping=True, future=True, connect_args=connect_args)

--- a/backend/src/app/jobs/celery_app.py
+++ b/backend/src/app/jobs/celery_app.py
@@ -27,6 +27,16 @@ if Celery is not None:
         "visionforge",
         broker=redis_url,
         backend=redis_url,
+        include=[
+            "app.jobs.tasks.training",
+            "app.jobs.tasks.evaluation",
+            "app.jobs.tasks.onnx_export",
+            "app.jobs.tasks.frame_extraction",
+            "app.jobs.tasks.embeddings",
+            "app.jobs.tasks.prelabels",
+            "app.jobs.tasks.uncertainty",
+            "app.jobs.tasks.error_mining",
+        ],
     )
     celery_app.conf.task_routes = {
         "app.jobs.tasks.*": {"queue": "default"},

--- a/backend/src/app/jobs/celery_app.py
+++ b/backend/src/app/jobs/celery_app.py
@@ -36,6 +36,7 @@ if Celery is not None:
             "app.jobs.tasks.prelabels",
             "app.jobs.tasks.uncertainty",
             "app.jobs.tasks.error_mining",
+            "app.jobs.tasks.al_uncertainty",
         ],
     )
     celery_app.conf.task_routes = {

--- a/backend/src/app/jobs/tasks/al_uncertainty.py
+++ b/backend/src/app/jobs/tasks/al_uncertainty.py
@@ -1,0 +1,151 @@
+"""Celery task: precompute per-asset uncertainty scores for active learning.
+
+The AL select endpoint (`/api/al/select`) only scores up to
+``VF_AL_INLINE_SCORE_CAP`` assets inline so the API stays fast. For full-pool
+scoring, dispatch this task — it runs the chosen artifact over every asset
+in the version and stores the score (margin = ``1 - top_score``) into
+``Asset.meta_data["uncertainty"]``. Subsequent ``/api/al/select`` calls will
+read those cached values instead of running inference again.
+
+Heavy ML deps are imported lazily so the module is safe to load in tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+try:
+    from celery import shared_task  # type: ignore
+except Exception:  # pragma: no cover
+
+    def shared_task(*args, **kwargs):
+        def _wrap(fn):
+            return fn
+
+        return _wrap
+
+
+def _make_session():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    db_url = os.getenv("DATABASE_URL", "sqlite+pysqlite:///./test.db")
+    connect_args = {"check_same_thread": False} if db_url.startswith("sqlite") else {}
+    engine = create_engine(db_url, connect_args=connect_args)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False)()
+
+
+def _top_score(result: dict | list) -> float:
+    if isinstance(result, dict):
+        cls_pred = result.get("classification")
+        if isinstance(cls_pred, dict) and "score" in cls_pred:
+            try:
+                return float(cls_pred["score"])
+            except Exception:
+                pass
+        if "top_score" in result:
+            try:
+                return float(result["top_score"])
+            except Exception:
+                pass
+        boxes = result.get("detections") or result.get("predictions") or []
+    elif isinstance(result, list):
+        boxes = result
+    else:
+        boxes = []
+    best = 0.0
+    for b in boxes:
+        score = b.get("score") or b.get("confidence") or 0.0
+        try:
+            score = float(score)
+        except Exception:
+            continue
+        if score > best:
+            best = score
+    return best
+
+
+@shared_task(name="app.jobs.tasks.al_uncertainty.score_assets")
+def score_assets(payload: dict) -> dict:
+    job_id = payload.get("jobId")
+    artifact_id = payload.get("artifactId")
+    version_id = payload.get("datasetVersionId")
+    max_assets = int(payload.get("maxAssets", 0)) or None
+
+    db = _make_session()
+    scored = 0
+    skipped = 0
+    try:
+        from sqlalchemy import select
+
+        from app.models.artifact import ModelArtifact
+        from app.models.asset import Asset
+        from app.services import inference_service
+        from app.services.asset_fetch import fetch_asset_bytes
+        from app.services.jobs_service import update_job_status
+
+        if job_id:
+            update_job_status(db, job_id, status="running", progress=0.05)
+
+        artifact = db.get(ModelArtifact, artifact_id)
+        if artifact is None:
+            raise RuntimeError("artifact not found")
+
+        assets = list(
+            db.scalars(
+                select(Asset)
+                .where(Asset.version_id == version_id)
+                .where(Asset.label_status.in_(("unlabeled", "unlabelled", "in_progress")))
+            ).all()
+        )
+        if max_assets:
+            assets = assets[:max_assets]
+
+        for i, asset in enumerate(assets):
+            image_bytes = fetch_asset_bytes(asset.uri)
+            if not image_bytes:
+                skipped += 1
+                continue
+            try:
+                result = inference_service.predict(artifact, image_bytes, score_threshold=0.0)
+            except Exception:
+                skipped += 1
+                continue
+            margin = 1.0 - _top_score(result)
+            try:
+                meta = json.loads(asset.meta_data) if asset.meta_data else {}
+            except Exception:
+                meta = {}
+            if not isinstance(meta, dict):
+                meta = {}
+            meta["uncertainty"] = float(margin)
+            meta["uncertainty_artifact_id"] = artifact.id
+            asset.meta_data = json.dumps(meta)
+            db.add(asset)
+            scored += 1
+            if (i + 1) % 25 == 0:
+                db.commit()
+                if job_id:
+                    update_job_status(
+                        db,
+                        job_id,
+                        status="running",
+                        progress=0.1 + 0.85 * (i / max(1, len(assets))),
+                    )
+
+        db.commit()
+        if job_id:
+            update_job_status(db, job_id, status="succeeded", progress=1.0)
+        return {"status": "succeeded", "scored": scored, "skipped": skipped}
+    except Exception as exc:  # noqa: BLE001
+        try:
+            from app.services.jobs_service import update_job_status as _us
+
+            if job_id:
+                _us(db, job_id, status="failed", progress=0.0)
+        except Exception:
+            pass
+        return {"status": "failed", "error": str(exc)}
+    finally:
+        db.close()

--- a/backend/src/app/jobs/tasks/embeddings.py
+++ b/backend/src/app/jobs/tasks/embeddings.py
@@ -8,9 +8,11 @@ from pathlib import Path
 try:
     from celery import shared_task  # type: ignore
 except Exception:  # pragma: no cover
+
     def shared_task(*args, **kwargs):
         def _wrap(fn):
             return fn
+
         return _wrap
 
 
@@ -28,7 +30,7 @@ def _extract_minio_key(uri: str) -> str:
     """Extract the object key from an asset URI."""
     for prefix in ("s3://", "minio://"):
         if uri.startswith(prefix):
-            parts = uri[len(prefix):].split("/", 1)
+            parts = uri[len(prefix) :].split("/", 1)
             return parts[1] if len(parts) > 1 else uri
     if uri.startswith("http://") or uri.startswith("https://"):
         path = uri.split("/", 3)
@@ -141,6 +143,7 @@ def generate_embeddings(payload: dict) -> dict:
         try:
             if job_id:
                 from app.services.jobs_service import update_job_status
+
                 update_job_status(db, job_id, status="failed", progress=0.0)
         except Exception:
             pass

--- a/backend/src/app/jobs/tasks/error_mining.py
+++ b/backend/src/app/jobs/tasks/error_mining.py
@@ -54,27 +54,17 @@ def _iou(a: tuple[float, ...], b: tuple[float, ...]) -> float:
 
 
 def _predict_boxes(artifact, asset, score_threshold: float) -> list[dict[str, Any]]:
-    """Run the cached inference service against ``asset``. Returns det dicts."""
-    from urllib.request import urlopen
+    """Run the cached inference service against ``asset``. Returns det dicts.
 
-    from app.services import inference_service, storage
+    Asset URIs are resolved through ``fetch_asset_bytes`` which enforces the
+    SSRF policy (object-store keys + opt-in remote URLs with private-IP
+    blocklist). Any fetch or inference failure returns an empty prediction
+    list so the caller can keep iterating.
+    """
+    from app.services import inference_service
+    from app.services.asset_fetch import fetch_asset_bytes
 
-    image_bytes: bytes | None = None
-    try:
-        if asset.uri.startswith(("http://", "https://")):
-            with urlopen(asset.uri, timeout=10) as response:  # noqa: S310
-                image_bytes = response.read()
-        elif asset.uri:
-            client = storage.get_minio_client()
-            bucket = os.getenv("MINIO_BUCKET", os.getenv("S3_BUCKET", "visionforge"))
-            resp = client.get_object(bucket, asset.uri)
-            try:
-                image_bytes = resp.read()
-            finally:
-                resp.close()
-                resp.release_conn()
-    except Exception:
-        return []
+    image_bytes = fetch_asset_bytes(asset.uri)
     if not image_bytes:
         return []
     try:

--- a/backend/src/app/jobs/tasks/error_mining.py
+++ b/backend/src/app/jobs/tasks/error_mining.py
@@ -1,0 +1,216 @@
+"""Celery task: flag annotations whose model predictions disagree.
+
+Runs an existing artifact over labelled assets in a dataset version. For
+each ground-truth annotation, finds the best-IoU same-class prediction. If
+the best IoU is below ``iou_threshold`` the annotation is flagged with a
+short reason; otherwise the flag is cleared.
+
+The intent is to surface likely mislabels in the review queue without
+requiring a full evaluation run.
+
+Heavy ML deps are imported lazily so the module is safe to load in tests
+where those wheels are absent.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from typing import Any
+
+try:
+    from celery import shared_task  # type: ignore
+except Exception:  # pragma: no cover
+
+    def shared_task(*args, **kwargs):
+        def _wrap(fn):
+            return fn
+
+        return _wrap
+
+
+def _make_session():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    db_url = os.getenv("DATABASE_URL", "sqlite+pysqlite:///./test.db")
+    connect_args = {"check_same_thread": False} if db_url.startswith("sqlite") else {}
+    engine = create_engine(db_url, connect_args=connect_args)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False)()
+
+
+def _iou(a: tuple[float, ...], b: tuple[float, ...]) -> float:
+    ax1, ay1, aw, ah = a
+    bx1, by1, bw, bh = b
+    ax2, ay2 = ax1 + aw, ay1 + ah
+    bx2, by2 = bx1 + bw, by1 + bh
+    ix1, iy1 = max(ax1, bx1), max(ay1, by1)
+    ix2, iy2 = min(ax2, bx2), min(ay2, by2)
+    iw, ih = max(0.0, ix2 - ix1), max(0.0, iy2 - iy1)
+    inter = iw * ih
+    union = max(0.0, aw) * max(0.0, ah) + max(0.0, bw) * max(0.0, bh) - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _predict_boxes(artifact, asset, score_threshold: float) -> list[dict[str, Any]]:
+    """Run the cached inference service against ``asset``. Returns det dicts."""
+    from urllib.request import urlopen
+
+    from app.services import inference_service, storage
+
+    image_bytes: bytes | None = None
+    try:
+        if asset.uri.startswith(("http://", "https://")):
+            with urlopen(asset.uri, timeout=10) as response:  # noqa: S310
+                image_bytes = response.read()
+        elif asset.uri:
+            client = storage.get_minio_client()
+            bucket = os.getenv("MINIO_BUCKET", os.getenv("S3_BUCKET", "visionforge"))
+            resp = client.get_object(bucket, asset.uri)
+            try:
+                image_bytes = resp.read()
+            finally:
+                resp.close()
+                resp.release_conn()
+    except Exception:
+        return []
+    if not image_bytes:
+        return []
+    try:
+        result = inference_service.predict(artifact, image_bytes, score_threshold=score_threshold)
+    except Exception:
+        return []
+    return list(result.get("detections") or [])
+
+
+def _flag_annotation(db, ann, *, reason: str | None) -> None:
+    if reason is None:
+        if ann.flagged:
+            ann.flagged = False
+            ann.flag_reason = None
+            db.add(ann)
+    else:
+        ann.flagged = True
+        ann.flag_reason = reason[:255]
+        db.add(ann)
+
+
+@shared_task(name="app.jobs.tasks.error_mining.mine_errors")
+def mine_errors(payload: dict) -> dict:
+    job_id = payload.get("jobId")
+    artifact_id = payload.get("artifactId")
+    version_id = payload.get("datasetVersionId")
+    iou_threshold = float(payload.get("iouThreshold", 0.5))
+    score_threshold = float(payload.get("scoreThreshold", 0.25))
+    max_assets = int(payload.get("maxAssets", 0)) or None
+
+    db = _make_session()
+    try:
+        from sqlalchemy import select
+
+        from app.models.annotation import Annotation
+        from app.models.artifact import ModelArtifact
+        from app.models.asset import Asset
+        from app.services.jobs_service import update_job_status
+
+        if job_id:
+            update_job_status(db, job_id, status="running", progress=0.05)
+
+        artifact = db.get(ModelArtifact, artifact_id)
+        if not artifact:
+            raise RuntimeError("artifact not found")
+
+        assets = list(
+            db.scalars(
+                select(Asset)
+                .where(Asset.version_id == version_id)
+                .where(Asset.label_status.in_(("labeled", "in_progress")))
+            ).all()
+        )
+        if max_assets:
+            assets = assets[:max_assets]
+
+        flagged = 0
+        cleared = 0
+        scanned = 0
+
+        for i, asset in enumerate(assets):
+            anns = list(
+                db.scalars(
+                    select(Annotation)
+                    .where(Annotation.asset_id == asset.id)
+                    .where(Annotation.type == "box")
+                ).all()
+            )
+            if not anns:
+                continue
+            preds = _predict_boxes(artifact, asset, score_threshold)
+            # Group preds by class for fast lookup
+            by_class: dict[str, list[dict[str, Any]]] = defaultdict(list)
+            for p in preds:
+                by_class[p.get("class") or ""].append(p)
+
+            for ann in anns:
+                scanned += 1
+                try:
+                    g = json.loads(ann.geometry)
+                    gt_box = (
+                        float(g.get("x", 0)),
+                        float(g.get("y", 0)),
+                        float(g.get("w", 0)),
+                        float(g.get("h", 0)),
+                    )
+                except Exception:
+                    continue
+                cls = ann.class_name or ""
+                same_class = by_class.get(cls, [])
+                best_iou = 0.0
+                for p in same_class:
+                    bbox = p.get("bbox") or [0.0, 0.0, 0.0, 0.0]
+                    iou = _iou(tuple(bbox), gt_box)
+                    if iou > best_iou:
+                        best_iou = iou
+                if best_iou < iou_threshold:
+                    if best_iou == 0.0:
+                        reason = f"no model prediction for class '{cls}' on this asset"
+                    else:
+                        reason = f"best IoU {best_iou:.2f} < threshold {iou_threshold:.2f}"
+                    _flag_annotation(db, ann, reason=reason)
+                    flagged += 1
+                else:
+                    if ann.flagged:
+                        cleared += 1
+                    _flag_annotation(db, ann, reason=None)
+
+            if (i + 1) % 10 == 0:
+                db.commit()
+                if job_id:
+                    update_job_status(
+                        db,
+                        job_id,
+                        status="running",
+                        progress=0.1 + 0.85 * (i / max(1, len(assets))),
+                    )
+
+        db.commit()
+
+        if job_id:
+            update_job_status(db, job_id, status="succeeded", progress=1.0)
+        return {
+            "status": "succeeded",
+            "scanned": scanned,
+            "flagged": flagged,
+            "cleared": cleared,
+        }
+    except Exception as exc:  # noqa: BLE001
+        try:
+            from app.services.jobs_service import update_job_status as _us
+
+            if job_id:
+                _us(db, job_id, status="failed", progress=0.0)
+        except Exception:
+            pass
+        return {"status": "failed", "error": str(exc)}
+    finally:
+        db.close()

--- a/backend/src/app/jobs/tasks/evaluation.py
+++ b/backend/src/app/jobs/tasks/evaluation.py
@@ -319,8 +319,10 @@ def compute_detection_metrics(
         macro_ap /= counted
 
     # mAP@[.5:.95] — average of mAP at IoU thresholds 0.50, 0.55, ..., 0.95.
-    # Skip the threshold we already computed (iou_threshold) by re-computing
-    # each one against the same items so behaviour is identical to COCO.
+    # Each threshold is computed against the same items so behaviour matches
+    # COCO. ``mAP50`` is always tied to IoU=0.50 (per the canonical definition);
+    # ``mAP_at_iou`` carries the metric at the caller-supplied threshold so
+    # downstream consumers can reason about both without naming collisions.
     iou_thresholds = [round(0.50 + 0.05 * i, 2) for i in range(10)]
     map_per_iou: dict[str, float] = {}
     sum_map = 0.0
@@ -329,16 +331,32 @@ def compute_detection_metrics(
         per_cls = compute_detection_ap_at_iou(items, classes, thr)
         valid = [v for c, v in per_cls.items() if support[c] > 0]
         m = sum(valid) / len(valid) if valid else 0.0
-        map_per_iou[f"mAP_{int(thr*100):02d}"] = round(m, 4)
+        map_per_iou[f"mAP_{int(thr * 100):02d}"] = round(m, 4)
         sum_map += m
         counted_iou += 1
     map_5095 = sum_map / counted_iou if counted_iou else 0.0
-    primary_map = round(map_per_iou.get(f"mAP_{int(iou_threshold*100):02d}", macro_ap), 4)
+    map50 = map_per_iou.get("mAP_50", round(macro_ap, 4))
+
+    # mAP at the caller-selected IoU. If the caller passed a non-grid value
+    # (anything outside .5/.55/.../.95) compute it on demand so we still
+    # report the metric they asked for.
+    iou_key = f"mAP_{int(iou_threshold * 100):02d}"
+    if iou_key in map_per_iou:
+        map_at_iou = map_per_iou[iou_key]
+    else:
+        per_cls_caller = compute_detection_ap_at_iou(items, classes, iou_threshold)
+        valid_caller = [v for c, v in per_cls_caller.items() if support[c] > 0]
+        map_at_iou = round(sum(valid_caller) / len(valid_caller) if valid_caller else 0.0, 4)
 
     return {
         "metrics": {
-            "mAP50": primary_map,
+            # Canonical mAP definitions — always tied to their fixed IoU.
+            "mAP50": map50,
             "mAP_5095": round(map_5095, 4),
+            # The caller-selected threshold, separately keyed so it never
+            # silently shadows ``mAP50`` for non-0.5 callers.
+            "mAP_at_iou": map_at_iou,
+            "iou_threshold": iou_threshold,
             **map_per_iou,
             "precision": round(macro_p, 4),
             "recall": round(macro_r, 4),

--- a/backend/src/app/jobs/tasks/evaluation.py
+++ b/backend/src/app/jobs/tasks/evaluation.py
@@ -128,6 +128,62 @@ def compute_classification_metrics(
     }
 
 
+def _ap_from_pr(pr_data: list[tuple[float, int]], npos: int) -> float:
+    """11-point interpolated AP from a (score_desc, is_tp) list."""
+    if npos <= 0:
+        return 0.0
+    rows = sorted(pr_data, key=lambda x: -x[0])
+    cum_tp = cum_fp = 0
+    recalls = [0.0]
+    precisions = [1.0]
+    for _score, is_tp in rows:
+        if is_tp:
+            cum_tp += 1
+        else:
+            cum_fp += 1
+        recall = cum_tp / npos
+        prec = cum_tp / max(1, cum_tp + cum_fp)
+        recalls.append(recall)
+        precisions.append(prec)
+    ap = 0.0
+    for t in [i / 10 for i in range(11)]:
+        valid = [precisions[i] for i in range(len(recalls)) if recalls[i] >= t]
+        ap += max(valid) if valid else 0.0
+    return ap / 11.0
+
+
+def compute_detection_ap_at_iou(
+    items: list[dict[str, Any]], classes: list[str], iou_threshold: float
+) -> dict[str, float]:
+    """Per-class AP at a single IoU threshold. Returns {class: ap}."""
+    pr_data: dict[str, list[tuple[float, int]]] = defaultdict(list)
+    pr_npos: dict[str, int] = defaultdict(int)
+    for item in items:
+        gts = list(item.get("gt") or [])
+        preds = sorted(item.get("pred") or [], key=lambda p: -float(p.get("score", 0.0)))
+        for g in gts:
+            if g.get("class") in classes:
+                pr_npos[g["class"]] += 1
+        used = [False] * len(gts)
+        for p in preds:
+            cls = p.get("class")
+            best_j = -1
+            best_iou = 0.0
+            for j, g in enumerate(gts):
+                if used[j] or g.get("class") != cls:
+                    continue
+                iou = _iou(tuple(p["bbox"]), tuple(g["bbox"]))
+                if iou > best_iou:
+                    best_iou = iou
+                    best_j = j
+            if best_j >= 0 and best_iou >= iou_threshold:
+                used[best_j] = True
+                pr_data[cls].append((float(p.get("score", 0.0)), 1))
+            else:
+                pr_data[cls].append((float(p.get("score", 0.0)), 0))
+    return {c: _ap_from_pr(pr_data.get(c, []), pr_npos.get(c, 0)) for c in classes}
+
+
 def compute_detection_metrics(
     items: list[dict[str, Any]],
     classes: list[str],
@@ -138,6 +194,7 @@ def compute_detection_metrics(
 
     `items` is a list of {asset_id, gt: [{class, bbox}], pred: [{class, bbox, score}]}.
     bbox is (x, y, w, h) in pixel space.
+    Also computes mAP@[.5:.95] (10-point) for COCO-style reporting.
     """
     idx = {c: i for i, c in enumerate(classes)}
     matrix = [[0 for _ in classes] for _ in classes]
@@ -152,9 +209,7 @@ def compute_detection_metrics(
 
     for item in items:
         gts = list(item.get("gt") or [])
-        preds = sorted(
-            item.get("pred") or [], key=lambda p: -float(p.get("score", 0.0))
-        )
+        preds = sorted(item.get("pred") or [], key=lambda p: -float(p.get("score", 0.0)))
         for cls in {g.get("class") for g in gts}:
             if cls in idx:
                 pr_npos[cls] += sum(1 for g in gts if g.get("class") == cls)
@@ -263,9 +318,28 @@ def compute_detection_metrics(
         macro_f1 /= counted
         macro_ap /= counted
 
+    # mAP@[.5:.95] — average of mAP at IoU thresholds 0.50, 0.55, ..., 0.95.
+    # Skip the threshold we already computed (iou_threshold) by re-computing
+    # each one against the same items so behaviour is identical to COCO.
+    iou_thresholds = [round(0.50 + 0.05 * i, 2) for i in range(10)]
+    map_per_iou: dict[str, float] = {}
+    sum_map = 0.0
+    counted_iou = 0
+    for thr in iou_thresholds:
+        per_cls = compute_detection_ap_at_iou(items, classes, thr)
+        valid = [v for c, v in per_cls.items() if support[c] > 0]
+        m = sum(valid) / len(valid) if valid else 0.0
+        map_per_iou[f"mAP_{int(thr*100):02d}"] = round(m, 4)
+        sum_map += m
+        counted_iou += 1
+    map_5095 = sum_map / counted_iou if counted_iou else 0.0
+    primary_map = round(map_per_iou.get(f"mAP_{int(iou_threshold*100):02d}", macro_ap), 4)
+
     return {
         "metrics": {
-            "mAP50": round(macro_ap, 4),
+            "mAP50": primary_map,
+            "mAP_5095": round(map_5095, 4),
+            **map_per_iou,
             "precision": round(macro_p, 4),
             "recall": round(macro_r, 4),
             "f1": round(macro_f1, 4),
@@ -406,9 +480,7 @@ def evaluate_task(payload: dict) -> dict:
         # Determine task: detection if any annotation has type "box", else classification
         first_asset_anns = list(
             db.scalars(
-                select(Annotation).where(
-                    Annotation.asset_id.in_([a.id for a in assets[:50]])
-                )
+                select(Annotation).where(Annotation.asset_id.in_([a.id for a in assets[:50]]))
             ).all()
         )
         is_detection = any(a.type == "box" for a in first_asset_anns)
@@ -424,9 +496,7 @@ def evaluate_task(payload: dict) -> dict:
             samples: list[dict[str, Any]] = []
             for i, asset in enumerate(assets):
                 anns = list(
-                    db.scalars(
-                        select(Annotation).where(Annotation.asset_id == asset.id)
-                    ).all()
+                    db.scalars(select(Annotation).where(Annotation.asset_id == asset.id)).all()
                 )
                 gts = []
                 for a in anns:
@@ -499,9 +569,7 @@ def evaluate_task(payload: dict) -> dict:
                         progress=0.1 + 0.85 * (i / len(assets)),
                     )
 
-            result = compute_detection_metrics(
-                items, classes, iou_threshold=iou_threshold
-            )
+            result = compute_detection_metrics(items, classes, iou_threshold=iou_threshold)
             write_result(
                 db,
                 eval_id,
@@ -517,9 +585,7 @@ def evaluate_task(payload: dict) -> dict:
             samples = []
             for i, asset in enumerate(assets):
                 anns = list(
-                    db.scalars(
-                        select(Annotation).where(Annotation.asset_id == asset.id)
-                    ).all()
+                    db.scalars(select(Annotation).where(Annotation.asset_id == asset.id)).all()
                 )
                 gt_cls: str | None = None
                 for a in anns:
@@ -626,9 +692,7 @@ def _predict_detections(model, asset, score_threshold: float) -> list[dict[str, 
                     {
                         "class": names.get(cls_idx, str(cls_idx)),
                         "bbox": (cx - w / 2, cy - h / 2, w, h),
-                        "score": (
-                            float(box.conf.item()) if hasattr(box, "conf") else 0.0
-                        ),
+                        "score": (float(box.conf.item()) if hasattr(box, "conf") else 0.0),
                     }
                 )
         return out

--- a/backend/src/app/jobs/tasks/frame_extraction.py
+++ b/backend/src/app/jobs/tasks/frame_extraction.py
@@ -9,9 +9,11 @@ from pathlib import Path
 try:
     from celery import shared_task  # type: ignore
 except Exception:  # pragma: no cover
+
     def shared_task(*args, **kwargs):
         def _wrap(fn):
             return fn
+
         return _wrap
 
 
@@ -29,7 +31,7 @@ def _extract_minio_key(uri: str) -> str:
     """Extract the object key from an asset URI."""
     for prefix in ("s3://", "minio://"):
         if uri.startswith(prefix):
-            parts = uri[len(prefix):].split("/", 1)
+            parts = uri[len(prefix) :].split("/", 1)
             return parts[1] if len(parts) > 1 else uri
     if uri.startswith("http://") or uri.startswith("https://"):
         path = uri.split("/", 3)
@@ -120,7 +122,9 @@ def extract_frames(payload: dict) -> dict:
                         cv2.imwrite(str(local_frame), frame)
 
                         h, w = frame.shape[:2]
-                        minio_key = f"datasets/{dataset_version_id}/frames/{asset_id}/{frame_filename}"
+                        minio_key = (
+                            f"datasets/{dataset_version_id}/frames/{asset_id}/{frame_filename}"
+                        )
 
                         if minio_client:
                             try:
@@ -140,19 +144,23 @@ def extract_frames(payload: dict) -> dict:
                             mime_type="image/jpeg",
                             width=w,
                             height=h,
-                            meta_data=json.dumps({
-                                "source_asset_id": asset_id,
-                                "frame_number": frame_num,
-                                "timestamp_seconds": frame_num / video_fps,
-                            }),
+                            meta_data=json.dumps(
+                                {
+                                    "source_asset_id": asset_id,
+                                    "frame_number": frame_num,
+                                    "timestamp_seconds": frame_num / video_fps,
+                                }
+                            ),
                             label_status="unlabelled",
                         )
                         db.add(frame_asset)
-                        frame_assets.append({
-                            "id": frame_asset.id,
-                            "frame_number": frame_num,
-                            "key": minio_key,
-                        })
+                        frame_assets.append(
+                            {
+                                "id": frame_asset.id,
+                                "frame_number": frame_num,
+                                "key": minio_key,
+                            }
+                        )
 
                         # Commit in batches
                         if (extracted_count + 1) % 25 == 0:
@@ -186,6 +194,7 @@ def extract_frames(payload: dict) -> dict:
         try:
             if job_id:
                 from app.services.jobs_service import update_job_status
+
                 update_job_status(db, job_id, status="failed", progress=0.0)
         except Exception:
             pass

--- a/backend/src/app/jobs/tasks/onnx_export.py
+++ b/backend/src/app/jobs/tasks/onnx_export.py
@@ -10,9 +10,11 @@ from pathlib import Path
 try:
     from celery import shared_task  # type: ignore
 except Exception:  # pragma: no cover - fallback when Celery not installed
+
     def shared_task(*args, **kwargs):
         def _wrap(fn):
             return fn
+
         return _wrap
 
 
@@ -30,6 +32,8 @@ def _make_session():
 def export_task(payload: dict) -> dict:
     job_id = payload.get("jobId")
     experiment_id = payload.get("experimentId")
+    dynamic_axes = payload.get("dynamicAxes")
+    opset = payload.get("opset")
     db = _make_session()
     result: dict = {}
 
@@ -102,7 +106,14 @@ def export_task(payload: dict) -> dict:
 
                 if pt_path.exists() and pt_path.stat().st_size > 0:
                     model = YOLO(str(pt_path))
-                    export_result = model.export(format="onnx", dynamic=True, simplify=True)
+                    export_kwargs: dict = {"format": "onnx", "simplify": True}
+                    if dynamic_axes is not None:
+                        export_kwargs["dynamic"] = bool(dynamic_axes)
+                    else:
+                        export_kwargs["dynamic"] = True
+                    if opset is not None:
+                        export_kwargs["opset"] = int(opset)
+                    export_result = model.export(**export_kwargs)
                     # export() returns the path to the exported file
                     if export_result:
                         onnx_path = Path(str(export_result))
@@ -148,7 +159,9 @@ def export_task(payload: dict) -> dict:
                 try:
                     import io
 
-                    minio_client.put_object(bucket, onnx_key, io.BytesIO(onnx_bytes), len(onnx_bytes))
+                    minio_client.put_object(
+                        bucket, onnx_key, io.BytesIO(onnx_bytes), len(onnx_bytes)
+                    )
                 except Exception as ul_err:
                     raise RuntimeError(f"Failed to upload ONNX model: {ul_err}") from ul_err
 
@@ -169,6 +182,9 @@ def export_task(payload: dict) -> dict:
             if existing:
                 existing.checksum = onnx_checksum
                 existing.size_bytes = onnx_size
+                if onnx_key:
+                    existing.storage_path = onnx_key
+                    existing.format = "onnx"
                 db.add(existing)
             else:
                 artifact = ModelArtifact(
@@ -177,6 +193,8 @@ def export_task(payload: dict) -> dict:
                     run_id=run.id,
                     version=1,
                     type="onnx",
+                    format="onnx",
+                    storage_path=onnx_key,
                     checksum=onnx_checksum,
                     size_bytes=onnx_size,
                 )
@@ -186,9 +204,7 @@ def export_task(payload: dict) -> dict:
 
                 # Update run.artifacts
                 artifacts_data_out: list[dict] = json.loads(run.artifacts or "[]")
-                artifacts_data_out.append(
-                    {"id": artifact.id, "type": "onnx", "key": onnx_key}
-                )
+                artifacts_data_out.append({"id": artifact.id, "type": "onnx", "key": onnx_key})
                 run.artifacts = json.dumps(artifacts_data_out)
                 db.add(run)
 
@@ -210,6 +226,7 @@ def export_task(payload: dict) -> dict:
         try:
             if job_id:
                 from app.services.jobs_service import update_job_status
+
                 update_job_status(db, job_id, status="failed", progress=0.0)
         except Exception:
             pass

--- a/backend/src/app/jobs/tasks/prelabels.py
+++ b/backend/src/app/jobs/tasks/prelabels.py
@@ -9,10 +9,13 @@ from pathlib import Path
 try:
     from celery import shared_task  # type: ignore
 except Exception:  # pragma: no cover
+
     def shared_task(*args, **kwargs):
         def _wrap(fn):
             return fn
+
         return _wrap
+
 
 SYSTEM_USER_ID = os.getenv("SYSTEM_USER_ID", "00000000-0000-0000-0000-000000000001")
 CONF_THRESHOLD = 0.5
@@ -32,7 +35,7 @@ def _extract_minio_key(uri: str) -> str:
     """Extract the object key from an asset URI."""
     for prefix in ("s3://", "minio://"):
         if uri.startswith(prefix):
-            parts = uri[len(prefix):].split("/", 1)
+            parts = uri[len(prefix) :].split("/", 1)
             return parts[1] if len(parts) > 1 else uri
     if uri.startswith("http://") or uri.startswith("https://"):
         path = uri.split("/", 3)
@@ -131,7 +134,9 @@ def apply_prelabels(payload: dict) -> dict:
                                 probs = getattr(pred, "probs", None)
                                 if probs is None:
                                     continue
-                                top_conf = float(probs.top1conf) if hasattr(probs, "top1conf") else 0.0
+                                top_conf = (
+                                    float(probs.top1conf) if hasattr(probs, "top1conf") else 0.0
+                                )
                                 if top_conf < conf_threshold:
                                     continue
                                 cls_idx = int(probs.top1) if hasattr(probs, "top1") else 0
@@ -152,11 +157,25 @@ def apply_prelabels(payload: dict) -> dict:
                                 boxes = getattr(pred, "boxes", None)
                                 if boxes is None or len(boxes) == 0:
                                     continue
-                                xyxy = boxes.xyxy.tolist() if hasattr(boxes.xyxy, "tolist") else list(boxes.xyxy)
-                                confs = boxes.conf.tolist() if hasattr(boxes.conf, "tolist") else list(boxes.conf)
-                                clss = boxes.cls.tolist() if hasattr(boxes.cls, "tolist") else list(boxes.cls)
+                                xyxy = (
+                                    boxes.xyxy.tolist()
+                                    if hasattr(boxes.xyxy, "tolist")
+                                    else list(boxes.xyxy)
+                                )
+                                confs = (
+                                    boxes.conf.tolist()
+                                    if hasattr(boxes.conf, "tolist")
+                                    else list(boxes.conf)
+                                )
+                                clss = (
+                                    boxes.cls.tolist()
+                                    if hasattr(boxes.cls, "tolist")
+                                    else list(boxes.cls)
+                                )
 
-                                for (x1, y1, x2, y2), conf, cls_id in zip(xyxy, confs, clss, strict=False):
+                                for (x1, y1, x2, y2), conf, cls_id in zip(
+                                    xyxy, confs, clss, strict=False
+                                ):
                                     if float(conf) < conf_threshold:
                                         continue
                                     cls_name = model_names.get(int(cls_id), str(int(cls_id)))
@@ -209,6 +228,7 @@ def apply_prelabels(payload: dict) -> dict:
         try:
             if job_id:
                 from app.services.jobs_service import update_job_status
+
                 update_job_status(db, job_id, status="failed", progress=0.0)
         except Exception:
             pass

--- a/backend/src/app/jobs/tasks/training.py
+++ b/backend/src/app/jobs/tasks/training.py
@@ -11,9 +11,11 @@ from typing import Any
 try:
     from celery import shared_task  # type: ignore
 except Exception:  # pragma: no cover - fallback when Celery not installed
+
     def shared_task(*args, **kwargs):
         def _wrap(fn):
             return fn
+
         return _wrap
 
 
@@ -32,7 +34,7 @@ def _extract_minio_key(uri: str) -> str:
     # URI may be: s3://bucket/key, minio://bucket/key, http://host/bucket/key, or plain key
     for prefix in ("s3://", "minio://"):
         if uri.startswith(prefix):
-            parts = uri[len(prefix):].split("/", 1)
+            parts = uri[len(prefix) :].split("/", 1)
             return parts[1] if len(parts) > 1 else uri
     if uri.startswith("http://") or uri.startswith("https://"):
         # http://host/bucket/key  →  key is everything after second /
@@ -84,7 +86,11 @@ def _build_yolo_dataset(
         if task_type == "classify":
             # Determine class from annotations
             ann_list = annotations_by_asset.get(asset.id, [])
-            cls_name = ann_list[0].class_name if ann_list else (class_names[0] if class_names else "unknown")
+            cls_name = (
+                ann_list[0].class_name
+                if ann_list
+                else (class_names[0] if class_names else "unknown")
+            )
             dest_dir = output_dir / split / cls_name
             dest_dir.mkdir(parents=True, exist_ok=True)
             dest_img = dest_dir / img_name
@@ -106,7 +112,9 @@ def _build_yolo_dataset(
             lines: list[str] = []
             for ann in ann_list:
                 try:
-                    geo = json.loads(ann.geometry) if isinstance(ann.geometry, str) else ann.geometry
+                    geo = (
+                        json.loads(ann.geometry) if isinstance(ann.geometry, str) else ann.geometry
+                    )
                 except Exception:
                     continue
                 cls_name = ann.class_name or ""
@@ -210,9 +218,7 @@ def train_task(payload: dict) -> dict:
             # Fetch all annotations for these assets
             asset_ids = [a.id for a in assets]
             if asset_ids:
-                ann_rows = (
-                    db.query(Annotation).filter(Annotation.asset_id.in_(asset_ids)).all()
-                )
+                ann_rows = db.query(Annotation).filter(Annotation.asset_id.in_(asset_ids)).all()
                 for ann in ann_rows:
                     annotations_by_asset.setdefault(ann.asset_id, []).append(ann)
 
@@ -422,6 +428,7 @@ def train_task(payload: dict) -> dict:
         try:
             if job_id:
                 from app.services.jobs_service import update_job_status
+
                 update_job_status(db, job_id, status="failed", progress=0.0)
         except Exception:
             pass

--- a/backend/src/app/jobs/tasks/uncertainty.py
+++ b/backend/src/app/jobs/tasks/uncertainty.py
@@ -9,9 +9,11 @@ from pathlib import Path
 try:
     from celery import shared_task  # type: ignore
 except Exception:  # pragma: no cover
+
     def shared_task(*args, **kwargs):
         def _wrap(fn):
             return fn
+
         return _wrap
 
 
@@ -29,7 +31,7 @@ def _extract_minio_key(uri: str) -> str:
     """Extract the object key from an asset URI."""
     for prefix in ("s3://", "minio://"):
         if uri.startswith(prefix):
-            parts = uri[len(prefix):].split("/", 1)
+            parts = uri[len(prefix) :].split("/", 1)
             return parts[1] if len(parts) > 1 else uri
     if uri.startswith("http://") or uri.startswith("https://"):
         path = uri.split("/", 3)
@@ -50,7 +52,9 @@ def _detection_uncertainty(predictions: list) -> float:
         try:
             boxes = pred.boxes
             if boxes is not None and len(boxes) > 0:
-                conf_vals = boxes.conf.tolist() if hasattr(boxes.conf, "tolist") else list(boxes.conf)
+                conf_vals = (
+                    boxes.conf.tolist() if hasattr(boxes.conf, "tolist") else list(boxes.conf)
+                )
                 confs.extend(conf_vals)
         except Exception:
             pass
@@ -73,7 +77,9 @@ def _classification_uncertainty(predictions: list) -> float:
         if probs is None:
             return 1.0
         prob_data = probs.data
-        prob_list: list[float] = prob_data.tolist() if hasattr(prob_data, "tolist") else list(prob_data)
+        prob_list: list[float] = (
+            prob_data.tolist() if hasattr(prob_data, "tolist") else list(prob_data)
+        )
         n = len(prob_list)
         if n <= 1:
             return 0.0
@@ -153,9 +159,7 @@ def score_uncertainty(payload: dict) -> dict:
                         img_path = tmp_path / f"{asset.id}.bin"
                         img_path.write_bytes(img_data)
 
-                        predictions = yolo_model.predict(
-                            str(img_path), verbose=False, conf=0.01
-                        )
+                        predictions = yolo_model.predict(str(img_path), verbose=False, conf=0.01)
                         if task_type == "classify":
                             uncertainty_score = _classification_uncertainty(predictions)
                         else:
@@ -190,6 +194,7 @@ def score_uncertainty(payload: dict) -> dict:
         try:
             if job_id:
                 from app.services.jobs_service import update_job_status
+
                 update_job_status(db, job_id, status="failed", progress=0.0)
         except Exception:
             pass

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -33,18 +33,21 @@ from app.services.auth import ensure_superuser
 # Import new routers (created by the new API implementation)
 try:
     from app.api.annotations import router as annotations_router
+
     _has_annotations = True
 except ImportError:
     _has_annotations = False
 
 try:
     from app.api.assets import router as assets_router
+
     _has_assets = True
 except ImportError:
     _has_assets = False
 
 try:
     from app.api.workspaces import router as workspaces_router
+
     _has_workspaces = True
 except ImportError:
     _has_workspaces = False

--- a/backend/src/app/models/__init__.py
+++ b/backend/src/app/models/__init__.py
@@ -1,18 +1,18 @@
+from app.models.admin import AuditEvent, Invitation, Notification  # noqa: F401
 from app.models.alitem import ALItem  # noqa: F401
 from app.models.alrun import ALRun  # noqa: F401
 from app.models.annotation import Annotation  # noqa: F401
 from app.models.annotation_schema import AnnotationSchema  # noqa: F401
 from app.models.artifact import ModelArtifact as Artifact  # noqa: F401
 from app.models.asset import Asset  # noqa: F401
-from app.models.cluster import Cluster  # noqa: F401
-from app.models.evaluation import Evaluation  # noqa: F401
 from app.models.audit import Audit  # noqa: F401
-from app.models.admin import AuditEvent, Invitation, Notification  # noqa: F401
-from app.models.dataset import Dataset, ClassMap  # noqa: F401
+from app.models.cluster import Cluster  # noqa: F401
+from app.models.dataset import ClassMap, Dataset  # noqa: F401
 from app.models.dataset_version import DatasetVersion  # noqa: F401
+from app.models.evaluation import Evaluation  # noqa: F401
 from app.models.experiment import ExperimentRun as Experiment  # noqa: F401
 from app.models.job import Job  # noqa: F401
 from app.models.project import Project  # noqa: F401
 from app.models.track import Track  # noqa: F401
 from app.models.user import User  # noqa: F401
-from app.models.workspace import Workspace, Role, Membership  # noqa: F401
+from app.models.workspace import Membership, Role, Workspace  # noqa: F401

--- a/backend/src/app/models/annotation.py
+++ b/backend/src/app/models/annotation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -14,6 +14,9 @@ def _uuid() -> str:
 
 # Allowed annotation types. Keep in sync with the frontend toolbox.
 ANNOTATION_TYPES = ("box", "polygon", "keypoint", "classification")
+
+# Allowed review states.
+REVIEW_STATUSES = ("unreviewed", "approved", "rejected")
 
 
 class Annotation(Base):
@@ -32,3 +35,15 @@ class Annotation(Base):
     created_at: Mapped[object] = mapped_column(DateTime(timezone=True), server_default=func.now())
     # JSON array of {version, geometry, class_name, updated_at}
     history: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Review workflow
+    review_status: Mapped[str] = mapped_column(String(32), nullable=False, default="unreviewed")
+    reviewer_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("users.id"), nullable=True
+    )
+    reviewed_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    review_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Error mining
+    flagged: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    flag_reason: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/backend/src/app/models/dataset.py
+++ b/backend/src/app/models/dataset.py
@@ -19,6 +19,9 @@ class Dataset(Base):
     project_id: Mapped[str] = mapped_column(String(36), ForeignKey("projects.id"), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # "detect" | "classify". Mirrors Project.task_type so a dataset can be
+    # validated against a training run without joining through the project.
+    task_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
     class_map_id: Mapped[str | None] = mapped_column(
         String(36), ForeignKey("class_maps.id"), nullable=True
     )

--- a/backend/src/app/models/project.py
+++ b/backend/src/app/models/project.py
@@ -23,6 +23,8 @@ class Project(Base):
     slug: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     status: Mapped[str] = mapped_column(String(50), nullable=False, default="active")
+    # "detect" | "classify". NULL for legacy projects created before Phase 2.
+    task_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
     tags: Mapped[str | None] = mapped_column(String(1000), nullable=True)  # JSON array
     archived_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[object] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/src/app/observability/metrics.py
+++ b/backend/src/app/observability/metrics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import Callable
+from collections.abc import Callable
 
 from prometheus_client import Counter, Gauge, Histogram
 

--- a/backend/src/app/schemas/evaluation.py
+++ b/backend/src/app/schemas/evaluation.py
@@ -83,3 +83,10 @@ class EvaluationJobResponse(BaseModel):
     progress: float = 0.0
     evaluationId: str
     clusterId: str | None = None
+
+
+class EvaluationListPage(BaseModel):
+    items: list[EvaluationSummary]
+    total: int
+    page: int
+    page_size: int

--- a/backend/src/app/schemas/project.py
+++ b/backend/src/app/schemas/project.py
@@ -1,14 +1,12 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
 
 class ProjectCreate(BaseModel):
     name: str
-    description: Optional[str] = None
+    description: str | None = None
 
 
 class Project(BaseModel):
     id: str
     name: str
-    description: Optional[str] = None
+    description: str | None = None

--- a/backend/src/app/services/annotation_service.py
+++ b/backend/src/app/services/annotation_service.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
+from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from app.models.annotation import ANNOTATION_TYPES, Annotation
+from app.models.annotation import ANNOTATION_TYPES, REVIEW_STATUSES, Annotation
 from app.models.asset import Asset
 
 
@@ -19,9 +20,7 @@ class VersionConflictError(AnnotationError):
 
 
 def get_asset_annotations(db: Session, asset_id: str) -> list[Annotation]:
-    return list(
-        db.scalars(select(Annotation).where(Annotation.asset_id == asset_id)).all()
-    )
+    return list(db.scalars(select(Annotation).where(Annotation.asset_id == asset_id)).all())
 
 
 def create_annotation(
@@ -73,9 +72,6 @@ def update_annotation(
             f"annotation version mismatch: have {ann.version}, expected {expected_version}"
         )
 
-    # Determine whether anything actually changes. An update with neither
-    # field is a no-op — return the current row without bumping the version
-    # (which would create needless optimistic-lock conflicts).
     geometry_changing = geometry is not None
     class_changing = class_name is not None and class_name != ann.class_name
     if not geometry_changing and not class_changing:
@@ -84,8 +80,6 @@ def update_annotation(
     if geometry_changing:
         _validate_geometry(ann.type, geometry)
 
-    # Snapshot the previous state into history whenever either the geometry
-    # OR the class label changes, so the audit trail is faithful.
     history: list[dict] = []
     if ann.history:
         try:
@@ -108,6 +102,11 @@ def update_annotation(
         ann.class_name = class_name
     ann.version = (ann.version or 1) + 1
     ann.updated_at = datetime.now(timezone.utc)
+    # An edit invalidates a prior review.
+    if ann.review_status != "unreviewed":
+        ann.review_status = "unreviewed"
+        ann.reviewer_id = None
+        ann.reviewed_at = None
     db.add(ann)
     db.commit()
     db.refresh(ann)
@@ -141,6 +140,242 @@ def mark_asset_labeled(db: Session, asset_id: str) -> None:
         db.commit()
 
 
+def set_review(
+    db: Session,
+    annotation_id: str,
+    *,
+    review_status: str,
+    reviewer_id: str,
+    notes: str | None = None,
+) -> Annotation | None:
+    """Approve / reject / reset an annotation."""
+    if review_status not in REVIEW_STATUSES:
+        raise AnnotationError(
+            f"review_status must be one of {REVIEW_STATUSES}, got {review_status!r}"
+        )
+    ann = db.get(Annotation, annotation_id)
+    if not ann:
+        return None
+    ann.review_status = review_status
+    if review_status == "unreviewed":
+        ann.reviewer_id = None
+        ann.reviewed_at = None
+        ann.review_notes = None
+    else:
+        ann.reviewer_id = reviewer_id
+        ann.reviewed_at = datetime.now(timezone.utc)
+        ann.review_notes = notes
+    db.add(ann)
+    db.commit()
+    db.refresh(ann)
+    return ann
+
+
+def list_review_queue(
+    db: Session,
+    *,
+    dataset_id: str,
+    version_id: str | None = None,
+    review_status: str | None = None,
+    flagged: bool | None = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict[str, Any]], int]:
+    """List annotations + parent-asset metadata for a review queue."""
+    base = (
+        select(Annotation, Asset)
+        .join(Asset, Asset.id == Annotation.asset_id)
+        .where(Asset.dataset_id == dataset_id)
+    )
+    if version_id:
+        base = base.where(Asset.version_id == version_id)
+    if review_status:
+        if review_status not in REVIEW_STATUSES:
+            raise AnnotationError(
+                f"review_status must be one of {REVIEW_STATUSES}, got {review_status!r}"
+            )
+        base = base.where(Annotation.review_status == review_status)
+    if flagged is not None:
+        base = base.where(Annotation.flagged == flagged)
+
+    count_q = (
+        select(func.count(Annotation.id))
+        .join(Asset, Asset.id == Annotation.asset_id)
+        .where(Asset.dataset_id == dataset_id)
+    )
+    if version_id:
+        count_q = count_q.where(Asset.version_id == version_id)
+    if review_status:
+        count_q = count_q.where(Annotation.review_status == review_status)
+    if flagged is not None:
+        count_q = count_q.where(Annotation.flagged == flagged)
+    total = db.scalar(count_q) or 0
+
+    offset = (page - 1) * page_size
+    rows = list(
+        db.execute(
+            base.order_by(Annotation.created_at.desc()).offset(offset).limit(page_size)
+        ).all()
+    )
+    items = []
+    for ann, asset in rows:
+        items.append(
+            {
+                "annotation": _ann_dict(ann),
+                "asset": {
+                    "id": asset.id,
+                    "uri": asset.uri,
+                    "width": asset.width,
+                    "height": asset.height,
+                    "label_status": asset.label_status,
+                },
+            }
+        )
+    return items, total
+
+
+def review_summary(
+    db: Session, *, dataset_id: str, version_id: str | None = None
+) -> dict[str, int]:
+    """Counts of annotations by review status (and flagged) for a dataset/version."""
+    base = (
+        select(Annotation.review_status, Annotation.flagged, func.count(Annotation.id))
+        .join(Asset, Asset.id == Annotation.asset_id)
+        .where(Asset.dataset_id == dataset_id)
+        .group_by(Annotation.review_status, Annotation.flagged)
+    )
+    if version_id:
+        base = base.where(Asset.version_id == version_id)
+    counts = {s: 0 for s in REVIEW_STATUSES}
+    flagged_count = 0
+    total = 0
+    for status, flagged, n in db.execute(base).all():
+        if status in counts:
+            counts[status] += int(n)
+        if flagged:
+            flagged_count += int(n)
+        total += int(n)
+    return {**counts, "flagged": flagged_count, "total": total}
+
+
+def bulk_save(
+    db: Session,
+    *,
+    author_id: str,
+    creates: list[dict[str, Any]] | None = None,
+    updates: list[dict[str, Any]] | None = None,
+    deletes: list[str] | None = None,
+) -> dict[str, Any]:
+    """Apply many annotation mutations in one round-trip.
+
+    Each entry is processed independently so a single failure doesn't block
+    the rest. The response surfaces per-entry status so the client can show
+    409s on the rows that conflicted.
+    """
+    creates = creates or []
+    updates = updates or []
+    deletes = deletes or []
+
+    created_results: list[dict[str, Any]] = []
+    updated_results: list[dict[str, Any]] = []
+    deleted_results: list[dict[str, Any]] = []
+
+    affected_assets: set[str] = set()
+
+    for c in creates:
+        client_id = c.get("client_id")
+        try:
+            ann = create_annotation(
+                db,
+                asset_id=c["asset_id"],
+                author_id=author_id,
+                type=c["type"],
+                geometry=c["geometry"],
+                class_name=c.get("class_name"),
+            )
+            affected_assets.add(c["asset_id"])
+            created_results.append(
+                {
+                    "client_id": client_id,
+                    "status": "ok",
+                    "annotation": _ann_dict(ann),
+                }
+            )
+        except AnnotationError as exc:
+            created_results.append({"client_id": client_id, "status": "error", "error": str(exc)})
+
+    for u in updates:
+        ann_id = u.get("id")
+        if not ann_id:
+            updated_results.append({"id": None, "status": "error", "error": "missing id"})
+            continue
+        try:
+            ann = update_annotation(
+                db,
+                ann_id,
+                geometry=u.get("geometry"),
+                class_name=u.get("class_name"),
+                expected_version=u.get("expected_version"),
+            )
+            if not ann:
+                updated_results.append({"id": ann_id, "status": "not_found"})
+                continue
+            affected_assets.add(ann.asset_id)
+            updated_results.append({"id": ann_id, "status": "ok", "annotation": _ann_dict(ann)})
+        except VersionConflictError as exc:
+            updated_results.append({"id": ann_id, "status": "conflict", "error": str(exc)})
+        except AnnotationError as exc:
+            updated_results.append({"id": ann_id, "status": "error", "error": str(exc)})
+
+    for ann_id in deletes:
+        ann = db.get(Annotation, ann_id)
+        if ann is not None:
+            affected_assets.add(ann.asset_id)
+        ok = delete_annotation(db, ann_id)
+        deleted_results.append({"id": ann_id, "status": "ok" if ok else "not_found"})
+
+    # Best-effort: any asset that still has at least one annotation flips to
+    # "in_progress" if it was "unlabeled". We don't auto-promote to "labeled"
+    # — that's an explicit action via mark-labeled.
+    for asset_id in affected_assets:
+        asset = db.get(Asset, asset_id)
+        if asset and asset.label_status in ("unlabeled", "unlabelled"):
+            remaining = db.scalar(
+                select(func.count(Annotation.id)).where(Annotation.asset_id == asset_id)
+            )
+            if remaining and int(remaining) > 0:
+                asset.label_status = "in_progress"
+                db.add(asset)
+    if affected_assets:
+        db.commit()
+
+    return {
+        "created": created_results,
+        "updated": updated_results,
+        "deleted": deleted_results,
+    }
+
+
+def _ann_dict(ann: Annotation) -> dict[str, Any]:
+    return {
+        "id": ann.id,
+        "asset_id": ann.asset_id,
+        "type": ann.type,
+        "geometry": (json.loads(ann.geometry) if isinstance(ann.geometry, str) else ann.geometry),
+        "class_name": ann.class_name,
+        "author_id": ann.author_id,
+        "version": ann.version,
+        "review_status": ann.review_status,
+        "reviewer_id": ann.reviewer_id,
+        "reviewed_at": ann.reviewed_at.isoformat() if ann.reviewed_at else None,
+        "review_notes": ann.review_notes,
+        "flagged": bool(ann.flagged),
+        "flag_reason": ann.flag_reason,
+        "updated_at": ann.updated_at.isoformat() if ann.updated_at else None,
+        "created_at": ann.created_at.isoformat() if ann.created_at else None,
+    }
+
+
 def _validate_geometry(atype: str, geometry: dict) -> None:
     if atype == "box":
         for k in ("x", "y", "w", "h"):
@@ -164,7 +399,7 @@ def _validate_geometry(atype: str, geometry: dict) -> None:
                 raise AnnotationError("keypoint point missing 'x' or 'y'")
     elif atype == "classification":
         if not geometry.get("class") and not geometry.get("class_name"):
-            # Allow empty class field — class_name on the row carries the label.
+            # Class label travels on the row, not the geometry.
             pass
     else:  # pragma: no cover - guarded above
         raise AnnotationError(f"unsupported type {atype}")

--- a/backend/src/app/services/annotation_service.py
+++ b/backend/src/app/services/annotation_service.py
@@ -31,6 +31,7 @@ def create_annotation(
     type: str,
     geometry: dict,
     class_name: str | None,
+    commit: bool = True,
 ) -> Annotation:
     if type not in ANNOTATION_TYPES:
         raise AnnotationError(
@@ -51,8 +52,11 @@ def create_annotation(
     if asset and asset.label_status in ("unlabeled", "unlabelled"):
         asset.label_status = "in_progress"
         db.add(asset)
-    db.commit()
-    db.refresh(ann)
+    if commit:
+        db.commit()
+        db.refresh(ann)
+    else:
+        db.flush()
     return ann
 
 
@@ -63,6 +67,7 @@ def update_annotation(
     geometry: dict | None = None,
     class_name: str | None = None,
     expected_version: int | None = None,
+    commit: bool = True,
 ) -> Annotation | None:
     ann = db.get(Annotation, annotation_id)
     if not ann:
@@ -108,17 +113,23 @@ def update_annotation(
         ann.reviewer_id = None
         ann.reviewed_at = None
     db.add(ann)
-    db.commit()
-    db.refresh(ann)
+    if commit:
+        db.commit()
+        db.refresh(ann)
+    else:
+        db.flush()
     return ann
 
 
-def delete_annotation(db: Session, annotation_id: str) -> bool:
+def delete_annotation(db: Session, annotation_id: str, *, commit: bool = True) -> bool:
     ann = db.get(Annotation, annotation_id)
     if not ann:
         return False
     db.delete(ann)
-    db.commit()
+    if commit:
+        db.commit()
+    else:
+        db.flush()
     return True
 
 
@@ -268,9 +279,12 @@ def bulk_save(
 ) -> dict[str, Any]:
     """Apply many annotation mutations in one round-trip.
 
-    Each entry is processed independently so a single failure doesn't block
-    the rest. The response surfaces per-entry status so the client can show
-    409s on the rows that conflicted.
+    Each entry is wrapped in a SAVEPOINT (``db.begin_nested()``) so a single
+    failed row rolls back just that row, leaving the rest of the batch
+    intact. The whole batch is then committed in **one** outer transaction
+    — no more O(n) commits like the original implementation. The response
+    surfaces per-entry status so the client can show 409s on the rows that
+    conflicted.
     """
     creates = creates or []
     updates = updates or []
@@ -282,8 +296,15 @@ def bulk_save(
 
     affected_assets: set[str] = set()
 
+    # If the session has no active transaction we need to start one before
+    # opening savepoints. SQLAlchemy 2.0 autoflush sessions don't carry an
+    # implicit transaction across commits.
+    if not db.in_transaction():
+        db.begin()
+
     for c in creates:
         client_id = c.get("client_id")
+        sp = db.begin_nested()
         try:
             ann = create_annotation(
                 db,
@@ -292,7 +313,9 @@ def bulk_save(
                 type=c["type"],
                 geometry=c["geometry"],
                 class_name=c.get("class_name"),
+                commit=False,
             )
+            sp.commit()
             affected_assets.add(c["asset_id"])
             created_results.append(
                 {
@@ -302,6 +325,7 @@ def bulk_save(
                 }
             )
         except AnnotationError as exc:
+            sp.rollback()
             created_results.append({"client_id": client_id, "status": "error", "error": str(exc)})
 
     for u in updates:
@@ -309,6 +333,7 @@ def bulk_save(
         if not ann_id:
             updated_results.append({"id": None, "status": "error", "error": "missing id"})
             continue
+        sp = db.begin_nested()
         try:
             ann = update_annotation(
                 db,
@@ -316,22 +341,33 @@ def bulk_save(
                 geometry=u.get("geometry"),
                 class_name=u.get("class_name"),
                 expected_version=u.get("expected_version"),
+                commit=False,
             )
             if not ann:
+                sp.rollback()
                 updated_results.append({"id": ann_id, "status": "not_found"})
                 continue
+            sp.commit()
             affected_assets.add(ann.asset_id)
             updated_results.append({"id": ann_id, "status": "ok", "annotation": _ann_dict(ann)})
         except VersionConflictError as exc:
+            sp.rollback()
             updated_results.append({"id": ann_id, "status": "conflict", "error": str(exc)})
         except AnnotationError as exc:
+            sp.rollback()
             updated_results.append({"id": ann_id, "status": "error", "error": str(exc)})
 
     for ann_id in deletes:
         ann = db.get(Annotation, ann_id)
         if ann is not None:
             affected_assets.add(ann.asset_id)
-        ok = delete_annotation(db, ann_id)
+        sp = db.begin_nested()
+        try:
+            ok = delete_annotation(db, ann_id, commit=False)
+            sp.commit()
+        except Exception:
+            sp.rollback()
+            ok = False
         deleted_results.append({"id": ann_id, "status": "ok" if ok else "not_found"})
 
     # Best-effort: any asset that still has at least one annotation flips to
@@ -346,8 +382,9 @@ def bulk_save(
             if remaining and int(remaining) > 0:
                 asset.label_status = "in_progress"
                 db.add(asset)
-    if affected_assets:
-        db.commit()
+
+    # Single commit for the whole batch.
+    db.commit()
 
     return {
         "created": created_results,

--- a/backend/src/app/services/asset_fetch.py
+++ b/backend/src/app/services/asset_fetch.py
@@ -1,0 +1,152 @@
+"""SSRF-hardened image fetcher used by AL and error-mining paths.
+
+Asset URIs come from many places — uploads, imports, frame extraction, etc.
+Some of those code paths historically left the URI as a raw string, which
+means an attacker who controls one of the upload paths could inject an
+``http://internal-service`` URL. Fetching that URL from the API process or
+a Celery worker is a classic SSRF.
+
+This module enforces a simple policy:
+  * Only ``MinIO`` keys are followed by default.
+  * ``http(s)`` URLs are only allowed when the env var
+    ``VF_ALLOW_REMOTE_ASSET_FETCH=true`` is set, and even then we resolve
+    the hostname and reject any address that lives on a loopback/private/
+    link-local/multicast/reserved IP range.
+  * Responses are capped at ``VF_MAX_ASSET_BYTES`` (default 50 MiB) so a
+    malicious server can't exhaust memory.
+
+Both `RemoteFetchDenied` and any I/O failure are surfaced as ``None``-byte
+returns from ``fetch_asset_bytes`` so callers can fall back gracefully.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import socket
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+DEFAULT_MAX_BYTES = 50 * 1024 * 1024
+
+log = logging.getLogger(__name__)
+
+
+class RemoteFetchDenied(Exception):
+    """Raised when an asset URI is rejected before any network I/O."""
+
+
+def _max_bytes() -> int:
+    raw = os.getenv("VF_MAX_ASSET_BYTES")
+    try:
+        return int(raw) if raw else DEFAULT_MAX_BYTES
+    except ValueError:
+        return DEFAULT_MAX_BYTES
+
+
+def _remote_allowed() -> bool:
+    return os.getenv("VF_ALLOW_REMOTE_ASSET_FETCH", "false").lower() == "true"
+
+
+def _is_safe_remote_host(host: str) -> bool:
+    """Reject loopback/private/link-local/multicast/reserved IPs."""
+    if not host:
+        return False
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except OSError:
+        return False
+    for info in infos:
+        addr = info[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            return False
+        if (
+            ip.is_loopback
+            or ip.is_private
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_reserved
+            or ip.is_unspecified
+        ):
+            return False
+    return True
+
+
+def fetch_asset_bytes(uri: str, *, timeout: float = 10.0) -> bytes | None:
+    """Best-effort download of ``uri`` into memory under the SSRF policy.
+
+    Returns the raw bytes on success, or ``None`` for any failure. Never
+    raises — callers can always fall back to a random/skip path.
+    """
+    if not uri:
+        return None
+
+    parsed = urlparse(uri)
+    scheme = (parsed.scheme or "").lower()
+
+    # Remote HTTP(S) — gated behind opt-in, and only public IPs.
+    if scheme in ("http", "https"):
+        if not _remote_allowed():
+            log.warning("rejecting remote asset fetch (opt-in disabled): %s", uri)
+            return None
+        host = parsed.hostname or ""
+        if not _is_safe_remote_host(host):
+            log.warning("rejecting remote asset fetch (unsafe host): %s", host)
+            return None
+        try:
+            req = Request(uri, headers={"User-Agent": "VisionForge/1.0"})
+            with urlopen(req, timeout=timeout) as response:  # noqa: S310
+                # Read in capped chunks so a malicious server can't OOM us.
+                cap = _max_bytes()
+                buf = bytearray()
+                while True:
+                    chunk = response.read(min(65536, cap - len(buf) + 1))
+                    if not chunk:
+                        break
+                    buf.extend(chunk)
+                    if len(buf) > cap:
+                        log.warning("remote asset exceeded cap (%d bytes): %s", cap, uri)
+                        return None
+                return bytes(buf)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("remote asset fetch failed: %s", exc)
+            return None
+
+    # Local filesystem path (used in tests and a few legacy paths).
+    if scheme in ("", "file"):
+        path = parsed.path if scheme == "file" else uri
+        try:
+            if os.path.exists(path):
+                with open(path, "rb") as fh:
+                    data = fh.read(_max_bytes() + 1)
+                if len(data) > _max_bytes():
+                    log.warning("local asset exceeded cap: %s", path)
+                    return None
+                return data
+        except OSError as exc:
+            log.warning("local asset read failed: %s", exc)
+            return None
+        # Otherwise treat as an object-store key below.
+
+    # Anything else: treat as a MinIO/S3 object key.
+    try:
+        from app.services import storage
+
+        client = storage.get_minio_client()
+        bucket = os.getenv("MINIO_BUCKET", os.getenv("S3_BUCKET", "visionforge"))
+        resp = client.get_object(bucket, uri)
+        try:
+            data = resp.read()
+        finally:
+            resp.close()
+            resp.release_conn()
+        if len(data) > _max_bytes():
+            log.warning("object-store asset exceeded cap: %s", uri)
+            return None
+        return data
+    except Exception as exc:  # noqa: BLE001
+        log.warning("object-store asset fetch failed: %s", exc)
+        return None

--- a/backend/src/app/services/datumaro_service.py
+++ b/backend/src/app/services/datumaro_service.py
@@ -83,9 +83,7 @@ def import_archive(
             return _import_coco(db, dataset, version, archive_dir, image_uri_base)
         if fmt == "yolo":
             return _import_yolo(db, dataset, version, archive_dir, image_uri_base)
-        return _import_via_datumaro(
-            db, dataset, version, archive_dir, fmt, image_uri_base
-        )
+        return _import_via_datumaro(db, dataset, version, archive_dir, fmt, image_uri_base)
 
 
 def _safe_extract(zf: zipfile.ZipFile, dest: Path) -> None:
@@ -140,9 +138,7 @@ def _import_coco(
         coco = json.load(f)
 
     cats = coco.get("categories") or []
-    class_id_to_name: dict[int, str] = {
-        c["id"]: c.get("name") or str(c["id"]) for c in cats
-    }
+    class_id_to_name: dict[int, str] = {c["id"]: c.get("name") or str(c["id"]) for c in cats}
     classes = [c.get("name") for c in cats if c.get("name")]
     _persist_classes(db, dataset, classes)
 
@@ -163,9 +159,7 @@ def _import_coco(
             width=width,
             height=height,
             label_status="labeled",
-            meta_data=json.dumps(
-                {"filename": file_name, "coco_image_id": img.get("id")}
-            ),
+            meta_data=json.dumps({"filename": file_name, "coco_image_id": img.get("id")}),
         )
         db.add(asset)
         db.flush()
@@ -188,9 +182,7 @@ def _import_coco(
         elif ann.get("segmentation"):
             seg = ann["segmentation"]
             poly = seg[0] if isinstance(seg, list) and seg else []
-            points = [
-                {"x": poly[i], "y": poly[i + 1]} for i in range(0, len(poly) - 1, 2)
-            ]
+            points = [{"x": poly[i], "y": poly[i + 1]} for i in range(0, len(poly) - 1, 2)]
             geom = {"points": points}
             atype = "polygon"
         else:
@@ -225,11 +217,7 @@ def _import_yolo(
         None,
     )
     if classes_file:
-        classes = [
-            line.strip()
-            for line in classes_file.read_text().splitlines()
-            if line.strip()
-        ]
+        classes = [line.strip() for line in classes_file.read_text().splitlines() if line.strip()]
     else:
         yaml_path = next((p for p in root.rglob("data.yaml")), None)
         if yaml_path:
@@ -238,9 +226,7 @@ def _import_yolo(
                     rest = line.split(":", 1)[1].strip()
                     if rest.startswith("["):
                         rest = rest.strip("[]")
-                        classes = [
-                            c.strip().strip("'\"") for c in rest.split(",") if c.strip()
-                        ]
+                        classes = [c.strip().strip("'\"") for c in rest.split(",") if c.strip()]
     if not classes:
         classes = ["object"]
     _persist_classes(db, dataset, classes)
@@ -295,9 +281,7 @@ def _import_yolo(
             except ValueError:
                 warnings.append(f"bad YOLO line: {line}")
                 continue
-            cls = (
-                classes[cls_idx] if 0 <= cls_idx < len(classes) else f"class_{cls_idx}"
-            )
+            cls = classes[cls_idx] if 0 <= cls_idx < len(classes) else f"class_{cls_idx}"
             x = (cx - bw / 2) * (w or 1)
             y = (cy - bh / 2) * (h or 1)
             ww = bw * (w or 1)
@@ -329,9 +313,7 @@ def _import_via_datumaro(
     try:
         import datumaro as dm  # type: ignore
     except Exception as exc:
-        raise DatumaroError(
-            f"format '{fmt}' requires the optional 'datumaro' package"
-        ) from exc
+        raise DatumaroError(f"format '{fmt}' requires the optional 'datumaro' package") from exc
 
     project = dm.Dataset.import_from(str(root), fmt)
     classes = [c for c in project.categories().get("label", dm.LabelCategories()).items]
@@ -365,10 +347,7 @@ def _import_via_datumaro(
             geom: dict[str, Any] | None = None
             atype: str | None = None
             cls = (
-                project.categories()
-                .get("label", dm.LabelCategories())
-                .items[a.label]
-                .name
+                project.categories().get("label", dm.LabelCategories()).items[a.label].name
                 if hasattr(a, "label") and a.label is not None
                 else "object"
             )
@@ -377,9 +356,7 @@ def _import_via_datumaro(
                 atype = "box"
             elif a.type == dm.AnnotationType.polygon:
                 pts = a.points
-                points = [
-                    {"x": pts[i], "y": pts[i + 1]} for i in range(0, len(pts) - 1, 2)
-                ]
+                points = [{"x": pts[i], "y": pts[i + 1]} for i in range(0, len(pts) - 1, 2)]
                 geom = {"points": points}
                 atype = "polygon"
             elif a.type == dm.AnnotationType.label:
@@ -463,9 +440,7 @@ def export_archive(
                     cy = (g.get("y", 0) + g.get("h", 0) / 2) / h
                     bw = g.get("w", 0) / w
                     bh = g.get("h", 0) / h
-                    cls_idx = (
-                        classes.index(a.class_name) if a.class_name in classes else 0
-                    )
+                    cls_idx = classes.index(a.class_name) if a.class_name in classes else 0
                     lines.append(f"{cls_idx} {cx:.6f} {cy:.6f} {bw:.6f} {bh:.6f}")
                 base_stem = Path(asset.uri).stem or asset.id
                 stem = base_stem
@@ -605,9 +580,7 @@ def _build_datumaro_dataset(
             dm.DatasetItem(
                 id=Path(asset.uri).stem,
                 annotations=ann_objs,
-                media=dm.Image(
-                    path=asset.uri, size=(asset.height or 0, asset.width or 0)
-                ),
+                media=dm.Image(path=asset.uri, size=(asset.height or 0, asset.width or 0)),
             )
         )
     return dm.Dataset.from_iterable(items, categories={dm.AnnotationType.label: cats})
@@ -659,9 +632,7 @@ def _iter_assets_with_annotations(
 
     assets = list(db.scalars(select(Asset).where(Asset.version_id == version.id)).all())
     for asset in assets:
-        anns = list(
-            db.scalars(select(Annotation).where(Annotation.asset_id == asset.id)).all()
-        )
+        anns = list(db.scalars(select(Annotation).where(Annotation.asset_id == asset.id)).all())
         yield asset, anns
 
 

--- a/backend/src/app/services/evaluation_service.py
+++ b/backend/src/app/services/evaluation_service.py
@@ -76,9 +76,7 @@ def create_evaluation(
     # error propagates and the caller turns it into a 409.
     if payload.cluster_id:
         try:
-            cluster_service.reserve_cluster(
-                db, payload.cluster_id, job_id=job_row.id, kind="eval"
-            )
+            cluster_service.reserve_cluster(db, payload.cluster_id, job_id=job_row.id, kind="eval")
         except Exception:
             # Mark the queued rows as failed so the dashboard doesn't show a
             # phantom queued evaluation.
@@ -145,7 +143,17 @@ def list_evaluations(
     artifact_id: str | None = None,
     dataset_version_id: str | None = None,
     project_id: str | None = None,
-) -> list[Evaluation]:
+    page: int = 1,
+    page_size: int = 50,
+    return_total: bool = False,
+):
+    """List evaluations.
+
+    When ``return_total`` is ``True`` returns ``(rows, total)`` for paginated
+    callers; otherwise returns a flat ``list[Evaluation]`` for legacy callers.
+    """
+    from sqlalchemy import func as _func
+
     q = select(Evaluation).order_by(Evaluation.created_at.desc())
     if artifact_id:
         q = q.where(Evaluation.artifact_id == artifact_id)
@@ -153,6 +161,12 @@ def list_evaluations(
         q = q.where(Evaluation.dataset_version_id == dataset_version_id)
     if project_id:
         q = q.where(Evaluation.project_id == project_id)
+
+    if return_total:
+        total = db.scalar(select(_func.count()).select_from(q.subquery())) or 0
+        offset = max(0, (page - 1) * page_size)
+        rows = list(db.scalars(q.offset(offset).limit(page_size)).all())
+        return rows, int(total)
     return list(db.scalars(q).all())
 
 

--- a/backend/src/app/services/notification_service.py
+++ b/backend/src/app/services/notification_service.py
@@ -1,6 +1,3 @@
-from typing import List
-
-
 class NotificationService:
     def __init__(self):
         self.notifications = []
@@ -11,7 +8,7 @@ class NotificationService:
             {"user_id": user_id, "type": type, "title": title, "body": body, "read": False}
         )
 
-    def get_notifications(self, user_id: str) -> List[dict]:
+    def get_notifications(self, user_id: str) -> list[dict]:
         return [n for n in self.notifications if n["user_id"] == user_id]
 
 

--- a/backend/src/app/services/onnx_service.py
+++ b/backend/src/app/services/onnx_service.py
@@ -9,6 +9,14 @@ from app.services import cluster_service
 from app.services.jobs_service import create_job
 
 
+class OnnxDispatchError(Exception):
+    """Raised when the ONNX export Celery task can't be dispatched.
+
+    The associated job row is marked ``failed`` before this is raised so the
+    UI doesn't show a phantom queued export.
+    """
+
+
 def export_onnx(
     db: Session,
     experiment_id: str,
@@ -21,8 +29,9 @@ def export_onnx(
 
     Mirrors training/evaluation behaviour: optionally reserve a cluster and
     route the Celery task to that cluster's queue. If reservation succeeds
-    but task dispatch fails (broker down), the cluster is released so we
-    don't pin capacity to a phantom job.
+    but task dispatch fails (broker down), the cluster is released and the
+    job row is flipped to ``failed`` — leaving stale ``queued`` rows around
+    is exactly the bug Copilot's review flagged.
     """
     payload: dict[str, Any] = {
         "experimentId": experiment_id,
@@ -51,17 +60,21 @@ def export_onnx(
         if queue:
             send_kwargs["queue"] = queue
         celery_app.send_task("app.jobs.tasks.onnx_export.export_task", **send_kwargs)
-    except Exception:
-        # If we already reserved a cluster, release it so capacity isn't
-        # pinned to a task no worker will ever see.
+    except Exception as exc:
+        # Release any reservation, then flip the job to failed so it doesn't
+        # sit in the dashboard as a phantom queued export.
         if cluster_id:
             try:
                 cluster_service.release_cluster(db, cluster_id)
             except Exception:
                 pass
-        # The job row is still in the DB; a worker can pick it up when the
-        # broker recovers. The cluster reservation is the only thing that
-        # could leak, and we just released it.
+        from app.services.jobs_service import update_job_status
+
+        try:
+            update_job_status(db, job_row.id, status="failed", progress=0.0)
+        except Exception:
+            pass
+        raise OnnxDispatchError(f"failed to dispatch ONNX export task: {exc}") from exc
 
     return {
         "id": job_row.id,

--- a/backend/src/app/services/onnx_service.py
+++ b/backend/src/app/services/onnx_service.py
@@ -13,25 +13,37 @@ def export_onnx(
     db: Session,
     experiment_id: str,
     dynamic_axes: bool | None = None,
+    *,
+    opset: int | None = None,
     cluster_id: str | None = None,
 ) -> dict[str, Any]:
-    if cluster_id:
-        cluster_service.reserve_cluster(db, cluster_id, job_id="pending", kind="eval")
+    """Queue an ONNX export of the artifact produced by ``experiment_id``.
 
-    payload = {
+    Mirrors training/evaluation behaviour: optionally reserve a cluster and
+    route the Celery task to that cluster's queue. If reservation succeeds
+    but task dispatch fails (broker down), the cluster is released so we
+    don't pin capacity to a phantom job.
+    """
+    payload: dict[str, Any] = {
         "experimentId": experiment_id,
         "dynamicAxes": dynamic_axes,
+        "opset": opset,
         "clusterId": cluster_id,
     }
     job_row = create_job(db, "onnx_export", payload)
     payload["jobId"] = job_row.id
 
     if cluster_id:
-        cluster = cluster_service.get_cluster(db, cluster_id)
-        if cluster:
-            cluster.active_job_id = job_row.id
-            db.add(cluster)
-            db.commit()
+        try:
+            cluster_service.reserve_cluster(db, cluster_id, job_id=job_row.id, kind="eval")
+        except Exception:
+            from app.services.jobs_service import update_job_status
+
+            try:
+                update_job_status(db, job_row.id, status="failed", progress=0.0)
+            except Exception:
+                pass
+            raise
 
     queue = f"cluster.{cluster_id}" if cluster_id else None
     try:
@@ -39,13 +51,21 @@ def export_onnx(
         if queue:
             send_kwargs["queue"] = queue
         celery_app.send_task("app.jobs.tasks.onnx_export.export_task", **send_kwargs)
-        job_id = job_row.id
     except Exception:
-        job_id = job_row.id
+        # If we already reserved a cluster, release it so capacity isn't
+        # pinned to a task no worker will ever see.
+        if cluster_id:
+            try:
+                cluster_service.release_cluster(db, cluster_id)
+            except Exception:
+                pass
+        # The job row is still in the DB; a worker can pick it up when the
+        # broker recovers. The cluster reservation is the only thing that
+        # could leak, and we just released it.
 
     return {
-        "id": job_id,
-        "jobId": job_id,
+        "id": job_row.id,
+        "jobId": job_row.id,
         "type": "onnx_export",
         "status": "queued",
         "progress": 0.0,

--- a/backend/src/app/services/project_dataset_service.py
+++ b/backend/src/app/services/project_dataset_service.py
@@ -16,7 +16,15 @@ def create_project(
     *,
     task_type: str | None = None,
     workspace_id: str | None = None,
+    commit: bool = True,
 ) -> Project:
+    """Create a Project row.
+
+    By default the row is committed so single-call callers (e.g. ``POST
+    /api/projects``) get a fully-persisted result. Multi-step callers like
+    the wizard can pass ``commit=False`` and own the transaction boundary
+    themselves so partial failures roll back cleanly.
+    """
     if task_type is not None and task_type not in VALID_TASK_TYPES:
         raise ValueError(f"task_type must be one of {VALID_TASK_TYPES}, got {task_type!r}")
     workspace_id = workspace_id or "00000000-0000-0000-0000-000000000000"
@@ -29,8 +37,11 @@ def create_project(
         task_type=task_type,
     )
     db.add(p)
-    db.commit()
-    db.refresh(p)
+    if commit:
+        db.commit()
+        db.refresh(p)
+    else:
+        db.flush()
     return p
 
 
@@ -41,11 +52,14 @@ def create_dataset(
     description: str | None = None,
     *,
     task_type: str | None = None,
+    commit: bool = True,
 ) -> tuple[Dataset, DatasetVersion]:
     """Create a dataset and its initial version.
 
     If ``task_type`` is omitted, the dataset inherits its parent project's
-    task_type (which is itself optional for legacy projects).
+    task_type (which is itself optional for legacy projects). Pass
+    ``commit=False`` from inside a larger transaction (e.g. the wizard) so
+    the caller can roll back cleanly on partial failure.
     """
     if task_type is not None and task_type not in VALID_TASK_TYPES:
         raise ValueError(f"task_type must be one of {VALID_TASK_TYPES}, got {task_type!r}")
@@ -65,7 +79,10 @@ def create_dataset(
     # Create initial version
     v = DatasetVersion(dataset_id=d.id, version=1)
     db.add(v)
-    db.commit()
-    db.refresh(d)
-    db.refresh(v)
+    if commit:
+        db.commit()
+        db.refresh(d)
+        db.refresh(v)
+    else:
+        db.flush()
     return d, v

--- a/backend/src/app/services/project_dataset_service.py
+++ b/backend/src/app/services/project_dataset_service.py
@@ -6,13 +6,28 @@ from app.models.dataset import Dataset
 from app.models.dataset_version import DatasetVersion
 from app.models.project import Project
 
+VALID_TASK_TYPES = ("detect", "classify")
 
-def create_project(db: Session, name: str, description: str | None) -> Project:
-    # For now, use a dummy workspace_id. In a real implementation,
-    # we'd get this from the authenticated user's workspace
-    dummy_workspace_id = "00000000-0000-0000-0000-000000000000"
+
+def create_project(
+    db: Session,
+    name: str,
+    description: str | None,
+    *,
+    task_type: str | None = None,
+    workspace_id: str | None = None,
+) -> Project:
+    if task_type is not None and task_type not in VALID_TASK_TYPES:
+        raise ValueError(f"task_type must be one of {VALID_TASK_TYPES}, got {task_type!r}")
+    workspace_id = workspace_id or "00000000-0000-0000-0000-000000000000"
     slug = name.lower().replace(" ", "-")
-    p = Project(workspace_id=dummy_workspace_id, name=name, slug=slug, description=description)
+    p = Project(
+        workspace_id=workspace_id,
+        name=name,
+        slug=slug,
+        description=description,
+        task_type=task_type,
+    )
     db.add(p)
     db.commit()
     db.refresh(p)
@@ -20,10 +35,30 @@ def create_project(db: Session, name: str, description: str | None) -> Project:
 
 
 def create_dataset(
-    db: Session, project_id: str, name: str, description: str | None = None
+    db: Session,
+    project_id: str,
+    name: str,
+    description: str | None = None,
+    *,
+    task_type: str | None = None,
 ) -> tuple[Dataset, DatasetVersion]:
-    """Create a dataset and its initial version"""
-    d = Dataset(project_id=project_id, name=name, description=description)
+    """Create a dataset and its initial version.
+
+    If ``task_type`` is omitted, the dataset inherits its parent project's
+    task_type (which is itself optional for legacy projects).
+    """
+    if task_type is not None and task_type not in VALID_TASK_TYPES:
+        raise ValueError(f"task_type must be one of {VALID_TASK_TYPES}, got {task_type!r}")
+    if task_type is None:
+        project = db.get(Project, project_id)
+        task_type = project.task_type if project else None
+
+    d = Dataset(
+        project_id=project_id,
+        name=name,
+        description=description,
+        task_type=task_type,
+    )
     db.add(d)
     db.flush()  # Get the dataset ID without committing
 

--- a/backend/src/app/services/training_service.py
+++ b/backend/src/app/services/training_service.py
@@ -12,6 +12,10 @@ from app.services import cluster_service
 from app.services.jobs_service import create_job
 
 
+class TaskTypeMismatch(Exception):
+    """Raised when a training run's task disagrees with its dataset's task_type."""
+
+
 def launch_training(
     db: Session,
     project_id: str,
@@ -23,6 +27,20 @@ def launch_training(
     owner_id: str | None = None,
     cluster_id: str | None = None,
 ) -> dict[str, Any]:
+    # Reject obvious task/dataset mismatches so we don't burn cluster time on
+    # a run we already know will fail (e.g. classify on a detection dataset).
+    from app.models.dataset import Dataset
+    from app.models.dataset_version import DatasetVersion
+
+    requested = (task or "").lower()
+    if requested in ("detect", "classify"):
+        version = db.get(DatasetVersion, dataset_version_id)
+        dataset = db.get(Dataset, version.dataset_id) if version else None
+        if dataset and dataset.task_type and dataset.task_type != requested:
+            raise TaskTypeMismatch(
+                f"task '{requested}' does not match dataset task_type " f"'{dataset.task_type}'"
+            )
+
     # Build full params including task and base_model so the worker can read them
     full_params = dict(params or {})
     full_params.setdefault("task", task)

--- a/backend/tests/contract/test_projects_get.py
+++ b/backend/tests/contract/test_projects_get.py
@@ -13,9 +13,13 @@ from app.main import app
 client = TestClient(app)
 
 
-def test_list_projects_contract_returns_array():
+def test_list_projects_contract_returns_paginated_envelope():
     r = client.get("/api/projects")
     assert r.status_code in (200, 204)
     if r.status_code == 200:
         data = r.json()
-        assert isinstance(data, list)
+        assert isinstance(data, dict)
+        assert "items" in data and isinstance(data["items"], list)
+        assert "total" in data
+        assert "page" in data
+        assert "page_size" in data

--- a/backend/tests/integration/test_annotations_phase2.py
+++ b/backend/tests/integration/test_annotations_phase2.py
@@ -1,0 +1,152 @@
+"""Integration tests for the Phase 2 annotation endpoints (bulk, review)."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.db.deps import get_current_user
+from app.main import app
+from app.models.user import User
+
+
+def _fake_user() -> User:
+    return User(id="test-user", email="t@x.com", name="Tester", password_hash="$2b$x")
+
+
+app.dependency_overrides[get_current_user] = _fake_user
+client = TestClient(app)
+
+
+def _u(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def _seed_dataset_with_asset() -> tuple[str, str, str]:
+    """Create a workspace/project/dataset/version/asset and return their IDs."""
+    from app.db.session import SessionLocal
+    from app.models.asset import Asset
+    from app.models.dataset import Dataset
+    from app.models.dataset_version import DatasetVersion
+    from app.models.project import Project
+    from app.models.user import User as UserModel
+    from app.models.workspace import Workspace
+
+    with SessionLocal() as db:
+        if not db.get(UserModel, "test-user"):
+            db.add(UserModel(id="test-user", email="t@x.com", name="T", password_hash="$2b$x"))
+            db.commit()
+        ws_id = _u("ws")
+        db.add(Workspace(id=ws_id, name="W", region="us", created_by="test-user"))
+        proj_id = _u("p")
+        db.add(Project(id=proj_id, workspace_id=ws_id, name="P", slug=proj_id))
+        ds_id = _u("d")
+        db.add(Dataset(id=ds_id, project_id=proj_id, name="D", description=""))
+        ver_id = _u("v")
+        db.add(DatasetVersion(id=ver_id, dataset_id=ds_id, version=1))
+        asset_id = _u("a")
+        db.add(
+            Asset(
+                id=asset_id,
+                dataset_id=ds_id,
+                version_id=ver_id,
+                uri="datasets/x/y.jpg",
+                mime_type="image/jpeg",
+                label_status="unlabeled",
+            )
+        )
+        db.commit()
+        return ds_id, ver_id, asset_id
+
+
+def test_bulk_save_creates_and_review_queue_summarises():
+    ds_id, _ver_id, asset_id = _seed_dataset_with_asset()
+
+    body = {
+        "creates": [
+            {
+                "client_id": "tmp-1",
+                "asset_id": asset_id,
+                "type": "box",
+                "geometry": {"x": 1, "y": 2, "w": 30, "h": 40},
+                "class_name": "cat",
+            },
+            {
+                "client_id": "tmp-2",
+                "asset_id": asset_id,
+                "type": "box",
+                "geometry": {"x": 5, "y": 5, "w": 50, "h": 50},
+                "class_name": "dog",
+            },
+        ],
+        "updates": [],
+        "deletes": [],
+    }
+    r = client.post("/api/annotations/bulk", json=body)
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert len(payload["created"]) == 2
+    assert all(c["status"] == "ok" for c in payload["created"])
+
+    # Approve one, leave the other unreviewed.
+    first_id = payload["created"][0]["annotation"]["id"]
+    r2 = client.post(
+        f"/api/annotations/{first_id}/review",
+        json={"review_status": "approved"},
+    )
+    assert r2.status_code == 200
+    assert r2.json()["review_status"] == "approved"
+
+    # Review queue should report 1 approved + 1 unreviewed.
+    summary = client.get(f"/api/annotations/datasets/{ds_id}/review/summary").json()
+    assert summary["approved"] == 1
+    assert summary["unreviewed"] == 1
+    assert summary["rejected"] == 0
+    assert summary["total"] == 2
+
+    queue = client.get(f"/api/annotations/datasets/{ds_id}/review?review_status=unreviewed").json()
+    assert queue["total"] == 1
+    assert len(queue["items"]) == 1
+    assert queue["items"][0]["annotation"]["review_status"] == "unreviewed"
+
+
+def test_bulk_save_reports_per_row_conflict():
+    _, _, asset_id = _seed_dataset_with_asset()
+
+    # Seed an annotation by creating one via bulk.
+    r = client.post(
+        "/api/annotations/bulk",
+        json={
+            "creates": [
+                {
+                    "client_id": "x",
+                    "asset_id": asset_id,
+                    "type": "box",
+                    "geometry": {"x": 0, "y": 0, "w": 5, "h": 5},
+                    "class_name": "dog",
+                }
+            ],
+            "updates": [],
+            "deletes": [],
+        },
+    )
+    ann = r.json()["created"][0]["annotation"]
+
+    # Now send an update with a wrong expected_version → conflict.
+    r2 = client.post(
+        "/api/annotations/bulk",
+        json={
+            "creates": [],
+            "updates": [
+                {
+                    "id": ann["id"],
+                    "geometry": {"x": 1, "y": 1, "w": 6, "h": 6},
+                    "expected_version": ann["version"] + 99,
+                }
+            ],
+            "deletes": [],
+        },
+    )
+    assert r2.status_code == 200
+    assert r2.json()["updated"][0]["status"] == "conflict"

--- a/backend/tests/integration/test_artifacts_phase3.py
+++ b/backend/tests/integration/test_artifacts_phase3.py
@@ -1,0 +1,111 @@
+"""Integration tests for Phase 3 artifact endpoints (download + lineage)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.db.deps import get_current_user
+from app.main import app
+from app.models.user import User
+
+
+def _fake_user() -> User:
+    return User(id="test-user", email="t@x.com", name="Tester", password_hash="$2b$x")
+
+
+app.dependency_overrides[get_current_user] = _fake_user
+client = TestClient(app)
+
+
+def _u(p: str) -> str:
+    return f"{p}-{uuid.uuid4().hex[:8]}"
+
+
+def _seed_artifact(storage_path: str | None = None) -> tuple[str, str, str]:
+    """Create the bare-minimum graph: project → run → artifact + dataset version."""
+    from app.db.session import SessionLocal
+    from app.models.artifact import ModelArtifact
+    from app.models.dataset import Dataset
+    from app.models.dataset_version import DatasetVersion
+    from app.models.experiment import ExperimentRun
+    from app.models.project import Project
+    from app.models.user import User as UserModel
+    from app.models.workspace import Workspace
+
+    with SessionLocal() as db:
+        if not db.get(UserModel, "test-user"):
+            db.add(UserModel(id="test-user", email="t@x.com", name="T", password_hash="$2b$x"))
+            db.commit()
+        ws_id = _u("ws")
+        db.add(Workspace(id=ws_id, name="W", region="us", created_by="test-user"))
+        proj_id = _u("p")
+        db.add(Project(id=proj_id, workspace_id=ws_id, name="P", slug=proj_id))
+        ds_id = _u("d")
+        db.add(Dataset(id=ds_id, project_id=proj_id, name="D"))
+        ver_id = _u("v")
+        db.add(DatasetVersion(id=ver_id, dataset_id=ds_id, version=1))
+        run_id = _u("r")
+        db.add(
+            ExperimentRun(
+                id=run_id,
+                project_id=proj_id,
+                dataset_version_id=ver_id,
+                owner_id="test-user",
+                name="run",
+                status="succeeded",
+            )
+        )
+        artifact_id = _u("a")
+        db.add(
+            ModelArtifact(
+                id=artifact_id,
+                project_id=proj_id,
+                run_id=run_id,
+                name="m",
+                version="1",
+                type="yolo",
+                format="pytorch",
+                storage_path=storage_path or "models/some/key.pt",
+            )
+        )
+        db.commit()
+        return artifact_id, run_id, ver_id
+
+
+def test_lineage_returns_full_graph():
+    artifact_id, run_id, ver_id = _seed_artifact()
+    r = client.get(f"/api/artifacts/models/{artifact_id}/lineage")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["artifact"]["id"] == artifact_id
+    assert body["experiment_run"]["id"] == run_id
+    assert body["dataset_version"]["id"] == ver_id
+    assert isinstance(body["evaluations"], list)
+    assert isinstance(body["siblings"], list)
+
+
+def test_download_streams_local_file():
+    """When storage_path is a local path that exists, the endpoint streams it."""
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pt") as f:
+        f.write(b"\x00\x01PYTORCH\x00")
+        local = f.name
+    try:
+        artifact_id, _run_id, _ver_id = _seed_artifact(storage_path=local)
+        r = client.get(f"/api/artifacts/models/{artifact_id}/download")
+        assert r.status_code == 200
+        assert r.content.startswith(b"\x00\x01PYTORCH")
+    finally:
+        os.unlink(local)
+
+
+def test_download_404_when_no_storage_path():
+    """Storage path missing entirely → 404."""
+    artifact_id, _, _ = _seed_artifact(storage_path="")
+    # storage_path was set to "" by _seed_artifact when we pass empty;
+    # however SQLAlchemy may turn '' into a falsy string. Confirm via API.
+    r = client.get(f"/api/artifacts/models/{artifact_id}/download")
+    assert r.status_code in (404, 502)

--- a/backend/tests/integration/test_phase2_3_review_fixes.py
+++ b/backend/tests/integration/test_phase2_3_review_fixes.py
@@ -1,0 +1,143 @@
+"""Regression tests for the Copilot-review issues addressed in PR #11.
+
+Covers:
+* fps_interval validation on the frame-extraction trigger
+* mAP50 invariance and mAP_at_iou for non-default thresholds (unit-side)
+* Wizard atomicity: a failed class map must roll back the project + dataset
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest import mock
+
+from fastapi.testclient import TestClient
+
+from app.db.deps import get_current_user
+from app.main import app
+from app.models.user import User
+
+
+def _fake_user() -> User:
+    return User(id="test-user", email="t@x.com", name="Tester", password_hash="$2b$x")
+
+
+app.dependency_overrides[get_current_user] = _fake_user
+client = TestClient(app)
+
+
+def _u(p: str) -> str:
+    return f"{p}-{uuid.uuid4().hex[:8]}"
+
+
+def _seed_video_asset() -> tuple[str, str]:
+    from app.db.session import SessionLocal
+    from app.models.asset import Asset
+    from app.models.dataset import Dataset
+    from app.models.dataset_version import DatasetVersion
+    from app.models.project import Project
+    from app.models.user import User as UserModel
+    from app.models.workspace import Workspace
+
+    with SessionLocal() as db:
+        if not db.get(UserModel, "test-user"):
+            db.add(UserModel(id="test-user", email="t@x.com", name="T", password_hash="$2b$x"))
+            db.commit()
+        ws_id = _u("ws")
+        db.add(Workspace(id=ws_id, name="W", region="us", created_by="test-user"))
+        proj_id = _u("p")
+        db.add(Project(id=proj_id, workspace_id=ws_id, name="P", slug=proj_id))
+        ds_id = _u("d")
+        db.add(Dataset(id=ds_id, project_id=proj_id, name="D"))
+        ver_id = _u("v")
+        db.add(DatasetVersion(id=ver_id, dataset_id=ds_id, version=1))
+        asset_id = _u("a")
+        db.add(
+            Asset(
+                id=asset_id,
+                dataset_id=ds_id,
+                version_id=ver_id,
+                uri=f"datasets/{ver_id}/clip.mp4",
+                mime_type="video/mp4",
+                label_status="unlabeled",
+            )
+        )
+        db.commit()
+        return ds_id, asset_id
+
+
+def test_extract_frames_rejects_zero_fps_interval():
+    ds_id, asset_id = _seed_video_asset()
+    r = client.post(
+        f"/api/datasets/{ds_id}/assets/{asset_id}/extract-frames?fps_interval=0",
+    )
+    assert r.status_code == 422  # FastAPI validation
+
+
+def test_extract_frames_rejects_negative_fps_interval():
+    ds_id, asset_id = _seed_video_asset()
+    r = client.post(
+        f"/api/datasets/{ds_id}/assets/{asset_id}/extract-frames?fps_interval=-1",
+    )
+    assert r.status_code == 422
+
+
+def test_wizard_rolls_back_project_when_class_map_fails():
+    """If ClassMap creation explodes mid-wizard, we must not leak a project.
+
+    We patch ClassMap to raise on construction. The wizard should rollback,
+    so the project name must NOT be findable after the failed call.
+    """
+    from app.models import dataset as dataset_models
+
+    name = f"rollback-{uuid.uuid4().hex[:8]}"
+    real_cm = dataset_models.ClassMap
+
+    class _Boom(real_cm):
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("simulated class-map failure")
+
+    with mock.patch.object(dataset_models, "ClassMap", _Boom):
+        r = client.post(
+            "/api/projects/wizard",
+            json={
+                "name": name,
+                "task_type": "detect",
+                "dataset_name": "default",
+                "classes": [{"name": "person"}],
+            },
+        )
+        # The endpoint propagates the failure as 500.
+        assert r.status_code in (500, 400)
+
+    # Project must not exist — the wizard rolled back.
+    listing = client.get("/api/projects?page=1&page_size=200").json()
+    names = [p["name"] for p in listing["items"]]
+    assert name not in names, f"wizard leaked a partial project: {name}"
+
+
+def test_extract_frames_dispatch_failure_marks_failed():
+    """Broker outage on extract-frames should fail the job, not leave it queued."""
+    from app.db.session import SessionLocal
+    from app.models.job import Job
+
+    ds_id, asset_id = _seed_video_asset()
+
+    with mock.patch(
+        "app.jobs.celery_app.celery_app.send_task",
+        side_effect=RuntimeError("broker unreachable"),
+    ):
+        r = client.post(
+            f"/api/datasets/{ds_id}/assets/{asset_id}/extract-frames?fps_interval=1.0",
+        )
+    assert r.status_code == 503
+
+    with SessionLocal() as db:
+        job = (
+            db.query(Job)
+            .filter(Job.type == "frame_extraction")
+            .order_by(Job.created_at.desc())
+            .first()
+        )
+        assert job is not None
+        assert job.status == "failed"

--- a/backend/tests/integration/test_project_wizard.py
+++ b/backend/tests/integration/test_project_wizard.py
@@ -1,0 +1,65 @@
+"""Integration tests for the multi-step project wizard endpoint."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.db.deps import get_current_user
+from app.main import app
+from app.models.user import User
+
+
+def _fake_user() -> User:
+    return User(id="test-user", email="t@x.com", name="Tester", password_hash="$2b$x")
+
+
+app.dependency_overrides[get_current_user] = _fake_user
+client = TestClient(app)
+
+
+def test_wizard_creates_project_dataset_and_class_map():
+    r = client.post(
+        "/api/projects/wizard",
+        json={
+            "name": "Wizard Detector",
+            "description": "Auto-created via wizard",
+            "task_type": "detect",
+            "dataset_name": "default",
+            "classes": [
+                {"name": "person"},
+                {"name": "car"},
+                {"name": "dog"},
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["project"]["task_type"] == "detect"
+    assert body["dataset"]["task_type"] == "detect"
+    assert body["version"]["version"] == 1
+    assert sorted(body["classes"]) == ["car", "dog", "person"]
+
+
+def test_wizard_rejects_unknown_task_type():
+    r = client.post(
+        "/api/projects/wizard",
+        json={
+            "name": "X",
+            "task_type": "segmentation",  # not in VALID_TASK_TYPES
+            "dataset_name": "default",
+            "classes": [],
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_paginated_projects_response_shape():
+    # The list endpoint now returns {items, total, page, page_size}.
+    r = client.get("/api/projects?page=1&page_size=5")
+    assert r.status_code == 200
+    body = r.json()
+    assert "items" in body
+    assert isinstance(body["items"], list)
+    assert "total" in body
+    assert "page" in body
+    assert "page_size" in body

--- a/backend/tests/unit/test_annotation_review_and_bulk.py
+++ b/backend/tests/unit/test_annotation_review_and_bulk.py
@@ -1,0 +1,205 @@
+"""Unit tests for the Phase 2 annotation review + bulk-save additions."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db.base import Base
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite+pysqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    session = Session()
+    yield session
+    session.close()
+    Base.metadata.drop_all(engine)
+
+
+def _seed(db, dataset_id: str = "ds-1") -> str:
+    from app.models.asset import Asset
+    from app.models.dataset import Dataset
+    from app.models.dataset_version import DatasetVersion
+    from app.models.project import Project
+    from app.models.user import User
+    from app.models.workspace import Workspace
+
+    db.add(Workspace(id="ws-1", name="W", created_by="user-1"))
+    db.add(Project(id="proj-1", workspace_id="ws-1", name="P", slug="p"))
+    db.add(Dataset(id=dataset_id, project_id="proj-1", name="DS"))
+    db.add(DatasetVersion(id="ver-1", dataset_id=dataset_id, version=1))
+    db.add(
+        Asset(
+            id="asset-1",
+            dataset_id=dataset_id,
+            version_id="ver-1",
+            uri="datasets/v1/img.jpg",
+            mime_type="image/jpeg",
+            label_status="unlabeled",
+        )
+    )
+    db.add(User(id="user-1", name="A", email="a@a.com"))
+    db.add(User(id="reviewer-1", name="R", email="r@r.com"))
+    db.commit()
+    return "asset-1"
+
+
+def test_bulk_save_creates_updates_and_deletes(db):
+    from app.services.annotation_service import bulk_save, get_asset_annotations
+
+    _seed(db)
+    # Seed an existing annotation we'll update.
+    from app.services.annotation_service import create_annotation
+
+    existing = create_annotation(
+        db,
+        asset_id="asset-1",
+        author_id="user-1",
+        type="box",
+        geometry={"x": 0, "y": 0, "w": 10, "h": 10},
+        class_name="dog",
+    )
+    base_version = existing.version
+
+    result = bulk_save(
+        db,
+        author_id="user-1",
+        creates=[
+            {
+                "client_id": "tmp-1",
+                "asset_id": "asset-1",
+                "type": "box",
+                "geometry": {"x": 5, "y": 5, "w": 20, "h": 20},
+                "class_name": "cat",
+            }
+        ],
+        updates=[
+            {
+                "id": existing.id,
+                "geometry": {"x": 1, "y": 1, "w": 11, "h": 11},
+                "class_name": "dog",
+                "expected_version": existing.version,
+            }
+        ],
+        deletes=[],
+    )
+
+    # One created, one updated, no deletes.
+    assert len(result["created"]) == 1
+    assert result["created"][0]["status"] == "ok"
+    assert result["created"][0]["client_id"] == "tmp-1"
+    assert len(result["updated"]) == 1
+    assert result["updated"][0]["status"] == "ok"
+    assert result["updated"][0]["annotation"]["version"] == base_version + 1
+
+    rows = get_asset_annotations(db, "asset-1")
+    assert len(rows) == 2
+
+
+def test_bulk_save_reports_version_conflict(db):
+    from app.services.annotation_service import bulk_save, create_annotation
+
+    _seed(db)
+    ann = create_annotation(
+        db,
+        asset_id="asset-1",
+        author_id="user-1",
+        type="box",
+        geometry={"x": 0, "y": 0, "w": 10, "h": 10},
+        class_name="dog",
+    )
+
+    result = bulk_save(
+        db,
+        author_id="user-1",
+        creates=[],
+        updates=[
+            {
+                "id": ann.id,
+                "class_name": "cat",
+                "expected_version": ann.version + 99,  # wrong
+            }
+        ],
+        deletes=[],
+    )
+    statuses = [u["status"] for u in result["updated"]]
+    assert statuses == ["conflict"]
+
+
+def test_set_review_approves_and_clears(db):
+    from app.services.annotation_service import (
+        create_annotation,
+        set_review,
+        update_annotation,
+    )
+
+    _seed(db)
+    ann = create_annotation(
+        db,
+        asset_id="asset-1",
+        author_id="user-1",
+        type="box",
+        geometry={"x": 0, "y": 0, "w": 10, "h": 10},
+        class_name="dog",
+    )
+
+    approved = set_review(
+        db, ann.id, review_status="approved", reviewer_id="reviewer-1", notes="lgtm"
+    )
+    assert approved.review_status == "approved"
+    assert approved.reviewer_id == "reviewer-1"
+    assert approved.review_notes == "lgtm"
+
+    # Updating an approved annotation invalidates the prior review.
+    after = update_annotation(
+        db, ann.id, geometry={"x": 2, "y": 2, "w": 12, "h": 12}, expected_version=ann.version
+    )
+    assert after.review_status == "unreviewed"
+    assert after.reviewer_id is None
+
+
+def test_review_summary_counts(db):
+    from app.services.annotation_service import (
+        create_annotation,
+        review_summary,
+        set_review,
+    )
+
+    _seed(db)
+    a = create_annotation(
+        db,
+        asset_id="asset-1",
+        author_id="user-1",
+        type="box",
+        geometry={"x": 0, "y": 0, "w": 10, "h": 10},
+        class_name="dog",
+    )
+    b = create_annotation(
+        db,
+        asset_id="asset-1",
+        author_id="user-1",
+        type="box",
+        geometry={"x": 1, "y": 1, "w": 11, "h": 11},
+        class_name="cat",
+    )
+    c = create_annotation(
+        db,
+        asset_id="asset-1",
+        author_id="user-1",
+        type="box",
+        geometry={"x": 2, "y": 2, "w": 12, "h": 12},
+        class_name="cat",
+    )
+    set_review(db, a.id, review_status="approved", reviewer_id="reviewer-1")
+    set_review(db, b.id, review_status="rejected", reviewer_id="reviewer-1")
+    summary = review_summary(db, dataset_id="ds-1")
+    assert summary["approved"] == 1
+    assert summary["rejected"] == 1
+    assert summary["unreviewed"] == 1
+    assert summary["total"] == 3
+    assert summary["flagged"] == 0
+    assert c is not None  # silence unused warning

--- a/backend/tests/unit/test_asset_fetch_ssrf.py
+++ b/backend/tests/unit/test_asset_fetch_ssrf.py
@@ -1,0 +1,77 @@
+"""Tests for the SSRF policy enforced by services/asset_fetch.py."""
+
+from __future__ import annotations
+
+import os
+import socket
+from unittest import mock
+
+from app.services import asset_fetch
+
+
+def test_remote_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("VF_ALLOW_REMOTE_ASSET_FETCH", raising=False)
+    # Even a public-looking URL is rejected when the opt-in flag is unset.
+    assert asset_fetch.fetch_asset_bytes("https://example.com/foo.jpg") is None
+
+
+def test_remote_enabled_blocks_loopback(monkeypatch):
+    monkeypatch.setenv("VF_ALLOW_REMOTE_ASSET_FETCH", "true")
+    # Pretend the host resolves to localhost.
+    with mock.patch.object(
+        asset_fetch.socket,
+        "getaddrinfo",
+        return_value=[(socket.AF_INET, None, None, "", ("127.0.0.1", 0))],
+    ):
+        assert asset_fetch.fetch_asset_bytes("http://internal/foo.jpg") is None
+
+
+def test_remote_enabled_blocks_private(monkeypatch):
+    monkeypatch.setenv("VF_ALLOW_REMOTE_ASSET_FETCH", "true")
+    with mock.patch.object(
+        asset_fetch.socket,
+        "getaddrinfo",
+        return_value=[(socket.AF_INET, None, None, "", ("10.0.0.5", 0))],
+    ):
+        assert asset_fetch.fetch_asset_bytes("http://internal-vpn/foo.jpg") is None
+
+
+def test_remote_enabled_blocks_link_local(monkeypatch):
+    monkeypatch.setenv("VF_ALLOW_REMOTE_ASSET_FETCH", "true")
+    with mock.patch.object(
+        asset_fetch.socket,
+        "getaddrinfo",
+        return_value=[(socket.AF_INET, None, None, "", ("169.254.169.254", 0))],
+    ):
+        # AWS metadata service exact target — must be blocked.
+        assert asset_fetch.fetch_asset_bytes("http://169.254.169.254/latest/meta-data") is None
+
+
+def test_local_file_under_cap(monkeypatch, tmp_path):
+    monkeypatch.delenv("VF_ALLOW_REMOTE_ASSET_FETCH", raising=False)
+    f = tmp_path / "img.bin"
+    f.write_bytes(b"PNG\x89data")
+    data = asset_fetch.fetch_asset_bytes(str(f))
+    assert data == b"PNG\x89data"
+
+
+def test_local_file_over_cap_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("VF_MAX_ASSET_BYTES", "8")
+    monkeypatch.delenv("VF_ALLOW_REMOTE_ASSET_FETCH", raising=False)
+    f = tmp_path / "big.bin"
+    f.write_bytes(b"\x00" * 64)
+    assert asset_fetch.fetch_asset_bytes(str(f)) is None
+    # Restore default for other tests in the suite.
+    os.environ.pop("VF_MAX_ASSET_BYTES", None)
+
+
+def test_object_store_path_falls_through_to_minio_helper():
+    """A bare key (no scheme, no on-disk match) should hit MinIO; we mock it."""
+    with mock.patch("app.services.storage.get_minio_client") as mocked:
+        client = mock.Mock()
+        resp = mock.Mock()
+        resp.read.return_value = b"BLOB"
+        client.get_object.return_value = resp
+        mocked.return_value = client
+        data = asset_fetch.fetch_asset_bytes("datasets/abc/img.jpg")
+    assert data == b"BLOB"

--- a/backend/tests/unit/test_bulk_save_savepoints.py
+++ b/backend/tests/unit/test_bulk_save_savepoints.py
@@ -1,0 +1,121 @@
+"""Verify bulk_save uses savepoints + a single commit (not O(n) commits)."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+
+from app.db.base import Base
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite+pysqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    session = Session()
+    yield session
+    session.close()
+    Base.metadata.drop_all(engine)
+
+
+def _seed(db) -> str:
+    from app.models.asset import Asset
+    from app.models.dataset import Dataset
+    from app.models.dataset_version import DatasetVersion
+    from app.models.project import Project
+    from app.models.user import User
+    from app.models.workspace import Workspace
+
+    db.add(Workspace(id="ws-1", name="W", created_by="user-1"))
+    db.add(Project(id="p-1", workspace_id="ws-1", name="P", slug="p"))
+    db.add(Dataset(id="d-1", project_id="p-1", name="D"))
+    db.add(DatasetVersion(id="v-1", dataset_id="d-1", version=1))
+    db.add(
+        Asset(
+            id="a-1",
+            dataset_id="d-1",
+            version_id="v-1",
+            uri="datasets/v1/img.jpg",
+            mime_type="image/jpeg",
+            label_status="unlabeled",
+        )
+    )
+    db.add(User(id="user-1", name="A", email="a@a.com"))
+    db.commit()
+    return "a-1"
+
+
+def test_bulk_save_emits_a_single_outer_commit(db):
+    """Multiple creates + updates should not cause O(n) outer commits."""
+    from app.services.annotation_service import bulk_save
+
+    asset_id = _seed(db)
+    engine = db.get_bind()
+    commit_count = {"n": 0}
+
+    @event.listens_for(engine, "commit")
+    def _on_commit(_conn):
+        commit_count["n"] += 1
+
+    bulk_save(
+        db,
+        author_id="user-1",
+        creates=[
+            {
+                "client_id": f"tmp-{i}",
+                "asset_id": asset_id,
+                "type": "box",
+                "geometry": {"x": i, "y": i, "w": 5, "h": 5},
+                "class_name": "cat",
+            }
+            for i in range(5)
+        ],
+        updates=[],
+        deletes=[],
+    )
+
+    # The exact count depends on SQLAlchemy bookkeeping, but it must be a
+    # small constant — emphatically not 5 (one per create).
+    assert commit_count["n"] <= 2, f"too many commits: {commit_count['n']}"
+
+
+def test_bulk_save_failed_row_does_not_block_rest(db):
+    """A bad geometry should fail just that row; the rest should land."""
+    from app.services.annotation_service import bulk_save, get_asset_annotations
+
+    asset_id = _seed(db)
+    result = bulk_save(
+        db,
+        author_id="user-1",
+        creates=[
+            {
+                "client_id": "good",
+                "asset_id": asset_id,
+                "type": "box",
+                "geometry": {"x": 0, "y": 0, "w": 10, "h": 10},
+                "class_name": "cat",
+            },
+            {
+                "client_id": "bad",
+                "asset_id": asset_id,
+                "type": "box",
+                "geometry": {"x": 0, "y": 0, "w": 0, "h": 0},  # invalid
+                "class_name": "cat",
+            },
+            {
+                "client_id": "also-good",
+                "asset_id": asset_id,
+                "type": "box",
+                "geometry": {"x": 5, "y": 5, "w": 5, "h": 5},
+                "class_name": "dog",
+            },
+        ],
+        updates=[],
+        deletes=[],
+    )
+    statuses = [c["status"] for c in result["created"]]
+    assert statuses == ["ok", "error", "ok"]
+    rows = get_asset_annotations(db, asset_id)
+    assert len(rows) == 2

--- a/backend/tests/unit/test_datumaro_import.py
+++ b/backend/tests/unit/test_datumaro_import.py
@@ -102,15 +102,11 @@ def test_export_roundtrip_coco(db):
     # First import a small COCO so we have data to export
     coco = {
         "images": [{"id": 1, "file_name": "a.jpg", "width": 100, "height": 100}],
-        "annotations": [
-            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [1, 2, 3, 4]}
-        ],
+        "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [1, 2, 3, 4]}],
         "categories": [{"id": 1, "name": "car"}],
     }
     archive = _zip_files({"annotations.json": json.dumps(coco).encode()})
-    import_archive(
-        db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco"
-    )
+    import_archive(db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco")
     blob = export_archive(db, dataset_id="d1", version_id="v1", fmt="coco")
     with zipfile.ZipFile(io.BytesIO(blob)) as zf:
         names = zf.namelist()
@@ -124,15 +120,11 @@ def test_export_roundtrip_coco(db):
 def test_export_yolo_writes_labels_and_classes(db):
     coco = {
         "images": [{"id": 1, "file_name": "a.jpg", "width": 100, "height": 100}],
-        "annotations": [
-            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [10, 20, 30, 40]}
-        ],
+        "annotations": [{"id": 1, "image_id": 1, "category_id": 1, "bbox": [10, 20, 30, 40]}],
         "categories": [{"id": 1, "name": "car"}],
     }
     archive = _zip_files({"annotations.json": json.dumps(coco).encode()})
-    import_archive(
-        db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco"
-    )
+    import_archive(db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco")
     blob = export_archive(db, dataset_id="d1", version_id="v1", fmt="yolo")
     with zipfile.ZipFile(io.BytesIO(blob)) as zf:
         names = zf.namelist()
@@ -157,9 +149,7 @@ def test_export_yolo_disambiguates_colliding_stems(db):
         "categories": [{"id": 1, "name": "car"}],
     }
     archive = _zip_files({"annotations.json": json.dumps(coco).encode()})
-    import_archive(
-        db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco"
-    )
+    import_archive(db, dataset_id="d1", version_id="v1", archive_bytes=archive, fmt="coco")
 
     blob = export_archive(db, dataset_id="d1", version_id="v1", fmt="yolo")
     with zipfile.ZipFile(io.BytesIO(blob)) as zf:

--- a/backend/tests/unit/test_evaluation_metrics_map5095.py
+++ b/backend/tests/unit/test_evaluation_metrics_map5095.py
@@ -51,3 +51,42 @@ def test_loose_predictions_have_lower_map5095():
 def test_compute_ap_helper_handles_empty():
     aps = compute_detection_ap_at_iou([], ["cat"], 0.5)
     assert aps == {"cat": 0.0}
+
+
+def test_map50_is_pinned_to_iou_0_5_regardless_of_caller_threshold():
+    """`mAP50` must always be mAP at IoU=0.50, even when caller picks 0.75.
+
+    The caller-selected threshold is reported separately under `mAP_at_iou`
+    so downstream code can reason about both metrics unambiguously.
+    """
+    items = []
+    for i in range(3):
+        gt = {"class": "cat", "bbox": (0.0, 0.0, 100.0, 100.0)}
+        # Shift by 30 pixels in x → IoU ≈ 0.538 (matches at .5 only)
+        pred = {"class": "cat", "bbox": (30.0, 0.0, 100.0, 100.0), "score": 0.99}
+        items.append({"asset_id": f"a{i}", "gt": [gt], "pred": [pred]})
+
+    metrics_at_50 = compute_detection_metrics(items, ["cat"], iou_threshold=0.5)["metrics"]
+    metrics_at_75 = compute_detection_metrics(items, ["cat"], iou_threshold=0.75)["metrics"]
+
+    # mAP50 is invariant — same value whether the caller passed 0.5 or 0.75.
+    assert metrics_at_50["mAP50"] == metrics_at_75["mAP50"]
+    # mAP_at_iou tracks the caller's choice.
+    assert metrics_at_50["mAP_at_iou"] == metrics_at_50["mAP_50"]
+    assert metrics_at_75["mAP_at_iou"] == metrics_at_75["mAP_75"]
+    # And iou_threshold is reported alongside.
+    assert metrics_at_50["iou_threshold"] == 0.5
+    assert metrics_at_75["iou_threshold"] == 0.75
+
+
+def test_non_grid_iou_threshold_is_supported():
+    """A caller-selected IoU outside the .5/.55/.../.95 grid still reports a value."""
+    items = []
+    for i in range(3):
+        gt = {"class": "cat", "bbox": (0.0, 0.0, 100.0, 100.0)}
+        pred = {"class": "cat", "bbox": (0.0, 0.0, 100.0, 100.0), "score": 0.99}
+        items.append({"asset_id": f"a{i}", "gt": [gt], "pred": [pred]})
+    metrics = compute_detection_metrics(items, ["cat"], iou_threshold=0.42)["metrics"]
+    assert metrics["iou_threshold"] == 0.42
+    assert "mAP_at_iou" in metrics
+    assert metrics["mAP50"] == 1.0  # canonical key still tied to 0.50

--- a/backend/tests/unit/test_evaluation_metrics_map5095.py
+++ b/backend/tests/unit/test_evaluation_metrics_map5095.py
@@ -1,0 +1,53 @@
+"""Tests for the new mAP@[.5:.95] computation in compute_detection_metrics."""
+
+from __future__ import annotations
+
+from app.jobs.tasks.evaluation import (
+    compute_detection_ap_at_iou,
+    compute_detection_metrics,
+)
+
+
+def _items_perfect():
+    """Predictions exactly match ground truth → AP at every IoU is 1."""
+    items = []
+    for i in range(3):
+        gt = {"class": "cat", "bbox": (0.0, 0.0, 100.0, 100.0)}
+        pred = {"class": "cat", "bbox": (0.0, 0.0, 100.0, 100.0), "score": 0.99}
+        items.append({"asset_id": f"a{i}", "gt": [gt], "pred": [pred]})
+    return items
+
+
+def test_perfect_predictions_yield_full_map5095():
+    items = _items_perfect()
+    metrics = compute_detection_metrics(items, ["cat"], iou_threshold=0.5)
+    m = metrics["metrics"]
+    assert m["mAP50"] == 1.0
+    assert m["mAP_5095"] == 1.0
+    # All ten threshold buckets should be 1.0 too.
+    for thr in (50, 55, 60, 65, 70, 75, 80, 85, 90, 95):
+        assert m[f"mAP_{thr:02d}"] == 1.0, f"mAP_{thr:02d} = {m[f'mAP_{thr:02d}']}"
+
+
+def test_loose_predictions_have_lower_map5095():
+    """With ~54% IoU overlap, mAP@.5 stays high but mAP@[.5:.95] drops."""
+    items = []
+    for i in range(3):
+        gt = {"class": "cat", "bbox": (0.0, 0.0, 100.0, 100.0)}
+        # Shift by 30 pixels in x → IoU ≈ 0.538
+        pred = {"class": "cat", "bbox": (30.0, 0.0, 100.0, 100.0), "score": 0.99}
+        items.append({"asset_id": f"a{i}", "gt": [gt], "pred": [pred]})
+    metrics = compute_detection_metrics(items, ["cat"], iou_threshold=0.5)
+    m = metrics["metrics"]
+    # The looser overlap is matched at IoU 0.50 only. The 11-point
+    # interpolation pads each curve with a (recall=0, precision=1) anchor,
+    # so unmatched thresholds produce ≈1/11 ≈ 0.091 — much lower than mAP_50.
+    assert m["mAP_50"] >= 0.5
+    assert m["mAP_75"] < 0.2
+    assert m["mAP_95"] < 0.2
+    assert m["mAP_5095"] < m["mAP_50"]
+
+
+def test_compute_ap_helper_handles_empty():
+    aps = compute_detection_ap_at_iou([], ["cat"], 0.5)
+    assert aps == {"cat": 0.0}

--- a/backend/tests/unit/test_onnx_dispatch_failure.py
+++ b/backend/tests/unit/test_onnx_dispatch_failure.py
@@ -1,0 +1,64 @@
+"""When the broker is down, export_onnx must mark the job failed (not queued)."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db.base import Base
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite+pysqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    session = Session()
+    yield session
+    session.close()
+    Base.metadata.drop_all(engine)
+
+
+def _seed_project_and_run(db) -> str:
+    """Create a minimal Project + ExperimentRun and return the run id."""
+    from app.models.experiment import ExperimentRun
+    from app.models.project import Project
+    from app.models.user import User
+    from app.models.workspace import Workspace
+
+    db.add(Workspace(id="ws-1", name="W", created_by="user-1"))
+    db.add(Project(id="p-1", workspace_id="ws-1", name="P", slug="p"))
+    db.add(User(id="user-1", name="U", email="u@u.com"))
+    run = ExperimentRun(
+        id="run-1",
+        project_id="p-1",
+        owner_id="user-1",
+        name="r",
+        status="succeeded",
+    )
+    db.add(run)
+    db.commit()
+    return run.id
+
+
+def test_dispatch_failure_marks_job_failed(db):
+    """If celery_app.send_task explodes, the job row must end up `failed`."""
+    from app.models.job import Job
+    from app.services.onnx_service import OnnxDispatchError, export_onnx
+
+    run_id = _seed_project_and_run(db)
+
+    with mock.patch(
+        "app.services.onnx_service.celery_app.send_task",
+        side_effect=RuntimeError("broker unreachable"),
+    ):
+        with pytest.raises(OnnxDispatchError):
+            export_onnx(db, run_id, dynamic_axes=True)
+
+    # Find the most recently created job and assert it's failed.
+    jobs = db.query(Job).filter(Job.type == "onnx_export").all()
+    assert jobs, "expected an onnx_export job row to be created"
+    assert jobs[-1].status == "failed"

--- a/backend/tests/unit/test_project_dataset_task_type.py
+++ b/backend/tests/unit/test_project_dataset_task_type.py
@@ -1,0 +1,76 @@
+"""Phase 2 task_type behaviour on Project + Dataset."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db.base import Base
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite+pysqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    session = Session()
+    yield session
+    session.close()
+    Base.metadata.drop_all(engine)
+
+
+def _ws(db):
+    from app.models.workspace import Workspace
+
+    db.add(Workspace(id="ws-1", name="W", created_by="user-1"))
+    db.commit()
+
+
+def test_create_project_persists_task_type(db):
+    from app.services.project_dataset_service import create_project
+
+    _ws(db)
+    p = create_project(db, "Detector", "obj det", task_type="detect", workspace_id="ws-1")
+    assert p.task_type == "detect"
+
+
+def test_create_project_rejects_unknown_task_type(db):
+    from app.services.project_dataset_service import create_project
+
+    _ws(db)
+    with pytest.raises(ValueError):
+        create_project(db, "X", None, task_type="bogus", workspace_id="ws-1")
+
+
+def test_dataset_inherits_project_task_type(db):
+    from app.services.project_dataset_service import create_dataset, create_project
+
+    _ws(db)
+    p = create_project(db, "Classifier", None, task_type="classify", workspace_id="ws-1")
+    dataset, version = create_dataset(db, p.id, "default", None)
+    assert dataset.task_type == "classify"
+    assert version.version == 1
+
+
+def test_training_rejects_task_type_mismatch(db):
+    from app.models.dataset_version import DatasetVersion
+    from app.services.project_dataset_service import create_dataset, create_project
+    from app.services.training_service import TaskTypeMismatch, launch_training
+
+    _ws(db)
+    p = create_project(db, "Detector", None, task_type="detect", workspace_id="ws-1")
+    dataset, _ = create_dataset(db, p.id, "default", None)
+    # Force the dataset's first version into the test scope.
+    version = db.query(DatasetVersion).filter(DatasetVersion.dataset_id == dataset.id).first()
+    assert version is not None
+
+    with pytest.raises(TaskTypeMismatch):
+        launch_training(
+            db,
+            p.id,
+            version.id,
+            task="classify",
+            params={},
+            owner_id="user-1",
+        )

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,11 +14,13 @@ import DatasetVersion from "./pages/datasets/version";
 import DatasetsIndex from "./pages/datasets/index";
 import DatasetDetail from "./pages/datasets/[datasetId]/index";
 import DatasetAnnotateGateway from "./pages/datasets/[datasetId]/annotate";
+import DatasetReviewQueue from "./pages/datasets/[datasetId]/review";
 import ExperimentsIndex from "./pages/experiments/index";
 import ExperimentsNew from "./pages/experiments/new";
 import ExperimentDetail from "./pages/experiments/[runId]";
 import ArtifactsIndex from "./pages/artifacts/index";
 import ArtifactsExport from "./pages/artifacts/export";
+import ArtifactsLineage from "./pages/artifacts/lineage";
 import ActiveLearningIndex from "./pages/active-learning/index";
 import ActiveLearningNew from "./pages/active-learning/new";
 import ALRunDetail from "./pages/active-learning/[alRunId]";
@@ -51,34 +53,97 @@ function StatReadout({ label, value, loading, href }) {
   );
 }
 
+function StatusRow({ label, component }) {
+  const status = component?.status || "unknown";
+  const cls =
+    status === "ok"
+      ? "text-[var(--hud-success-text)]"
+      : status === "degraded"
+      ? "text-[var(--hud-warning-text,oklch(0.78_0.18_85))]"
+      : "text-[var(--hud-danger-text)]";
+  const dot = status === "ok" ? "●" : status === "degraded" ? "◐" : "○";
+  const labelOut = status === "ok" ? "ONLINE" : status.toUpperCase();
+  return (
+    <div
+      className="flex items-center justify-between gap-4"
+      title={component?.detail || status}
+    >
+      <span className="text-[var(--hud-text-muted)]">{label}</span>
+      <span className={cls}>
+        {dot} {labelOut}
+      </span>
+    </div>
+  );
+}
+
+function SystemStatusPanel({ system }) {
+  const components = system?.components || {};
+  return (
+    <div className="border border-[var(--hud-border-default)] bg-[var(--hud-inset)] px-4 py-3 min-w-[160px]">
+      <div className="label-overline mb-2">System Status</div>
+      <div className="space-y-1.5 text-xs font-mono">
+        <StatusRow label="API"      component={components.api}      />
+        <StatusRow label="DATABASE" component={components.database} />
+        <StatusRow label="QUEUE"    component={components.queue}    />
+        <StatusRow label="STORAGE"  component={components.storage}  />
+      </div>
+    </div>
+  );
+}
+
 function HomeDashboard() {
   const [stats, setStats] = useState({ projects: null, datasets: null, models: null });
   const [statsLoading, setStatsLoading] = useState(true);
+  const [system, setSystem] = useState(null);
 
   useEffect(() => {
+    let cancelled = false;
     Promise.all([
-      apiGet("/api/projects"),
-      apiGet("/api/datasets"),
-      apiGet("/api/artifacts/models"),
+      apiGet("/api/projects?page=1&page_size=1"),
+      apiGet("/api/datasets?page=1&page_size=1"),
+      apiGet("/api/artifacts/models?page=1&page_size=1"),
     ])
       .then(([projects, datasets, models]) => {
+        if (cancelled) return;
+        const total = (resp) =>
+          typeof resp?.total === "number"
+            ? resp.total
+            : Array.isArray(resp)
+            ? resp.length
+            : 0;
         setStats({
-          projects: Array.isArray(projects) ? projects.length : 0,
-          datasets: Array.isArray(datasets) ? datasets.length : 0,
-          models: Array.isArray(models) ? models.length : 0,
+          projects: total(projects),
+          datasets: total(datasets),
+          models: total(models),
         });
       })
       .catch(console.error)
-      .finally(() => setStatsLoading(false));
+      .finally(() => !cancelled && setStatsLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer;
+    const tick = () => {
+      apiGet("/api/system/status")
+        .then((data) => !cancelled && setSystem(data))
+        .catch(() => !cancelled && setSystem({ status: "down", components: {} }));
+    };
+    tick();
+    timer = setInterval(tick, 15000);
+    return () => {
+      cancelled = true;
+      if (timer) clearInterval(timer);
+    };
   }, []);
 
   return (
     <div className="space-y-6">
-      {/* Hero section */}
       <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)] p-6">
-        {/* Top label */}
         <div className="label-overline mb-3">// VisionForge · Computer Vision Platform</div>
-
         <div className="grid gap-6 md:grid-cols-[1fr_auto] items-center">
           <div className="space-y-3">
             <h1 className="text-xl font-semibold tracking-tight text-[var(--hud-text-primary)]">
@@ -102,48 +167,28 @@ function HomeDashboard() {
               </Link>
             </div>
           </div>
-
-          {/* System status panel */}
-          <div className="border border-[var(--hud-border-default)] bg-[var(--hud-inset)] px-4 py-3 min-w-[160px]">
-            <div className="label-overline mb-2">System Status</div>
-            <div className="space-y-1.5 text-xs font-mono">
-              <div className="flex items-center justify-between gap-4">
-                <span className="text-[var(--hud-text-muted)]">API</span>
-                <span className="text-[var(--hud-success-text)]">● ONLINE</span>
-              </div>
-              <div className="flex items-center justify-between gap-4">
-                <span className="text-[var(--hud-text-muted)]">QUEUE</span>
-                <span className="text-[var(--hud-success-text)]">● ONLINE</span>
-              </div>
-              <div className="flex items-center justify-between gap-4">
-                <span className="text-[var(--hud-text-muted)]">STORAGE</span>
-                <span className="text-[var(--hud-success-text)]">● ONLINE</span>
-              </div>
-            </div>
-          </div>
+          <SystemStatusPanel system={system} />
         </div>
       </div>
 
-      {/* Stats row */}
       <div>
         <div className="label-overline mb-2">Platform Overview</div>
         <div className="grid grid-cols-3 gap-px bg-[var(--hud-border-default)]">
-          <StatReadout label="Projects"  value={stats.projects} loading={statsLoading} href="/projects"    />
-          <StatReadout label="Datasets"  value={stats.datasets} loading={statsLoading} href="/datasets"    />
-          <StatReadout label="Models"    value={stats.models}   loading={statsLoading} href="/artifacts"   />
+          <StatReadout label="Projects" value={stats.projects} loading={statsLoading} href="/projects"  />
+          <StatReadout label="Datasets" value={stats.datasets} loading={statsLoading} href="/datasets"  />
+          <StatReadout label="Models"   value={stats.models}   loading={statsLoading} href="/artifacts" />
         </div>
       </div>
 
-      {/* Quick nav grid */}
       <div>
         <div className="label-overline mb-2">Quick Access</div>
         <div className="grid grid-cols-2 sm:grid-cols-5 gap-px bg-[var(--hud-border-default)]">
           {[
-            { to: '/projects',        label: 'PROJECTS',       desc: 'Manage project workspaces'            },
-            { to: '/datasets',        label: 'DATASETS',       desc: 'Browse and upload datasets'           },
-            { to: '/experiments',     label: 'EXPERIMENTS',    desc: 'Training runs and metrics'            },
-            { to: '/artifacts',       label: 'ARTIFACTS',      desc: 'Model exports and lineage'            },
-            { to: '/active-learning', label: 'ACTIVE LEARN',   desc: 'Select informative samples to label'  },
+            { to: "/projects",        label: "PROJECTS",     desc: "Manage project workspaces"           },
+            { to: "/datasets",        label: "DATASETS",     desc: "Browse and upload datasets"          },
+            { to: "/experiments",     label: "EXPERIMENTS",  desc: "Training runs and metrics"           },
+            { to: "/artifacts",       label: "ARTIFACTS",    desc: "Model exports and lineage"           },
+            { to: "/active-learning", label: "ACTIVE LEARN", desc: "Select informative samples to label" },
           ].map(({ to, label, desc }) => (
             <Link
               key={to}
@@ -187,6 +232,7 @@ export default function App() {
             <Route path="/datasets/version" element={<ProtectedRoute><DatasetVersion /></ProtectedRoute>} />
             <Route path="/datasets/:datasetId" element={<ProtectedRoute><DatasetDetail /></ProtectedRoute>} />
             <Route path="/datasets/:datasetId/annotate" element={<ProtectedRoute><DatasetAnnotateGateway /></ProtectedRoute>} />
+            <Route path="/datasets/:datasetId/review" element={<ProtectedRoute><DatasetReviewQueue /></ProtectedRoute>} />
             {/* Experiments */}
             <Route path="/experiments" element={<ProtectedRoute><ExperimentsIndex /></ProtectedRoute>} />
             <Route path="/experiments/new" element={<ProtectedRoute><ExperimentsNew /></ProtectedRoute>} />
@@ -194,6 +240,7 @@ export default function App() {
             {/* Artifacts */}
             <Route path="/artifacts" element={<ProtectedRoute><ArtifactsIndex /></ProtectedRoute>} />
             <Route path="/artifacts/export/:modelId" element={<ProtectedRoute><ArtifactsExport /></ProtectedRoute>} />
+            <Route path="/artifacts/lineage/:modelId" element={<ProtectedRoute><ArtifactsLineage /></ProtectedRoute>} />
             {/* Active Learning */}
             <Route path="/active-learning" element={<ProtectedRoute><ActiveLearningIndex /></ProtectedRoute>} />
             <Route path="/active-learning/new" element={<ProtectedRoute><ActiveLearningNew /></ProtectedRoute>} />

--- a/frontend/src/components/common/Pager.tsx
+++ b/frontend/src/components/common/Pager.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Button from '@/components/ui/Button';
 
 interface Props {
@@ -10,9 +10,19 @@ interface Props {
 
 export default function Pager({ page, pageSize, total, onChange }: Props) {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  // Clamp the caller's `page` to a valid range so a stale page from a prior
+  // filter state never displays an impossible "26—10 of 10" range.
+  const safePage = Math.min(Math.max(1, Math.floor(page) || 1), totalPages);
+
+  // If the caller is out of bounds (filters reduced `total` but they still
+  // hold the old page), surface a snap-back so the parent's state agrees.
+  useEffect(() => {
+    if (safePage !== page) onChange(safePage);
+  }, [safePage, page, onChange]);
+
   if (totalPages <= 1) return null;
-  const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
-  const end = Math.min(total, page * pageSize);
+  const start = total === 0 ? 0 : (safePage - 1) * pageSize + 1;
+  const end = Math.min(total, safePage * pageSize);
   return (
     <div className="flex items-center justify-between text-xs font-mono text-[var(--hud-text-muted)] pt-2">
       <span>
@@ -24,20 +34,20 @@ export default function Pager({ page, pageSize, total, onChange }: Props) {
         <Button
           size="sm"
           variant="outline"
-          disabled={page <= 1}
-          onClick={() => onChange(page - 1)}
+          disabled={safePage <= 1}
+          onClick={() => onChange(Math.max(1, safePage - 1))}
         >
           ← PREV
         </Button>
         <span>
-          PAGE <span className="text-[var(--hud-text-data)]">{page}</span> /{' '}
+          PAGE <span className="text-[var(--hud-text-data)]">{safePage}</span> /{' '}
           <span className="text-[var(--hud-text-data)]">{totalPages}</span>
         </span>
         <Button
           size="sm"
           variant="outline"
-          disabled={page >= totalPages}
-          onClick={() => onChange(page + 1)}
+          disabled={safePage >= totalPages}
+          onClick={() => onChange(Math.min(totalPages, safePage + 1))}
         >
           NEXT →
         </Button>

--- a/frontend/src/components/common/Pager.tsx
+++ b/frontend/src/components/common/Pager.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import Button from '@/components/ui/Button';
+
+interface Props {
+  page: number;
+  pageSize: number;
+  total: number;
+  onChange: (page: number) => void;
+}
+
+export default function Pager({ page, pageSize, total, onChange }: Props) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  if (totalPages <= 1) return null;
+  const start = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const end = Math.min(total, page * pageSize);
+  return (
+    <div className="flex items-center justify-between text-xs font-mono text-[var(--hud-text-muted)] pt-2">
+      <span>
+        SHOWING <span className="text-[var(--hud-text-data)]">{start}</span>—
+        <span className="text-[var(--hud-text-data)]">{end}</span> OF{' '}
+        <span className="text-[var(--hud-text-data)]">{total}</span>
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={page <= 1}
+          onClick={() => onChange(page - 1)}
+        >
+          ← PREV
+        </Button>
+        <span>
+          PAGE <span className="text-[var(--hud-text-data)]">{page}</span> /{' '}
+          <span className="text-[var(--hud-text-data)]">{totalPages}</span>
+        </span>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={page >= totalPages}
+          onClick={() => onChange(page + 1)}
+        >
+          NEXT →
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export interface PaginatedResponse<T> {
+  items: T[];
+  total: number;
+  page: number;
+  page_size: number;
+}

--- a/frontend/src/pages/active-learning/index.tsx
+++ b/frontend/src/pages/active-learning/index.tsx
@@ -4,6 +4,7 @@ import Badge from '@/components/ui/Badge';
 import Loading from '@/components/common/Loading';
 import EmptyState from '@/components/common/EmptyState';
 import ErrorState from '@/components/common/ErrorState';
+import Pager, { PaginatedResponse } from '@/components/common/Pager';
 import { apiGet } from '@/services/api';
 
 interface ALRun {
@@ -13,20 +14,32 @@ interface ALRun {
   created_at?: string;
 }
 
+const PAGE_SIZE = 25;
+
 export default function ActiveLearningIndex() {
   const [searchParams] = useSearchParams();
   const projectId = searchParams.get('projectId') || '';
   const [runs, setRuns] = useState<ALRun[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const url = projectId ? `/api/al/runs?project_id=${projectId}` : '/api/al/runs';
-    apiGet<ALRun[]>(url)
-      .then(setRuns)
+    setLoading(true);
+    const params = new URLSearchParams({
+      page: String(page),
+      page_size: String(PAGE_SIZE),
+    });
+    if (projectId) params.set('project_id', projectId);
+    apiGet<PaginatedResponse<ALRun>>(`/api/al/runs?${params.toString()}`)
+      .then((data) => {
+        setRuns(data.items);
+        setTotal(data.total);
+      })
       .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load AL runs'))
       .finally(() => setLoading(false));
-  }, [projectId]);
+  }, [projectId, page]);
 
   if (loading) return <div className="py-6"><Loading label="Loading active learning runs…" /></div>;
   if (error) return <ErrorState title="Failed to load active learning runs" description={error} />;
@@ -61,32 +74,35 @@ export default function ActiveLearningIndex() {
           </Link>
         </EmptyState>
       ) : (
-        <div className="border border-[var(--hud-border-default)] divide-y divide-[var(--hud-border-subtle)]">
-          {runs.map((r) => (
-            <Link
-              key={r.id}
-              to={`/active-learning/${r.id}`}
-              className="flex items-center justify-between px-4 py-3 hover:bg-[var(--hud-elevated)] transition-colors group"
-            >
-              <div>
-                <div className="text-sm font-mono font-semibold text-[var(--hud-text-primary)]">
-                  {r.id.slice(0, 8)}…
-                </div>
-                {r.created_at && (
-                  <div className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] mt-0.5">
-                    {new Date(r.created_at).toLocaleString()}
+        <>
+          <div className="border border-[var(--hud-border-default)] divide-y divide-[var(--hud-border-subtle)]">
+            {runs.map((r) => (
+              <Link
+                key={r.id}
+                to={`/active-learning/${r.id}`}
+                className="flex items-center justify-between px-4 py-3 hover:bg-[var(--hud-elevated)] transition-colors group"
+              >
+                <div>
+                  <div className="text-sm font-mono font-semibold text-[var(--hud-text-primary)]">
+                    {r.id.slice(0, 8)}…
                   </div>
-                )}
-              </div>
-              <div className="flex items-center gap-3">
-                <Badge variant="default">{r.strategy}</Badge>
-                <span className="text-xs font-mono text-[var(--hud-accent)] group-hover:underline">
-                  VIEW →
-                </span>
-              </div>
-            </Link>
-          ))}
-        </div>
+                  {r.created_at && (
+                    <div className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] mt-0.5">
+                      {new Date(r.created_at).toLocaleString()}
+                    </div>
+                  )}
+                </div>
+                <div className="flex items-center gap-3">
+                  <Badge variant="default">{r.strategy}</Badge>
+                  <span className="text-xs font-mono text-[var(--hud-accent)] group-hover:underline">
+                    VIEW →
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+          <Pager page={page} pageSize={PAGE_SIZE} total={total} onChange={setPage} />
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/active-learning/new.tsx
+++ b/frontend/src/pages/active-learning/new.tsx
@@ -10,6 +10,8 @@ import { apiGet, apiPost } from '@/services/api';
 interface Project { id: string; name: string; }
 interface Dataset { id: string; name: string; latest_version_id?: string; }
 
+interface Page<T> { items: T[]; total: number; page: number; page_size: number; }
+
 function FieldLabel({ htmlFor, children }: { htmlFor: string; children: React.ReactNode }) {
   return (
     <label htmlFor={htmlFor} className="label-overline block mb-1">
@@ -35,13 +37,17 @@ export default function ActiveLearningNew() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    apiGet<Project[]>('/api/projects').then(setProjects).catch(console.error);
+    apiGet<Page<Project>>('/api/projects?page=1&page_size=200')
+      .then((d) => setProjects(d.items))
+      .catch(console.error);
   }, []);
 
   useEffect(() => {
     if (!form.projectId) { setDatasets([]); return; }
-    apiGet<Dataset[]>(`/api/datasets?project_id=${form.projectId}`)
-      .then(setDatasets)
+    apiGet<Page<Dataset>>(
+      `/api/datasets?project_id=${form.projectId}&page=1&page_size=200`,
+    )
+      .then((d) => setDatasets(d.items))
       .catch(console.error);
   }, [form.projectId]);
 

--- a/frontend/src/pages/annotate/Annotator.jsx
+++ b/frontend/src/pages/annotate/Annotator.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { apiGet, apiPost, apiPut, apiDelete, apiUrl } from '@/services/api';
+import { apiGet, apiPost, apiDelete, apiUrl } from '@/services/api';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -318,6 +318,25 @@ export default function AnnotatorPage() {
       try {
         const assetData = await apiGet(`/api/assets/${assetId}`);
         setAsset(assetData);
+
+        // Pre-populate the class sidebar from the dataset's ClassMap so
+        // annotators don't have to re-add classes every session.
+        try {
+          if (assetData.dataset_id) {
+            const dataset = await apiGet(`/api/datasets/${assetData.dataset_id}`);
+            const seeded = Array.isArray(dataset.classes) ? dataset.classes : [];
+            const names = seeded
+              .map((c) => (typeof c === 'string' ? c : c?.name))
+              .filter(Boolean);
+            if (names.length > 0) {
+              setClasses(names);
+              setSelectedClass(names[0]);
+            }
+          }
+        } catch {
+          // Falls back to the default ['object'] class.
+        }
+
         try {
           const annsData = await apiGet(`/api/assets/${assetId}/annotations`);
           const loaded = Array.isArray(annsData) ? annsData : annsData.items ?? [];
@@ -640,40 +659,90 @@ export default function AnnotatorPage() {
     if (!assetId) return;
     setStatus('Saving…');
     try {
-      const saved = [];
-      for (const ann of annotationsRef.current) {
+      const creates = [];
+      const updates = [];
+      const current = annotationsRef.current;
+      current.forEach((ann, idx) => {
         if (ann.isNew || !ann.id) {
-          const result = await apiPost('/api/annotations', {
+          creates.push({
+            client_id: `idx-${idx}`,
             asset_id: assetId,
             type: ann.type,
-            class_name: ann.class_name,
             geometry: ann.geometry,
+            class_name: ann.class_name,
           });
-          saved.push({ ...ann, id: result.id, version: result.version, isNew: false, dirty: false });
         } else if (ann.dirty) {
-          try {
-            const result = await apiPut(`/api/annotations/${ann.id}`, {
-              class_name: ann.class_name,
-              geometry: ann.geometry,
-              expected_version: ann.version,
-            });
-            saved.push({ ...ann, version: result.version, dirty: false });
-          } catch (err) {
-            if (String(err.message).includes('version mismatch')) {
-              setStatus(`Conflict on ${ann.id}: another editor changed it`);
-              saved.push(ann);
-            } else {
-              throw err;
-            }
-          }
-        } else {
-          saved.push(ann);
+          updates.push({
+            id: ann.id,
+            geometry: ann.geometry,
+            class_name: ann.class_name,
+            expected_version: ann.version,
+          });
         }
+      });
+      if (creates.length === 0 && updates.length === 0) {
+        setDirty(false);
+        setStatus('Nothing to save');
+        return;
       }
-      setAnnotations(saved);
-      annotationsRef.current = saved;
-      setDirty(false);
-      setStatus('Saved');
+      const result = await apiPost('/api/annotations/bulk', {
+        creates,
+        updates,
+        deletes: [],
+      });
+
+      const createdById = new Map();
+      (result.created || []).forEach((row) => {
+        if (row.client_id && row.status === 'ok' && row.annotation) {
+          createdById.set(row.client_id, row.annotation);
+        }
+      });
+      const updatedById = new Map();
+      (result.updated || []).forEach((row) => {
+        if (row.id) updatedById.set(row.id, row);
+      });
+
+      const next = current.map((ann, idx) => {
+        if (ann.isNew || !ann.id) {
+          const created = createdById.get(`idx-${idx}`);
+          if (created) {
+            return {
+              ...ann,
+              id: created.id,
+              version: created.version,
+              isNew: false,
+              dirty: false,
+            };
+          }
+          return ann;
+        }
+        if (ann.dirty) {
+          const u = updatedById.get(ann.id);
+          if (!u) return ann;
+          if (u.status === 'ok' && u.annotation) {
+            return { ...ann, version: u.annotation.version, dirty: false };
+          }
+          if (u.status === 'conflict') {
+            setStatus(`Conflict on ${ann.id}: another editor changed it`);
+            return ann;
+          }
+        }
+        return ann;
+      });
+
+      setAnnotations(next);
+      annotationsRef.current = next;
+      const errors = [
+        ...(result.created || []).filter((r) => r.status !== 'ok'),
+        ...(result.updated || []).filter((r) => r.status !== 'ok'),
+      ];
+      if (errors.length === 0) {
+        setDirty(false);
+        setStatus('Saved');
+      } else {
+        setDirty(true);
+        setStatus(`Saved with ${errors.length} issue(s) — see status`);
+      }
     } catch (err) {
       setStatus(`Save failed: ${err.message}`);
     }

--- a/frontend/src/pages/artifacts/export.tsx
+++ b/frontend/src/pages/artifacts/export.tsx
@@ -3,19 +3,28 @@ import { useParams, Link } from 'react-router-dom';
 import Badge from '@/components/ui/Badge';
 import Button from '@/components/ui/Button';
 import Alert from '@/components/ui/Alert';
+import Select from '@/components/ui/Select';
 import Loading from '@/components/common/Loading';
-import ErrorState from '@/components/common/ErrorState';
+import ClusterSelect from '@/components/common/ClusterSelect';
 import { apiGet, apiPost } from '@/services/api';
 
 interface Lineage {
-  id: string;
+  artifact?: {
+    id: string;
+    name?: string;
+    type?: string;
+    version?: number;
+    runId?: string;
+    createdAt?: string;
+    storagePath?: string;
+  };
+  // Backwards-compat: pre-Phase 3 lineage shape was flat.
+  id?: string;
   name?: string;
   type?: string;
   version?: number;
   run_id?: string;
-  project_id?: string;
   created_at?: string;
-  storage_path?: string;
 }
 
 interface JobStatus {
@@ -43,6 +52,9 @@ export default function ArtifactsExport() {
   const [job, setJob]                     = useState<JobStatus | null>(null);
   const [exporting, setExporting]         = useState(false);
   const [error, setError]                 = useState<string | null>(null);
+  const [clusterId, setClusterId]         = useState<string>('');
+  const [dynamicAxes, setDynamicAxes]     = useState<boolean>(true);
+  const [opset, setOpset]                 = useState<string>('');
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
@@ -78,7 +90,14 @@ export default function ArtifactsExport() {
     setExporting(true);
     setError(null);
     try {
-      const j = await apiPost<{ id: string; status: string }>(`/api/artifacts/models/${modelId}/export`, {});
+      const body: Record<string, unknown> = { dynamic_axes: dynamicAxes };
+      if (clusterId) body.cluster_id = clusterId;
+      const opsetParsed = parseInt(opset, 10);
+      if (Number.isFinite(opsetParsed) && opsetParsed > 0) body.opset = opsetParsed;
+      const j = await apiPost<{ id: string; status: string }>(
+        `/api/artifacts/models/${modelId}/export`,
+        body,
+      );
       const initial: JobStatus = { id: j.id, status: j.status, progress: 0 };
       setJob(initial);
       pollJob(j.id);
@@ -106,57 +125,69 @@ export default function ArtifactsExport() {
       {artifactError && <Alert variant="warning">Could not load model lineage: {artifactError}</Alert>}
 
       {/* Model info */}
-      {artifact && (
-        <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)]">
-          <div className="border-b border-[var(--hud-border-subtle)] px-4 py-2 flex items-center gap-2">
-            <div className="h-1.5 w-1.5 bg-[var(--hud-border-strong)]" />
-            <span className="label-overline">Model Info</span>
+      {artifact && (() => {
+        const a = artifact.artifact || artifact;
+        const name = (a as any).name as string | undefined;
+        const type = (a as any).type as string | undefined;
+        const version = (a as any).version as number | undefined;
+        const runId =
+          ((a as any).runId as string | undefined) ||
+          ((a as any).run_id as string | undefined);
+        const createdAt =
+          ((a as any).createdAt as string | undefined) ||
+          ((a as any).created_at as string | undefined);
+        return (
+          <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)]">
+            <div className="border-b border-[var(--hud-border-subtle)] px-4 py-2 flex items-center gap-2">
+              <div className="h-1.5 w-1.5 bg-[var(--hud-border-strong)]" />
+              <span className="label-overline">Model Info</span>
+            </div>
+            <table className="w-full text-xs font-mono">
+              <tbody>
+                {name && (
+                  <tr className="border-b border-[var(--hud-border-subtle)]">
+                    <td className="px-4 py-1.5 text-[var(--hud-text-muted)] uppercase">Name</td>
+                    <td className="px-4 py-1.5 text-[var(--hud-text-primary)]">{name}</td>
+                  </tr>
+                )}
+                {type && (
+                  <tr className="border-b border-[var(--hud-border-subtle)]">
+                    <td className="px-4 py-1.5 text-[var(--hud-text-muted)] uppercase">Type</td>
+                    <td className="px-4 py-1.5"><Badge>{type}</Badge></td>
+                  </tr>
+                )}
+                {version != null && (
+                  <tr className="border-b border-[var(--hud-border-subtle)]">
+                    <td className="px-4 py-1.5 text-[var(--hud-text-muted)] uppercase">Version</td>
+                    <td className="px-4 py-1.5 text-[var(--hud-text-data)]">v{version}</td>
+                  </tr>
+                )}
+                {runId && (
+                  <tr className="border-b border-[var(--hud-border-subtle)]">
+                    <td className="px-4 py-1.5 text-[var(--hud-text-muted)] uppercase">Training Run</td>
+                    <td className="px-4 py-1.5">
+                      <Link
+                        to={`/experiments/runs/${runId}`}
+                        className="text-[var(--hud-accent)] hover:underline underline-offset-1"
+                      >
+                        {runId.slice(0, 12)}…
+                      </Link>
+                    </td>
+                  </tr>
+                )}
+                {createdAt && (
+                  <tr>
+                    <td className="px-4 py-1.5 text-[var(--hud-text-muted)] uppercase">Created</td>
+                    <td className="px-4 py-1.5 text-[var(--hud-text-secondary)]">
+                      {new Date(createdAt).toLocaleString()}
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
           </div>
-          <table className="w-full text-xs font-mono">
-            <tbody>
-              {artifact.name && (
-                <tr className="border-b border-[var(--hud-border-subtle)]">
-                  <td className="px-4 py-1.5 text-[var(--hud-text-muted)] uppercase">Name</td>
-                  <td className="px-4 py-1.5 text-[var(--hud-text-primary)]">{artifact.name}</td>
-                </tr>
-              )}
-              {artifact.type && (
-                <tr className="border-b border-[var(--hud-border-subtle)]">
-                  <td className="px-4 py-1.5 text-[var(--hud-text-muted)] uppercase">Type</td>
-                  <td className="px-4 py-1.5"><Badge>{artifact.type}</Badge></td>
-                </tr>
-              )}
-              {artifact.version != null && (
-                <tr className="border-b border-[var(--hud-border-subtle)]">
-                  <td className="px-4 py-1.5 text-[var(--hud-text-muted)] uppercase">Version</td>
-                  <td className="px-4 py-1.5 text-[var(--hud-text-data)]">v{artifact.version}</td>
-                </tr>
-              )}
-              {artifact.run_id && (
-                <tr className="border-b border-[var(--hud-border-subtle)]">
-                  <td className="px-4 py-1.5 text-[var(--hud-text-muted)] uppercase">Training Run</td>
-                  <td className="px-4 py-1.5">
-                    <Link
-                      to={`/experiments/runs/${artifact.run_id}`}
-                      className="text-[var(--hud-accent)] hover:underline underline-offset-1"
-                    >
-                      {artifact.run_id.slice(0, 12)}…
-                    </Link>
-                  </td>
-                </tr>
-              )}
-              {artifact.created_at && (
-                <tr>
-                  <td className="px-4 py-1.5 text-[var(--hud-text-muted)] uppercase">Created</td>
-                  <td className="px-4 py-1.5 text-[var(--hud-text-secondary)]">
-                    {new Date(artifact.created_at).toLocaleString()}
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Export controls */}
       <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)]">
@@ -172,9 +203,55 @@ export default function ArtifactsExport() {
           {error && <Alert variant="error">{error}</Alert>}
 
           {!job && (
-            <Button onClick={onExport} disabled={exporting || !modelId}>
-              {exporting ? 'Starting export…' : 'Export to ONNX'}
-            </Button>
+            <div className="space-y-3">
+              <div>
+                <label className="label-overline block mb-1" htmlFor="onnx-cluster">
+                  Compute Cluster
+                </label>
+                <ClusterSelect
+                  id="onnx-cluster"
+                  kind="eval"
+                  value={clusterId}
+                  onChange={setClusterId}
+                  allowAuto
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="label-overline block mb-1" htmlFor="onnx-dynamic">
+                    Dynamic Axes
+                  </label>
+                  <Select
+                    id="onnx-dynamic"
+                    value={dynamicAxes ? 'on' : 'off'}
+                    onChange={(e) => setDynamicAxes(e.target.value === 'on')}
+                  >
+                    <option value="on">On (variable batch / size)</option>
+                    <option value="off">Off (fixed shapes)</option>
+                  </Select>
+                </div>
+                <div>
+                  <label className="label-overline block mb-1" htmlFor="onnx-opset">
+                    ONNX Opset
+                  </label>
+                  <Select
+                    id="onnx-opset"
+                    value={opset}
+                    onChange={(e) => setOpset(e.target.value)}
+                  >
+                    <option value="">auto</option>
+                    <option value="13">13</option>
+                    <option value="14">14</option>
+                    <option value="15">15</option>
+                    <option value="16">16</option>
+                    <option value="17">17</option>
+                  </Select>
+                </div>
+              </div>
+              <Button onClick={onExport} disabled={exporting || !modelId}>
+                {exporting ? 'Starting export…' : 'Export to ONNX'}
+              </Button>
+            </div>
           )}
 
           {job && (

--- a/frontend/src/pages/artifacts/index.tsx
+++ b/frontend/src/pages/artifacts/index.tsx
@@ -4,21 +4,25 @@ import Badge from '@/components/ui/Badge';
 import Loading from '@/components/common/Loading';
 import EmptyState from '@/components/common/EmptyState';
 import ErrorState from '@/components/common/ErrorState';
-import { apiGet } from '@/services/api';
+import Pager, { PaginatedResponse } from '@/components/common/Pager';
+import { apiGet, apiUrl } from '@/services/api';
+import { getStoredToken } from '@/services/token-store';
 
 interface Artifact {
   id: string;
   type: string;
   version: number;
   name?: string;
-  run_id?: string;
-  project_id?: string;
-  project_name?: string;
-  file_size_bytes?: number;
-  created_at: string;
+  runId?: string;
+  projectId?: string;
+  format?: string;
+  sizeBytes?: number | null;
+  createdAt?: string;
+  storagePath?: string;
 }
 
-function formatBytes(bytes: number): string {
+function formatBytes(bytes?: number | null): string {
+  if (bytes == null) return '—';
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
@@ -33,24 +37,67 @@ function typeVariant(type: string): 'default' | 'success' | 'warning' | 'danger'
   }
 }
 
+const PAGE_SIZE = 24;
+
+async function downloadArtifact(modelId: string) {
+  const token = getStoredToken();
+  const res = await fetch(apiUrl(`/api/artifacts/models/${modelId}/download`), {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) {
+    throw new Error(`Download failed: HTTP ${res.status}`);
+  }
+  const ctype = res.headers.get('content-type') || '';
+  if (ctype.includes('application/json')) {
+    // Presigned URL response → open in new tab so the browser can download.
+    const data = await res.json();
+    if (data.url) {
+      window.location.href = data.url;
+      return;
+    }
+  }
+  // Stream → save via blob URL.
+  const blob = await res.blob();
+  const dispositionMatch = (res.headers.get('content-disposition') || '').match(
+    /filename="?([^"]+)"?/,
+  );
+  const filename = dispositionMatch?.[1] || `model-${modelId}`;
+  const blobUrl = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = blobUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(blobUrl);
+}
+
 export default function ArtifactsIndex() {
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
   const [loading, setLoading]     = useState(true);
   const [error, setError]         = useState<string | null>(null);
+  const [page, setPage]           = useState(1);
+  const [total, setTotal]         = useState(0);
+  const [downloadErr, setDownloadErr] = useState<string | null>(null);
 
   useEffect(() => {
-    apiGet<Artifact[]>('/api/artifacts/models')
-      .then(setArtifacts)
+    setLoading(true);
+    apiGet<PaginatedResponse<Artifact>>(
+      `/api/artifacts/models?page=${page}&page_size=${PAGE_SIZE}`,
+    )
+      .then((data) => {
+        setArtifacts(data.items);
+        setTotal(data.total);
+      })
       .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load artifacts'))
       .finally(() => setLoading(false));
-  }, []);
+  }, [page]);
 
   if (loading) return <div className="py-6"><Loading label="Loading artifacts…" /></div>;
   if (error)   return <ErrorState title="Failed to load artifacts" description={error} />;
 
   return (
     <div className="space-y-4">
-      {/* Header */}
       <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
         <div>
           <div className="label-overline mb-0.5">// Artifacts</div>
@@ -60,6 +107,12 @@ export default function ArtifactsIndex() {
           VIEW RUNS →
         </Link>
       </div>
+
+      {downloadErr && (
+        <div className="border border-[var(--hud-danger)] bg-[var(--hud-danger-dim)] px-3 py-2 text-xs font-mono text-[var(--hud-danger-text)]">
+          {downloadErr}
+        </div>
+      )}
 
       {artifacts.length === 0 ? (
         <EmptyState
@@ -74,80 +127,88 @@ export default function ArtifactsIndex() {
           </Link>
         </EmptyState>
       ) : (
-        <div className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-3 bg-[var(--hud-border-default)]">
-          {artifacts.map((a) => (
-            <div key={a.id} className="bg-[var(--hud-surface)] p-4 flex flex-col gap-2 hover:bg-[var(--hud-elevated)] transition-colors">
-              {/* Title + badge */}
-              <div className="flex items-start justify-between gap-2">
-                <div className="font-semibold text-sm text-[var(--hud-text-primary)] leading-tight">
-                  {a.name || `Model v${a.version}`}
+        <>
+          <div className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-3 bg-[var(--hud-border-default)]">
+            {artifacts.map((a) => (
+              <div
+                key={a.id}
+                className="bg-[var(--hud-surface)] p-4 flex flex-col gap-2 hover:bg-[var(--hud-elevated)] transition-colors"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="font-semibold text-sm text-[var(--hud-text-primary)] leading-tight">
+                    {a.name || `Model v${a.version}`}
+                  </div>
+                  <Badge variant={typeVariant(a.type)}>{a.type}</Badge>
                 </div>
-                <Badge variant={typeVariant(a.type)}>{a.type}</Badge>
-              </div>
 
-              {/* Metadata */}
-              <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs font-mono">
-                {a.project_name && (
-                  <div className="col-span-2 truncate">
-                    <span className="text-[var(--hud-text-muted)]">PROJ </span>
-                    <span className="text-[var(--hud-text-secondary)]">{a.project_name}</span>
-                  </div>
-                )}
-                {a.run_id && (
-                  <div>
-                    <span className="text-[var(--hud-text-muted)]">RUN </span>
-                    <Link
-                      to={`/experiments/runs/${a.run_id}`}
-                      className="text-[var(--hud-accent)] hover:underline underline-offset-1"
-                    >
-                      {a.run_id.slice(0, 8)}…
-                    </Link>
-                  </div>
-                )}
-                {a.file_size_bytes != null && (
+                <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs font-mono">
+                  {a.runId && (
+                    <div>
+                      <span className="text-[var(--hud-text-muted)]">RUN </span>
+                      <Link
+                        to={`/experiments/runs/${a.runId}`}
+                        className="text-[var(--hud-accent)] hover:underline underline-offset-1"
+                      >
+                        {a.runId.slice(0, 8)}…
+                      </Link>
+                    </div>
+                  )}
                   <div>
                     <span className="text-[var(--hud-text-muted)]">SIZE </span>
-                    <span className="text-[var(--hud-text-data)]">{formatBytes(a.file_size_bytes)}</span>
+                    <span className="text-[var(--hud-text-data)]">{formatBytes(a.sizeBytes)}</span>
                   </div>
-                )}
-                <div>
-                  <span className="text-[var(--hud-text-muted)]">CREATED </span>
-                  <span className="text-[var(--hud-text-secondary)]">
-                    {new Date(a.created_at).toLocaleDateString()}
-                  </span>
+                  {a.createdAt && (
+                    <div className="col-span-2">
+                      <span className="text-[var(--hud-text-muted)]">CREATED </span>
+                      <span className="text-[var(--hud-text-secondary)]">
+                        {new Date(a.createdAt).toLocaleDateString()}
+                      </span>
+                    </div>
+                  )}
+                </div>
+
+                <div className="mt-auto pt-2 border-t border-[var(--hud-border-subtle)] flex gap-2 flex-wrap">
+                  <Link
+                    to={`/artifacts/predict/${a.id}`}
+                    className="text-[0.6875rem] font-mono text-[oklch(0.10_0.008_240)] bg-[var(--hud-accent)] border border-[var(--hud-accent)] px-2 py-0.5 hover:bg-[var(--hud-accent-hover)] transition-colors"
+                  >
+                    PREDICT
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      downloadArtifact(a.id).catch((err) =>
+                        setDownloadErr(err instanceof Error ? err.message : 'Download failed'),
+                      )
+                    }
+                    className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] border border-[var(--hud-border-default)] px-2 py-0.5 hover:text-[var(--hud-accent)] hover:border-[var(--hud-accent)] transition-colors"
+                  >
+                    DOWNLOAD
+                  </button>
+                  <Link
+                    to={`/evaluations/new?artifact_id=${a.id}`}
+                    className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] border border-[var(--hud-border-default)] px-2 py-0.5 hover:text-[var(--hud-accent)] hover:border-[var(--hud-accent)] transition-colors"
+                  >
+                    EVALUATE
+                  </Link>
+                  <Link
+                    to={`/artifacts/export/${a.id}`}
+                    className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] border border-[var(--hud-border-default)] px-2 py-0.5 hover:text-[var(--hud-accent)] hover:border-[var(--hud-accent)] transition-colors"
+                  >
+                    EXPORT ONNX
+                  </Link>
+                  <Link
+                    to={`/artifacts/lineage/${a.id}`}
+                    className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] border border-[var(--hud-border-default)] px-2 py-0.5 hover:text-[var(--hud-accent)] hover:border-[var(--hud-accent)] transition-colors"
+                  >
+                    LINEAGE
+                  </Link>
                 </div>
               </div>
-
-              {/* Actions */}
-              <div className="mt-auto pt-2 border-t border-[var(--hud-border-subtle)] flex gap-2 flex-wrap">
-                <Link
-                  to={`/artifacts/predict/${a.id}`}
-                  className="text-[0.6875rem] font-mono text-[oklch(0.10_0.008_240)] bg-[var(--hud-accent)] border border-[var(--hud-accent)] px-2 py-0.5 hover:bg-[var(--hud-accent-hover)] transition-colors"
-                >
-                  PREDICT
-                </Link>
-                <Link
-                  to={`/evaluations/new?artifact_id=${a.id}`}
-                  className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] border border-[var(--hud-border-default)] px-2 py-0.5 hover:text-[var(--hud-accent)] hover:border-[var(--hud-accent)] transition-colors"
-                >
-                  EVALUATE
-                </Link>
-                <Link
-                  to={`/artifacts/export/${a.id}`}
-                  className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] border border-[var(--hud-border-default)] px-2 py-0.5 hover:text-[var(--hud-accent)] hover:border-[var(--hud-accent)] transition-colors"
-                >
-                  EXPORT ONNX
-                </Link>
-                <Link
-                  to={`/artifacts/export/${a.id}`}
-                  className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] border border-[var(--hud-border-default)] px-2 py-0.5 hover:text-[var(--hud-accent)] hover:border-[var(--hud-accent)] transition-colors"
-                >
-                  LINEAGE
-                </Link>
-              </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+          <Pager page={page} pageSize={PAGE_SIZE} total={total} onChange={setPage} />
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/artifacts/lineage.tsx
+++ b/frontend/src/pages/artifacts/lineage.tsx
@@ -1,0 +1,321 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import Badge from '@/components/ui/Badge';
+import Loading from '@/components/common/Loading';
+import ErrorState from '@/components/common/ErrorState';
+import { apiGet } from '@/services/api';
+
+interface ArtifactLite {
+  id: string;
+  name?: string;
+  version?: number;
+  type?: string;
+  format?: string;
+  sizeBytes?: number | null;
+  storagePath?: string | null;
+  createdAt?: string | null;
+  runId?: string | null;
+}
+
+interface Lineage {
+  artifact: ArtifactLite;
+  experiment_run: {
+    id: string;
+    name: string;
+    status: string;
+    params?: Record<string, unknown>;
+    metrics?: Record<string, unknown> | unknown[];
+    started_at?: string | null;
+    completed_at?: string | null;
+  } | null;
+  dataset_version: {
+    id: string;
+    version: number;
+    asset_count: number;
+    locked: boolean;
+  } | null;
+  dataset: {
+    id: string;
+    name: string;
+    task_type?: string | null;
+  } | null;
+  classes: string[];
+  cluster: {
+    id: string;
+    name: string;
+    kind: string;
+    gpu_vendor: string;
+  } | null;
+  siblings: ArtifactLite[];
+  evaluations: Array<{
+    id: string;
+    status: string;
+    dataset_version_id: string;
+    primary_metric_name: string | null;
+    primary_metric: number | null;
+    created_at: string | null;
+    completed_at: string | null;
+  }>;
+}
+
+function evalStatusBadge(status: string) {
+  switch (status) {
+    case 'succeeded': return <Badge variant="success">DONE</Badge>;
+    case 'running':   return <Badge variant="warning">RUNNING</Badge>;
+    case 'failed':    return <Badge variant="danger">FAILED</Badge>;
+    default:          return <Badge>{status.toUpperCase()}</Badge>;
+  }
+}
+
+function formatBytes(bytes?: number | null) {
+  if (bytes == null) return '—';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+export default function ArtifactsLineage() {
+  const { modelId } = useParams<{ modelId: string }>();
+  const [data, setData] = useState<Lineage | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!modelId) return;
+    setLoading(true);
+    apiGet<Lineage>(`/api/artifacts/models/${modelId}/lineage`)
+      .then(setData)
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load lineage'))
+      .finally(() => setLoading(false));
+  }, [modelId]);
+
+  if (loading) return <div className="py-6"><Loading label="Loading lineage…" /></div>;
+  if (error) return <ErrorState title="Lineage unavailable" description={error} />;
+  if (!data) return <ErrorState title="Not found" />;
+
+  const a = data.artifact;
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
+        <div>
+          <div className="label-overline mb-0.5">// Artifacts / Lineage</div>
+          <h1 className="flex items-center gap-2">
+            {a.name || `Model v${a.version}`}
+            {a.type && <Badge variant="default">{a.type}</Badge>}
+            {a.format && <Badge variant="default">{a.format}</Badge>}
+          </h1>
+          <p className="text-xs text-[var(--hud-text-muted)] mt-1">
+            Provenance for this model: training run → dataset version → class map → evaluations.
+          </p>
+        </div>
+        <Link
+          to="/artifacts"
+          className="text-xs font-mono text-[var(--hud-accent)] hover:underline"
+        >
+          ← ARTIFACTS
+        </Link>
+      </div>
+
+      <div className="grid gap-px md:grid-cols-2 bg-[var(--hud-border-default)]">
+        <Section label="Artifact">
+          <Row k="ID" v={a.id} mono />
+          <Row k="Version" v={`v${a.version ?? '—'}`} />
+          <Row k="Size" v={formatBytes(a.sizeBytes)} />
+          <Row k="Storage" v={a.storagePath || '—'} mono />
+          <Row k="Created" v={a.createdAt ? new Date(a.createdAt).toLocaleString() : '—'} />
+        </Section>
+
+        <Section label="Training Run">
+          {data.experiment_run ? (
+            <>
+              <Row
+                k="Run"
+                v={
+                  <Link
+                    to={`/experiments/runs/${data.experiment_run.id}`}
+                    className="text-[var(--hud-accent)] hover:underline"
+                  >
+                    {data.experiment_run.name || data.experiment_run.id.slice(0, 12)}
+                  </Link>
+                }
+              />
+              <Row k="Status" v={data.experiment_run.status} />
+              <Row
+                k="Started"
+                v={
+                  data.experiment_run.started_at
+                    ? new Date(data.experiment_run.started_at).toLocaleString()
+                    : '—'
+                }
+              />
+              <Row
+                k="Completed"
+                v={
+                  data.experiment_run.completed_at
+                    ? new Date(data.experiment_run.completed_at).toLocaleString()
+                    : '—'
+                }
+              />
+              <Row
+                k="Params"
+                v={
+                  <code className="text-[0.6875rem] text-[var(--hud-text-data)] break-all">
+                    {Object.entries(data.experiment_run.params || {})
+                      .slice(0, 6)
+                      .map(([k, v]) => `${k}=${String(v)}`)
+                      .join(' ') || '—'}
+                  </code>
+                }
+              />
+            </>
+          ) : (
+            <div className="text-xs font-mono text-[var(--hud-text-muted)]">No run linked.</div>
+          )}
+        </Section>
+
+        <Section label="Dataset / Version">
+          {data.dataset && data.dataset_version ? (
+            <>
+              <Row
+                k="Dataset"
+                v={
+                  <Link
+                    to={`/datasets/${data.dataset.id}`}
+                    className="text-[var(--hud-accent)] hover:underline"
+                  >
+                    {data.dataset.name}
+                  </Link>
+                }
+              />
+              <Row k="Task" v={data.dataset.task_type || '—'} />
+              <Row k="Version" v={`v${data.dataset_version.version}`} />
+              <Row k="Assets" v={String(data.dataset_version.asset_count)} mono />
+              <Row k="Locked" v={data.dataset_version.locked ? 'YES' : 'NO'} />
+            </>
+          ) : (
+            <div className="text-xs font-mono text-[var(--hud-text-muted)]">No dataset linked.</div>
+          )}
+        </Section>
+
+        <Section label="Compute Cluster">
+          {data.cluster ? (
+            <>
+              <Row k="Cluster" v={data.cluster.name} />
+              <Row k="Kind" v={data.cluster.kind.toUpperCase()} />
+              <Row k="GPU" v={data.cluster.gpu_vendor.toUpperCase()} />
+            </>
+          ) : (
+            <div className="text-xs font-mono text-[var(--hud-text-muted)]">
+              No cluster recorded (run executed on shared queue).
+            </div>
+          )}
+        </Section>
+      </div>
+
+      <Section label={`Classes (${data.classes.length})`}>
+        {data.classes.length === 0 ? (
+          <div className="text-xs font-mono text-[var(--hud-text-muted)]">No class map.</div>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {data.classes.map((c) => (
+              <span
+                key={c}
+                className="text-[0.6875rem] font-mono text-[var(--hud-text-data)] border border-[var(--hud-border-default)] bg-[var(--hud-inset)] px-2 py-0.5"
+              >
+                {c}
+              </span>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      <Section label={`Sibling Artifacts (${data.siblings.length})`}>
+        {data.siblings.length === 0 ? (
+          <div className="text-xs font-mono text-[var(--hud-text-muted)]">
+            No other artifacts produced by the same run.
+          </div>
+        ) : (
+          <ul className="divide-y divide-[var(--hud-border-subtle)]">
+            {data.siblings.map((s) => (
+              <li key={s.id} className="flex items-center justify-between py-1.5 text-xs font-mono">
+                <span className="text-[var(--hud-text-muted)]">
+                  {s.type} v{s.version}
+                </span>
+                <Link
+                  to={`/artifacts/lineage/${s.id}`}
+                  className="text-[var(--hud-accent)] hover:underline"
+                >
+                  VIEW LINEAGE →
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+
+      <Section label={`Evaluations (${data.evaluations.length})`}>
+        {data.evaluations.length === 0 ? (
+          <div className="text-xs font-mono text-[var(--hud-text-muted)]">
+            This artifact has not been evaluated yet.
+          </div>
+        ) : (
+          <ul className="divide-y divide-[var(--hud-border-subtle)]">
+            {data.evaluations.map((ev) => (
+              <li key={ev.id} className="flex items-center justify-between py-1.5 text-xs font-mono">
+                <span className="text-[var(--hud-text-muted)]">
+                  {ev.created_at ? new Date(ev.created_at).toLocaleString() : '—'}
+                </span>
+                <span className="flex items-center gap-3">
+                  {evalStatusBadge(ev.status)}
+                  {ev.primary_metric != null && ev.primary_metric_name && (
+                    <span className="text-[var(--hud-text-data)]">
+                      {ev.primary_metric_name} {(ev.primary_metric * 100).toFixed(1)}%
+                    </span>
+                  )}
+                  <Link
+                    to={`/evaluations/${ev.id}`}
+                    className="text-[var(--hud-accent)] hover:underline"
+                  >
+                    VIEW →
+                  </Link>
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Section>
+    </div>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-[var(--hud-surface)]">
+      <div className="border-b border-[var(--hud-border-subtle)] px-4 py-2 flex items-center gap-2">
+        <div className="h-1.5 w-1.5 bg-[var(--hud-accent)]" />
+        <span className="label-overline">{label}</span>
+      </div>
+      <div className="px-4 py-3 text-xs font-mono space-y-1">{children}</div>
+    </div>
+  );
+}
+
+function Row({ k, v, mono = false }: { k: string; v: React.ReactNode; mono?: boolean }) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <span className="text-[var(--hud-text-muted)] tracking-widest uppercase min-w-[120px]">
+        {k}
+      </span>
+      <span
+        className={
+          mono
+            ? 'text-[var(--hud-text-data)] truncate'
+            : 'text-[var(--hud-text-primary)]'
+        }
+      >
+        {v}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/pages/datasets/[datasetId]/index.tsx
+++ b/frontend/src/pages/datasets/[datasetId]/index.tsx
@@ -108,6 +108,12 @@ export default function DatasetDetail() {
                 )}
               </>
             )}
+            <Link
+              to={`/datasets/${dataset.id}/review`}
+              className="inline-flex items-center h-8 px-3 text-xs font-mono border border-[var(--hud-border-strong)] text-[var(--hud-text-secondary)] hover:border-[var(--hud-accent)] hover:text-[var(--hud-accent)] transition-colors tracking-wide"
+            >
+              REVIEW
+            </Link>
             <Button size="sm" variant="outline" onClick={createSnapshot} disabled={snapshotLoading}>
               {snapshotLoading ? 'Creating…' : 'SNAPSHOT'}
             </Button>
@@ -240,6 +246,12 @@ export default function DatasetDetail() {
                 </Link>
               )}
               <Link
+                to={`/datasets/${dataset.id}/review`}
+                className="text-xs font-mono text-[var(--hud-text-muted)] hover:text-[var(--hud-accent)] border border-[var(--hud-border-default)] px-3 py-2 hover:border-[var(--hud-accent)] transition-colors text-center"
+              >
+                Open Review Queue →
+              </Link>
+              <Link
                 to={`/datasets/version?datasetId=${dataset.id}`}
                 className="text-xs font-mono text-[var(--hud-text-muted)] hover:text-[var(--hud-accent)] border border-[var(--hud-border-default)] px-3 py-2 hover:border-[var(--hud-accent)] transition-colors text-center"
               >
@@ -247,8 +259,125 @@ export default function DatasetDetail() {
               </Link>
             </div>
           </section>
+
+          {/* Video frame extraction */}
+          {latestVersion && (
+            <FrameExtractionCard datasetId={dataset.id} versionId={latestVersion.id} />
+          )}
         </div>
       </div>
     </div>
+  );
+}
+
+interface AssetSummary {
+  id: string;
+  uri: string;
+  mime_type?: string;
+  label_status: string;
+}
+
+function FrameExtractionCard({
+  datasetId,
+  versionId,
+}: {
+  datasetId: string;
+  versionId: string;
+}) {
+  const [videos, setVideos] = useState<AssetSummary[]>([]);
+  const [running, setRunning] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [fps, setFps] = useState(1.0);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiGet<{ items: AssetSummary[] }>(
+      `/api/datasets/${datasetId}/assets?version_id=${versionId}&limit=100`,
+    )
+      .then((data) => {
+        if (cancelled) return;
+        const items = data.items || [];
+        const isVideo = (a: AssetSummary) =>
+          (a.mime_type || '').toLowerCase().startsWith('video/') ||
+          a.uri.toLowerCase().endsWith('.mp4') ||
+          a.uri.toLowerCase().endsWith('.mov') ||
+          a.uri.toLowerCase().endsWith('.avi') ||
+          a.uri.toLowerCase().endsWith('.mkv') ||
+          a.uri.toLowerCase().endsWith('.webm');
+        setVideos(items.filter(isVideo));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, versionId]);
+
+  async function trigger(assetId: string) {
+    setRunning(assetId);
+    setError(null);
+    setSuccess(null);
+    try {
+      const res = await apiPost<{ jobId: string; status: string; fpsInterval: number }>(
+        `/api/datasets/${datasetId}/assets/${assetId}/extract-frames?fps_interval=${fps}`,
+      );
+      setSuccess(`Job ${res.jobId.slice(0, 8)} queued at ${res.fpsInterval} fps interval`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to queue extraction');
+    } finally {
+      setRunning(null);
+    }
+  }
+
+  if (videos.length === 0) {
+    return null;
+  }
+
+  return (
+    <section>
+      <div className="label-overline mb-2">Video → Frames</div>
+      <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)] p-4 space-y-3">
+        <p className="text-xs text-[var(--hud-text-muted)]">
+          Extract one frame every <span className="text-[var(--hud-text-data)]">N</span> seconds
+          and persist as new image assets.
+        </p>
+        <div className="flex items-center gap-2 text-xs font-mono">
+          <label htmlFor="fps-int" className="text-[var(--hud-text-muted)]">
+            FPS interval
+          </label>
+          <input
+            id="fps-int"
+            type="number"
+            min={0.1}
+            step={0.1}
+            value={fps}
+            onChange={(e) => setFps(parseFloat(e.target.value) || 1.0)}
+            className="bg-[var(--hud-inset)] border border-[var(--hud-border-default)] text-[var(--hud-text-data)] px-2 py-0.5 w-20"
+          />
+          <span className="text-[var(--hud-text-muted)]">sec / frame</span>
+        </div>
+        <ul className="divide-y divide-[var(--hud-border-subtle)] text-xs font-mono">
+          {videos.map((v) => (
+            <li key={v.id} className="flex items-center justify-between py-1.5 gap-2">
+              <span className="truncate text-[var(--hud-text-secondary)]" title={v.uri}>
+                {v.uri.split('/').slice(-1)[0] || v.id.slice(0, 12)}
+              </span>
+              <Button
+                size="xs"
+                variant="outline"
+                disabled={running === v.id}
+                onClick={() => trigger(v.id)}
+              >
+                {running === v.id ? 'Queuing…' : 'EXTRACT'}
+              </Button>
+            </li>
+          ))}
+        </ul>
+        {error && <div className="text-xs font-mono text-[var(--hud-danger-text)]">{error}</div>}
+        {success && (
+          <div className="text-xs font-mono text-[var(--hud-success-text)]">{success}</div>
+        )}
+      </div>
+    </section>
   );
 }

--- a/frontend/src/pages/datasets/[datasetId]/review.tsx
+++ b/frontend/src/pages/datasets/[datasetId]/review.tsx
@@ -1,0 +1,416 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import Badge from '@/components/ui/Badge';
+import Button from '@/components/ui/Button';
+import Select from '@/components/ui/Select';
+import Loading from '@/components/common/Loading';
+import EmptyState from '@/components/common/EmptyState';
+import ErrorState from '@/components/common/ErrorState';
+import Pager, { PaginatedResponse } from '@/components/common/Pager';
+import { apiGet, apiPost } from '@/services/api';
+
+interface AnnotationRow {
+  id: string;
+  asset_id: string;
+  type: string;
+  geometry: Record<string, unknown>;
+  class_name: string | null;
+  version: number;
+  review_status: 'unreviewed' | 'approved' | 'rejected';
+  reviewer_id: string | null;
+  reviewed_at: string | null;
+  review_notes: string | null;
+  flagged: boolean;
+  flag_reason: string | null;
+  created_at: string | null;
+}
+
+interface AssetRow {
+  id: string;
+  uri: string;
+  width: number | null;
+  height: number | null;
+  label_status: string;
+}
+
+interface QueueItem {
+  annotation: AnnotationRow;
+  asset: AssetRow;
+}
+
+interface Summary {
+  unreviewed: number;
+  approved: number;
+  rejected: number;
+  flagged: number;
+  total: number;
+}
+
+interface ArtifactLite {
+  id: string;
+  name?: string;
+  version?: number;
+}
+
+const PAGE_SIZE = 25;
+
+export default function DatasetReviewQueue() {
+  const { datasetId } = useParams<{ datasetId: string }>();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const versionId = searchParams.get('versionId') || '';
+  const reviewStatus = (searchParams.get('status') || '') as
+    | ''
+    | 'unreviewed'
+    | 'approved'
+    | 'rejected';
+  const flaggedFilter = searchParams.get('flagged') || '';
+
+  const [items, setItems] = useState<QueueItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [datasetName, setDatasetName] = useState('');
+  const [versions, setVersions] = useState<{ id: string; version: number }[]>([]);
+  const [artifacts, setArtifacts] = useState<ArtifactLite[]>([]);
+  const [mineArtifactId, setMineArtifactId] = useState('');
+  const [mineRunning, setMineRunning] = useState(false);
+  const [mineResult, setMineResult] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!datasetId) return;
+    apiGet<{
+      id: string;
+      name: string;
+      versions: { id: string; version: number }[];
+    }>(`/api/datasets/${datasetId}`)
+      .then((d) => {
+        setDatasetName(d.name);
+        setVersions(d.versions || []);
+      })
+      .catch(console.error);
+  }, [datasetId]);
+
+  useEffect(() => {
+    apiGet<{ items: ArtifactLite[] }>('/api/artifacts/models?page=1&page_size=200')
+      .then((r) => setArtifacts(r.items || []))
+      .catch(() => {});
+  }, []);
+
+  function buildQuery(extra: Record<string, string | undefined> = {}) {
+    const p = new URLSearchParams();
+    p.set('page', String(page));
+    p.set('page_size', String(PAGE_SIZE));
+    if (versionId) p.set('version_id', versionId);
+    if (reviewStatus) p.set('review_status', reviewStatus);
+    if (flaggedFilter) p.set('flagged', flaggedFilter);
+    for (const [k, v] of Object.entries(extra)) {
+      if (v) p.set(k, v);
+    }
+    return p.toString();
+  }
+
+  function refresh() {
+    if (!datasetId) return;
+    setLoading(true);
+    setError(null);
+    Promise.all([
+      apiGet<PaginatedResponse<QueueItem>>(
+        `/api/annotations/datasets/${datasetId}/review?${buildQuery()}`,
+      ),
+      apiGet<Summary>(
+        `/api/annotations/datasets/${datasetId}/review/summary${
+          versionId ? `?version_id=${versionId}` : ''
+        }`,
+      ),
+    ])
+      .then(([data, sum]) => {
+        setItems(data.items);
+        setTotal(data.total);
+        setSummary(sum);
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load queue'))
+      .finally(() => setLoading(false));
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(refresh, [datasetId, versionId, reviewStatus, flaggedFilter, page]);
+
+  function setFilter(key: string, value: string) {
+    const next = new URLSearchParams(searchParams);
+    if (value) next.set(key, value);
+    else next.delete(key);
+    setSearchParams(next);
+    setPage(1);
+  }
+
+  async function reviewOne(annotationId: string, status: 'approved' | 'rejected') {
+    try {
+      await apiPost(`/api/annotations/${annotationId}/review`, {
+        review_status: status,
+      });
+      refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Failed to ${status}`);
+    }
+  }
+
+  async function runErrorMining() {
+    if (!mineArtifactId) {
+      setError('Pick a model artifact first');
+      return;
+    }
+    if (!datasetId) return;
+    let targetVersion = versionId;
+    if (!targetVersion && versions.length) {
+      targetVersion = versions[0].id;
+    }
+    if (!targetVersion) {
+      setError('Pick a dataset version to mine against');
+      return;
+    }
+    setMineRunning(true);
+    setError(null);
+    try {
+      const res = await apiPost<{ jobId: string; status: string }>('/api/annotations/error-mine', {
+        artifact_id: mineArtifactId,
+        dataset_version_id: targetVersion,
+      });
+      setMineResult(`queued: job ${res.jobId.slice(0, 8)}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to queue error mining');
+    } finally {
+      setMineRunning(false);
+    }
+  }
+
+  const counts = summary;
+
+  const annotations = useMemo(() => items, [items]);
+
+  return (
+    <div className="space-y-4">
+      <div className="border-b border-[var(--hud-border-subtle)] pb-3">
+        <nav className="label-overline mb-1">
+          <Link to="/datasets" className="hover:text-[var(--hud-accent)]">DATASETS</Link>
+          <span className="mx-1.5 text-[var(--hud-border-strong)]">/</span>
+          <Link
+            to={`/datasets/${datasetId}`}
+            className="hover:text-[var(--hud-accent)]"
+          >
+            {datasetName.toUpperCase() || (datasetId || '').slice(0, 8).toUpperCase()}
+          </Link>
+          <span className="mx-1.5 text-[var(--hud-border-strong)]">/</span>
+          <span className="text-[var(--hud-text-secondary)]">REVIEW</span>
+        </nav>
+        <h1>Annotation Review Queue</h1>
+        <p className="text-xs text-[var(--hud-text-muted)] mt-1">
+          Approve or reject annotations and triage flagged items.
+        </p>
+      </div>
+
+      {/* Summary chips */}
+      {counts && (
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-px bg-[var(--hud-border-default)]">
+          {[
+            { label: 'TOTAL',      value: counts.total,      filter: ''            },
+            { label: 'UNREVIEWED', value: counts.unreviewed, filter: 'unreviewed'  },
+            { label: 'APPROVED',   value: counts.approved,   filter: 'approved'    },
+            { label: 'REJECTED',   value: counts.rejected,   filter: 'rejected'    },
+            { label: 'FLAGGED',    value: counts.flagged,    filter: '__flagged__' },
+          ].map((c) => {
+            const isActive =
+              c.filter === '__flagged__' ? flaggedFilter === 'true' : reviewStatus === c.filter;
+            return (
+              <button
+                key={c.label}
+                type="button"
+                onClick={() => {
+                  if (c.filter === '__flagged__') {
+                    setFilter('flagged', flaggedFilter === 'true' ? '' : 'true');
+                  } else {
+                    setFilter('status', reviewStatus === c.filter ? '' : c.filter);
+                  }
+                }}
+                className={[
+                  'bg-[var(--hud-surface)] p-3 text-left transition-colors',
+                  isActive
+                    ? 'border border-[var(--hud-accent)] bg-[var(--hud-elevated)]'
+                    : 'hover:bg-[var(--hud-elevated)]',
+                ].join(' ')}
+              >
+                <div className="label-overline mb-1">{c.label}</div>
+                <div className="text-2xl font-mono font-semibold text-[var(--hud-text-data)]">
+                  {c.value}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)] px-4 py-3 flex flex-wrap items-end gap-3">
+        <div>
+          <label className="label-overline block mb-1" htmlFor="rev-version">
+            Version
+          </label>
+          <Select
+            id="rev-version"
+            value={versionId}
+            onChange={(e) => setFilter('versionId', e.target.value)}
+          >
+            <option value="">— all —</option>
+            {versions.map((v) => (
+              <option key={v.id} value={v.id}>v{v.version}</option>
+            ))}
+          </Select>
+        </div>
+        <div>
+          <label className="label-overline block mb-1" htmlFor="rev-status">
+            Status
+          </label>
+          <Select
+            id="rev-status"
+            value={reviewStatus}
+            onChange={(e) => setFilter('status', e.target.value)}
+          >
+            <option value="">— all —</option>
+            <option value="unreviewed">Unreviewed</option>
+            <option value="approved">Approved</option>
+            <option value="rejected">Rejected</option>
+          </Select>
+        </div>
+        <div>
+          <label className="label-overline block mb-1" htmlFor="rev-flag">
+            Flagged
+          </label>
+          <Select
+            id="rev-flag"
+            value={flaggedFilter}
+            onChange={(e) => setFilter('flagged', e.target.value)}
+          >
+            <option value="">— all —</option>
+            <option value="true">Flagged</option>
+            <option value="false">Clean</option>
+          </Select>
+        </div>
+
+        <div className="ml-auto flex items-end gap-2">
+          <div>
+            <label className="label-overline block mb-1" htmlFor="rev-mine-art">
+              Error mining model
+            </label>
+            <Select
+              id="rev-mine-art"
+              value={mineArtifactId}
+              onChange={(e) => setMineArtifactId(e.target.value)}
+            >
+              <option value="">— select model —</option>
+              {artifacts.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name || a.id.slice(0, 8)}
+                  {a.version != null ? ` v${a.version}` : ''}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <Button
+            onClick={runErrorMining}
+            disabled={mineRunning || !mineArtifactId}
+            size="md"
+          >
+            {mineRunning ? 'Queuing…' : 'Run Error Mining'}
+          </Button>
+        </div>
+      </div>
+
+      {mineResult && (
+        <div className="border border-[var(--hud-success)] bg-[var(--hud-success-dim)] px-3 py-2 text-xs font-mono text-[var(--hud-success-text)]">
+          {mineResult} — refresh in a few minutes to see the flagged column populate.
+        </div>
+      )}
+
+      {error && <ErrorState title="Review queue error" description={error} />}
+
+      {loading ? (
+        <div className="py-6"><Loading label="Loading queue…" /></div>
+      ) : annotations.length === 0 ? (
+        <EmptyState
+          title="Queue is empty"
+          description="No annotations match the current filters."
+        />
+      ) : (
+        <>
+          <div className="border border-[var(--hud-border-default)] divide-y divide-[var(--hud-border-subtle)]">
+            {annotations.map(({ annotation: ann, asset }) => (
+              <div
+                key={ann.id}
+                className="px-3 py-2.5 flex flex-wrap items-center gap-3 hover:bg-[var(--hud-elevated)] transition-colors"
+              >
+                <div className="flex-1 min-w-[260px]">
+                  <div className="flex items-center gap-2 text-xs font-mono">
+                    <span className="text-[var(--hud-text-muted)]">{ann.type.toUpperCase()}</span>
+                    {ann.class_name && (
+                      <span className="text-[var(--hud-text-primary)]">{ann.class_name}</span>
+                    )}
+                    {ann.flagged && (
+                      <Badge variant="danger">FLAGGED</Badge>
+                    )}
+                    {ann.review_status === 'approved' && (
+                      <Badge variant="success">APPROVED</Badge>
+                    )}
+                    {ann.review_status === 'rejected' && (
+                      <Badge variant="danger">REJECTED</Badge>
+                    )}
+                  </div>
+                  <div className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] mt-0.5 truncate">
+                    asset {asset.id.slice(0, 12)}… · v{ann.version}
+                    {ann.flag_reason && (
+                      <span className="ml-2 text-[var(--hud-danger-text)]">
+                        ({ann.flag_reason})
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <Link
+                  to={`/annotate/${ann.asset_id}`}
+                  className="text-[0.6875rem] font-mono text-[var(--hud-accent)] hover:underline"
+                >
+                  OPEN ANNOTATOR →
+                </Link>
+                <div className="flex gap-1.5">
+                  <Button
+                    size="xs"
+                    variant="success"
+                    onClick={() => reviewOne(ann.id, 'approved')}
+                    disabled={ann.review_status === 'approved'}
+                  >
+                    APPROVE
+                  </Button>
+                  <Button
+                    size="xs"
+                    variant="danger"
+                    onClick={() => reviewOne(ann.id, 'rejected')}
+                    disabled={ann.review_status === 'rejected'}
+                  >
+                    REJECT
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+          <Pager
+            page={page}
+            pageSize={PAGE_SIZE}
+            total={total}
+            onChange={setPage}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/datasets/import.tsx
+++ b/frontend/src/pages/datasets/import.tsx
@@ -46,7 +46,9 @@ export default function DatasetImport() {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    apiGet<DatasetSummary[]>('/api/datasets').then(setDatasets).catch(() => {});
+    apiGet<{ items: DatasetSummary[] }>('/api/datasets?page=1&page_size=200')
+      .then((d) => setDatasets(d.items || []))
+      .catch(() => {});
     apiGet<{ formats: string[] }>('/api/datasets/formats')
       .then((r) => setFormats(r.formats))
       .catch(() => {});

--- a/frontend/src/pages/datasets/index.tsx
+++ b/frontend/src/pages/datasets/index.tsx
@@ -4,6 +4,7 @@ import Badge from '@/components/ui/Badge';
 import Loading from '@/components/common/Loading';
 import EmptyState from '@/components/common/EmptyState';
 import ErrorState from '@/components/common/ErrorState';
+import Pager, { PaginatedResponse } from '@/components/common/Pager';
 import { apiGet } from '@/services/api';
 
 interface Dataset {
@@ -14,24 +15,37 @@ interface Dataset {
   latest_version_id?: string;
   project_id?: string;
   project_name?: string;
+  task_type?: 'detect' | 'classify' | null;
   created_at: string;
 }
+
+const PAGE_SIZE = 24;
 
 export default function DatasetsIndex() {
   const [searchParams] = useSearchParams();
   const projectId = searchParams.get('projectId') || '';
 
   const [datasets, setDatasets] = useState<Dataset[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const url = projectId ? `/api/datasets?project_id=${projectId}` : '/api/datasets';
-    apiGet<Dataset[]>(url)
-      .then(setDatasets)
+    setLoading(true);
+    const params = new URLSearchParams({
+      page: String(page),
+      page_size: String(PAGE_SIZE),
+    });
+    if (projectId) params.set('project_id', projectId);
+    apiGet<PaginatedResponse<Dataset>>(`/api/datasets?${params.toString()}`)
+      .then((data) => {
+        setDatasets(data.items);
+        setTotal(data.total);
+      })
       .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load datasets'))
       .finally(() => setLoading(false));
-  }, [projectId]);
+  }, [projectId, page]);
 
   if (loading) return <div className="py-6"><Loading label="Loading datasets…" /></div>;
   if (error) return <ErrorState title="Failed to load datasets" description={error} />;
@@ -87,6 +101,7 @@ export default function DatasetsIndex() {
           </Link>
         </EmptyState>
       ) : (
+      <>
         <div className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-3 bg-[var(--hud-border-default)]">
           {datasets.map((ds) => (
             <div key={ds.id} className="bg-[var(--hud-surface)] p-4 flex flex-col gap-2 hover:bg-[var(--hud-elevated)] transition-colors">
@@ -98,9 +113,16 @@ export default function DatasetsIndex() {
                 >
                   {ds.name}
                 </Link>
-                {ds.latest_version != null && (
-                  <Badge variant="default">v{ds.latest_version}</Badge>
-                )}
+                <div className="flex items-center gap-1">
+                  {ds.task_type && (
+                    <span className="text-[0.625rem] font-mono text-[var(--hud-accent)] border border-[var(--hud-border-default)] px-1.5 py-0.5 tracking-widest uppercase">
+                      {ds.task_type}
+                    </span>
+                  )}
+                  {ds.latest_version != null && (
+                    <Badge variant="default">v{ds.latest_version}</Badge>
+                  )}
+                </div>
               </div>
 
               {/* Metadata */}
@@ -145,10 +167,18 @@ export default function DatasetsIndex() {
                     ANNOTATE
                   </Link>
                 )}
+                <Link
+                  to={`/datasets/${ds.id}/review`}
+                  className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] hover:text-[var(--hud-accent)] border border-[var(--hud-border-default)] px-2 py-0.5 hover:border-[var(--hud-accent)] transition-colors"
+                >
+                  REVIEW
+                </Link>
               </div>
             </div>
           ))}
         </div>
+        <Pager page={page} pageSize={PAGE_SIZE} total={total} onChange={setPage} />
+      </>
       )}
     </div>
   );

--- a/frontend/src/pages/datasets/upload.tsx
+++ b/frontend/src/pages/datasets/upload.tsx
@@ -38,7 +38,9 @@ export default function DatasetUpload() {
   // Load projects for the creation form
   useEffect(() => {
     if (!datasetId) {
-      apiGet<Project[]>('/api/projects').then(setProjects).catch(console.error);
+      apiGet<{ items: Project[] }>('/api/projects?page=1&page_size=200')
+        .then((d) => setProjects(d.items || []))
+        .catch(console.error);
     }
   }, [datasetId]);
 

--- a/frontend/src/pages/evaluations/index.tsx
+++ b/frontend/src/pages/evaluations/index.tsx
@@ -4,6 +4,7 @@ import Badge from '@/components/ui/Badge';
 import Spinner from '@/components/ui/Spinner';
 import EmptyState from '@/components/common/EmptyState';
 import ErrorState from '@/components/common/ErrorState';
+import Pager, { PaginatedResponse } from '@/components/common/Pager';
 import { apiGet } from '@/services/api';
 
 interface EvaluationSummary {
@@ -17,6 +18,8 @@ interface EvaluationSummary {
   completed_at: string | null;
 }
 
+const PAGE_SIZE = 25;
+
 function statusBadge(status: string) {
   if (status === 'succeeded') return <Badge variant="success">DONE</Badge>;
   if (status === 'running') return <Badge variant="info">RUNNING</Badge>;
@@ -27,6 +30,8 @@ function statusBadge(status: string) {
 export default function EvaluationsIndex() {
   const [params] = useSearchParams();
   const [rows, setRows] = useState<EvaluationSummary[] | null>(null);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -37,11 +42,16 @@ export default function EvaluationsIndex() {
     if (dsv) qp.set('dataset_version_id', dsv);
     const project = params.get('project_id');
     if (project) qp.set('project_id', project);
+    qp.set('page', String(page));
+    qp.set('page_size', String(PAGE_SIZE));
 
-    apiGet<EvaluationSummary[]>(`/api/evaluations?${qp.toString()}`)
-      .then(setRows)
+    apiGet<PaginatedResponse<EvaluationSummary>>(`/api/evaluations?${qp.toString()}`)
+      .then((data) => {
+        setRows(data.items);
+        setTotal(data.total);
+      })
       .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load'));
-  }, [params]);
+  }, [params, page]);
 
   return (
     <div className="space-y-4">
@@ -78,6 +88,7 @@ export default function EvaluationsIndex() {
       )}
 
       {rows && rows.length > 0 && (
+        <>
         <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)]">
           <table className="w-full text-xs font-mono">
             <thead className="bg-[var(--hud-inset)]">
@@ -122,6 +133,8 @@ export default function EvaluationsIndex() {
             </tbody>
           </table>
         </div>
+        <Pager page={page} pageSize={PAGE_SIZE} total={total} onChange={setPage} />
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/evaluations/new.tsx
+++ b/frontend/src/pages/evaluations/new.tsx
@@ -41,8 +41,12 @@ export default function EvaluationsNew() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    apiGet<ModelArtifact[]>('/api/artifacts/models').then(setModels).catch(() => {});
-    apiGet<DatasetSummary[]>('/api/datasets').then(setDatasets).catch(() => {});
+    apiGet<{ items: ModelArtifact[] }>('/api/artifacts/models?page=1&page_size=200')
+      .then((d) => setModels(d.items || []))
+      .catch(() => {});
+    apiGet<{ items: DatasetSummary[] }>('/api/datasets?page=1&page_size=200')
+      .then((d) => setDatasets(d.items || []))
+      .catch(() => {});
   }, []);
 
   function setField<K extends keyof typeof form>(key: K, value: (typeof form)[K]) {

--- a/frontend/src/pages/experiments/index.tsx
+++ b/frontend/src/pages/experiments/index.tsx
@@ -1,16 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import Badge from '@/components/ui/Badge';
-import Button from '@/components/ui/Button';
 import Loading from '@/components/common/Loading';
 import EmptyState from '@/components/common/EmptyState';
+import Pager, { PaginatedResponse } from '@/components/common/Pager';
 import { apiGet } from '@/services/api';
 
 interface Run {
   id: string;
   name?: string;
   status: 'queued' | 'running' | 'succeeded' | 'failed';
-  createdAt: string;
+  created_at?: string;
+  createdAt?: string;
 }
 
 function statusVariant(s: string): 'default' | 'success' | 'warning' | 'danger' {
@@ -22,28 +23,40 @@ function statusVariant(s: string): 'default' | 'success' | 'warning' | 'danger' 
   }
 }
 
+const PAGE_SIZE = 25;
+
 export default function ExperimentsIndex() {
   const [runs, setRuns] = useState<Run[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    apiGet<Run[]>('/api/experiments/runs')
-      .then(setRuns)
+    setLoading(true);
+    apiGet<PaginatedResponse<Run>>(
+      `/api/experiments/runs?page=${page}&page_size=${PAGE_SIZE}`,
+    )
+      .then((data) => {
+        setRuns(data.items);
+        setTotal(data.total);
+      })
       .catch(console.error)
       .finally(() => setLoading(false));
-  }, []);
+  }, [page]);
 
   return (
     <div className="space-y-4">
-      {/* Header */}
       <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
         <div>
           <div className="label-overline mb-0.5">// Experiments</div>
           <h1>Training Runs</h1>
         </div>
-        <Button as-child>
-          <Link to="/experiments/new">+ New Run</Link>
-        </Button>
+        <Link
+          to="/experiments/new"
+          className="inline-flex items-center h-8 px-3 text-xs font-mono font-medium bg-[var(--hud-accent)] text-[oklch(0.10_0.008_240)] border border-[var(--hud-accent)] hover:bg-[var(--hud-accent-hover)] tracking-wide"
+        >
+          + NEW RUN
+        </Link>
       </div>
 
       {loading ? (
@@ -61,41 +74,45 @@ export default function ExperimentsIndex() {
           </Link>
         </EmptyState>
       ) : (
-        <div className="border border-[var(--hud-border-default)] divide-y divide-[var(--hud-border-subtle)]">
-          {/* Table header */}
-          <div className="grid grid-cols-[1fr_auto_auto_auto] gap-4 px-4 py-2 bg-[var(--hud-inset)]">
-            <span className="label-overline">Run</span>
-            <span className="label-overline">Status</span>
-            <span className="label-overline">Started</span>
-            <span className="label-overline">Details</span>
-          </div>
-
-          {runs.map((r) => (
-            <div
-              key={r.id}
-              className="grid grid-cols-[1fr_auto_auto_auto] gap-4 items-center px-4 py-2.5 hover:bg-[var(--hud-elevated)] transition-colors"
-            >
-              <div>
-                <div className="text-sm font-medium text-[var(--hud-text-primary)]">
-                  {r.name || `Run ${r.id.slice(0, 8)}`}
-                </div>
-                <div className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] mt-0.5">
-                  {r.id.slice(0, 16)}…
-                </div>
-              </div>
-              <Badge variant={statusVariant(r.status)}>{r.status}</Badge>
-              <span className="text-xs font-mono text-[var(--hud-text-muted)] whitespace-nowrap">
-                {r.createdAt ? new Date(r.createdAt).toLocaleDateString() : '—'}
-              </span>
-              <Link
-                to={`/experiments/runs/${r.id}`}
-                className="text-xs font-mono text-[var(--hud-accent)] hover:underline underline-offset-2 whitespace-nowrap"
-              >
-                VIEW →
-              </Link>
+        <>
+          <div className="border border-[var(--hud-border-default)] divide-y divide-[var(--hud-border-subtle)]">
+            <div className="grid grid-cols-[1fr_auto_auto_auto] gap-4 px-4 py-2 bg-[var(--hud-inset)]">
+              <span className="label-overline">Run</span>
+              <span className="label-overline">Status</span>
+              <span className="label-overline">Started</span>
+              <span className="label-overline">Details</span>
             </div>
-          ))}
-        </div>
+            {runs.map((r) => {
+              const ts = r.created_at || r.createdAt;
+              return (
+                <div
+                  key={r.id}
+                  className="grid grid-cols-[1fr_auto_auto_auto] gap-4 items-center px-4 py-2.5 hover:bg-[var(--hud-elevated)] transition-colors"
+                >
+                  <div>
+                    <div className="text-sm font-medium text-[var(--hud-text-primary)]">
+                      {r.name || `Run ${r.id.slice(0, 8)}`}
+                    </div>
+                    <div className="text-[0.6875rem] font-mono text-[var(--hud-text-muted)] mt-0.5">
+                      {r.id.slice(0, 16)}…
+                    </div>
+                  </div>
+                  <Badge variant={statusVariant(r.status)}>{r.status}</Badge>
+                  <span className="text-xs font-mono text-[var(--hud-text-muted)] whitespace-nowrap">
+                    {ts ? new Date(ts).toLocaleDateString() : '—'}
+                  </span>
+                  <Link
+                    to={`/experiments/runs/${r.id}`}
+                    className="text-xs font-mono text-[var(--hud-accent)] hover:underline underline-offset-2 whitespace-nowrap"
+                  >
+                    VIEW →
+                  </Link>
+                </div>
+              );
+            })}
+          </div>
+          <Pager page={page} pageSize={PAGE_SIZE} total={total} onChange={setPage} />
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/experiments/new.tsx
+++ b/frontend/src/pages/experiments/new.tsx
@@ -66,12 +66,18 @@ export default function ExperimentsNew() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    apiGet<Project[]>('/api/projects').then(setProjects).catch(console.error);
+    apiGet<{ items: Project[] }>('/api/projects?page=1&page_size=200')
+      .then((d) => setProjects(d.items || []))
+      .catch(console.error);
   }, []);
 
   useEffect(() => {
     if (!form.projectId) { setDatasets([]); return; }
-    apiGet<Dataset[]>(`/api/datasets?project_id=${form.projectId}`).then(setDatasets).catch(console.error);
+    apiGet<{ items: Dataset[] }>(
+      `/api/datasets?project_id=${form.projectId}&page=1&page_size=200`,
+    )
+      .then((d) => setDatasets(d.items || []))
+      .catch(console.error);
   }, [form.projectId]);
 
   function setField<K extends keyof typeof form>(key: K, value: (typeof form)[K]) {

--- a/frontend/src/pages/projects/[projectId]/index.tsx
+++ b/frontend/src/pages/projects/[projectId]/index.tsx
@@ -66,12 +66,12 @@ export default function ProjectDashboard() {
     Promise.all([
       apiGet<ProjectDetail>(`/api/projects/${projectId}`),
       apiGet<Dataset[]>(`/api/projects/${projectId}/datasets`),
-      apiGet<Run[]>('/api/experiments/runs'),
+      apiGet<{ items: Run[] }>(`/api/experiments/runs?project_id=${projectId}&page=1&page_size=20`),
     ])
-      .then(([proj, ds, allRuns]) => {
+      .then(([proj, ds, runsPage]) => {
         setProject(proj);
         setDatasets(ds);
-        setRuns(allRuns.filter((r) => r.project_id === projectId).slice(0, 5));
+        setRuns((runsPage.items || []).slice(0, 5));
       })
       .catch((err) => setError(err instanceof Error ? err.message : 'Failed to load project'))
       .finally(() => setLoading(false));

--- a/frontend/src/pages/projects/create.tsx
+++ b/frontend/src/pages/projects/create.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Input from '@/components/ui/Input';
 import Button from '@/components/ui/Button';
@@ -6,100 +6,353 @@ import Alert from '@/components/ui/Alert';
 import ErrorState from '@/components/common/ErrorState';
 import { apiPost } from '@/services/api';
 
-interface Project {
-  id: string;
+type TaskType = 'detect' | 'classify';
+
+interface ClassRow {
   name: string;
+  color?: string;
   description?: string;
 }
 
+interface WizardResponse {
+  project: { id: string; name: string; task_type: TaskType };
+  dataset: { id: string; name: string; task_type: TaskType };
+  version: { id: string; version: number };
+  classes: string[];
+}
+
+const STEPS = [
+  { key: 'task',     label: 'Task Type'  },
+  { key: 'project',  label: 'Project'    },
+  { key: 'classes',  label: 'Classes'    },
+  { key: 'dataset',  label: 'Dataset'    },
+  { key: 'review',   label: 'Review'     },
+] as const;
+
 export default function ProjectsCreate() {
+  const navigate = useNavigate();
+  const [stepIdx, setStepIdx] = useState(0);
+  const [task, setTask] = useState<TaskType | null>(null);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [created, setCreated] = useState<string | null>(null);
+  const [classes, setClasses] = useState<ClassRow[]>([]);
+  const [classDraft, setClassDraft] = useState('');
+  const [datasetName, setDatasetName] = useState('default');
+  const [datasetDescription, setDatasetDescription] = useState('');
+  const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const navigate = useNavigate();
 
-  async function onSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!name) {
-      setError('Project name is required');
+  const step = STEPS[stepIdx].key;
+
+  const canAdvance = useMemo(() => {
+    if (step === 'task') return task !== null;
+    if (step === 'project') return name.trim().length > 0;
+    if (step === 'classes') return classes.length > 0;
+    if (step === 'dataset') return datasetName.trim().length > 0;
+    return true;
+  }, [step, task, name, classes, datasetName]);
+
+  function next() {
+    setError(null);
+    if (stepIdx < STEPS.length - 1) setStepIdx(stepIdx + 1);
+  }
+
+  function back() {
+    setError(null);
+    if (stepIdx > 0) setStepIdx(stepIdx - 1);
+  }
+
+  function addClass() {
+    const trimmed = classDraft.trim();
+    if (!trimmed) return;
+    if (classes.some((c) => c.name === trimmed)) {
+      setError(`class "${trimmed}" already added`);
       return;
     }
+    setClasses([...classes, { name: trimmed }]);
+    setClassDraft('');
+  }
+
+  function removeClass(idx: number) {
+    setClasses(classes.filter((_, i) => i !== idx));
+  }
+
+  async function submit() {
+    if (!task) {
+      setError('Pick a task type');
+      setStepIdx(0);
+      return;
+    }
+    setSubmitting(true);
     setError(null);
-    setLoading(true);
     try {
-      const project = await apiPost<Project>('/api/projects', {
-        name,
-        description: description || undefined,
+      const res = await apiPost<WizardResponse>('/api/projects/wizard', {
+        name: name.trim(),
+        description: description.trim() || undefined,
+        task_type: task,
+        dataset_name: datasetName.trim() || 'default',
+        dataset_description: datasetDescription.trim() || undefined,
+        classes: classes.map((c) => ({
+          name: c.name,
+          color: c.color,
+          description: c.description,
+        })),
       });
-      setCreated(`Created project ${name}`);
-      setTimeout(() => navigate(`/projects/${project.id}`), 400);
+      navigate(`/projects/${res.project.id}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create project');
     } finally {
-      setLoading(false);
+      setSubmitting(false);
     }
   }
 
   return (
-    <div className="max-w-lg space-y-4">
-      {/* Header */}
+    <div className="max-w-2xl space-y-4">
       <div className="border-b border-[var(--hud-border-subtle)] pb-3">
         <div className="label-overline mb-0.5">// Projects / New</div>
         <h1>New Project</h1>
       </div>
 
-      {/* Form */}
+      <ol className="flex items-center gap-1 text-xs font-mono">
+        {STEPS.map((s, i) => {
+          const done = i < stepIdx;
+          const active = i === stepIdx;
+          return (
+            <li key={s.key} className="flex items-center gap-1">
+              <span
+                className={[
+                  'inline-flex h-6 min-w-6 items-center justify-center px-2 border tracking-widest uppercase',
+                  active
+                    ? 'bg-[var(--hud-accent)] text-[oklch(0.10_0.008_240)] border-[var(--hud-accent)]'
+                    : done
+                    ? 'bg-[var(--hud-success-dim)] text-[var(--hud-success-text)] border-[var(--hud-success)]'
+                    : 'bg-[var(--hud-surface)] text-[var(--hud-text-muted)] border-[var(--hud-border-default)]',
+                ].join(' ')}
+              >
+                {i + 1}. {s.label}
+              </span>
+              {i < STEPS.length - 1 && (
+                <span className="text-[var(--hud-text-muted)]">›</span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
       <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)]">
         <div className="border-b border-[var(--hud-border-subtle)] px-4 py-2 flex items-center gap-2">
           <div className="h-1.5 w-1.5 bg-[var(--hud-accent)]" />
-          <span className="label-overline">Configuration</span>
+          <span className="label-overline">{STEPS[stepIdx].label}</span>
         </div>
-        <form onSubmit={onSubmit} className="p-4 space-y-4">
-          <div className="space-y-1.5">
-            <label htmlFor="proj-name" className="label-overline block">
-              Project Name <span className="text-[var(--hud-danger-text)]">*</span>
-            </label>
-            <Input
-              id="proj-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="my-project"
-              disabled={loading}
-            />
-          </div>
-          <div className="space-y-1.5">
-            <label htmlFor="proj-desc" className="label-overline block">
-              Description <span className="text-[var(--hud-text-muted)]">(optional)</span>
-            </label>
-            <Input
-              id="proj-desc"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Brief description of project scope"
-              disabled={loading}
-            />
-          </div>
+        <div className="p-4 space-y-4 min-h-[280px]">
+          {step === 'task' && (
+            <div className="grid grid-cols-2 gap-3">
+              {[
+                {
+                  value: 'detect' as const,
+                  label: 'Object Detection',
+                  desc: 'Localise objects with bounding boxes (YOLO detect).',
+                },
+                {
+                  value: 'classify' as const,
+                  label: 'Image Classification',
+                  desc: 'Assign one label per image (YOLO classify).',
+                },
+              ].map((o) => {
+                const selected = task === o.value;
+                return (
+                  <button
+                    key={o.value}
+                    type="button"
+                    onClick={() => setTask(o.value)}
+                    className={[
+                      'text-left border p-4 transition-colors',
+                      selected
+                        ? 'border-[var(--hud-accent)] bg-[var(--hud-elevated)]'
+                        : 'border-[var(--hud-border-default)] hover:border-[var(--hud-border-accent)] hover:bg-[var(--hud-elevated)]',
+                    ].join(' ')}
+                  >
+                    <div className="font-mono text-[0.6875rem] tracking-widest uppercase text-[var(--hud-accent)] mb-1">
+                      {o.value}
+                    </div>
+                    <div className="font-medium text-sm text-[var(--hud-text-primary)]">
+                      {o.label}
+                    </div>
+                    <div className="text-xs text-[var(--hud-text-muted)] mt-1">
+                      {o.desc}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {step === 'project' && (
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <label htmlFor="proj-name" className="label-overline block">
+                  Project Name <span className="text-[var(--hud-danger-text)]">*</span>
+                </label>
+                <Input
+                  id="proj-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="my-project"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label htmlFor="proj-desc" className="label-overline block">
+                  Description{' '}
+                  <span className="text-[var(--hud-text-muted)]">(optional)</span>
+                </label>
+                <Input
+                  id="proj-desc"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Brief description"
+                />
+              </div>
+            </div>
+          )}
+
+          {step === 'classes' && (
+            <div className="space-y-3">
+              <div className="text-xs text-[var(--hud-text-muted)]">
+                Define the labels annotators will apply.{' '}
+                {task === 'classify'
+                  ? 'For classification, each image gets exactly one of these labels.'
+                  : 'For detection, every box gets one of these labels.'}
+              </div>
+              <div className="flex gap-2">
+                <Input
+                  value={classDraft}
+                  onChange={(e) => setClassDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      addClass();
+                    }
+                  }}
+                  placeholder="e.g. person"
+                />
+                <Button onClick={addClass} disabled={!classDraft.trim()}>
+                  Add
+                </Button>
+              </div>
+              {classes.length === 0 ? (
+                <div className="text-xs font-mono text-[var(--hud-text-muted)] py-3">
+                  No classes added yet.
+                </div>
+              ) : (
+                <ul className="border border-[var(--hud-border-default)] divide-y divide-[var(--hud-border-subtle)]">
+                  {classes.map((c, i) => (
+                    <li
+                      key={c.name}
+                      className="flex items-center justify-between px-3 py-2 text-xs font-mono"
+                    >
+                      <span>
+                        <span className="text-[var(--hud-text-muted)] mr-2">
+                          {String(i).padStart(2, '0')}
+                        </span>
+                        <span className="text-[var(--hud-text-primary)]">{c.name}</span>
+                      </span>
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        onClick={() => removeClass(i)}
+                      >
+                        Remove
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {step === 'dataset' && (
+            <div className="space-y-3">
+              <div className="text-xs text-[var(--hud-text-muted)]">
+                A first dataset and version will be created so you can start
+                uploading images right after the wizard.
+              </div>
+              <div className="space-y-1.5">
+                <label htmlFor="ds-name" className="label-overline block">
+                  Dataset Name <span className="text-[var(--hud-danger-text)]">*</span>
+                </label>
+                <Input
+                  id="ds-name"
+                  value={datasetName}
+                  onChange={(e) => setDatasetName(e.target.value)}
+                  placeholder="default"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label htmlFor="ds-desc" className="label-overline block">
+                  Dataset Description{' '}
+                  <span className="text-[var(--hud-text-muted)]">(optional)</span>
+                </label>
+                <Input
+                  id="ds-desc"
+                  value={datasetDescription}
+                  onChange={(e) => setDatasetDescription(e.target.value)}
+                  placeholder="What's in this dataset?"
+                />
+              </div>
+            </div>
+          )}
+
+          {step === 'review' && (
+            <div className="space-y-3 text-xs font-mono">
+              <Row label="Task Type" value={(task || '—').toUpperCase()} />
+              <Row label="Project Name" value={name} />
+              {description && <Row label="Description" value={description} />}
+              <Row
+                label="Classes"
+                value={classes.map((c) => c.name).join(', ') || '—'}
+              />
+              <Row label="Dataset Name" value={datasetName} />
+              {datasetDescription && (
+                <Row label="Dataset Desc" value={datasetDescription} />
+              )}
+            </div>
+          )}
 
           {error && <ErrorState title="Error" description={error} />}
-          {created && <Alert variant="success">{created}</Alert>}
-
-          <div className="flex items-center gap-2 pt-1">
-            <Button type="submit" disabled={loading}>
-              {loading ? 'Creating…' : 'Create Project'}
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => navigate('/projects')}
-              disabled={loading}
-            >
+        </div>
+        <div className="border-t border-[var(--hud-border-subtle)] px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" onClick={() => navigate('/projects')}>
               Cancel
             </Button>
           </div>
-        </form>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" onClick={back} disabled={stepIdx === 0}>
+              ← Back
+            </Button>
+            {stepIdx < STEPS.length - 1 ? (
+              <Button onClick={next} disabled={!canAdvance}>
+                Next →
+              </Button>
+            ) : (
+              <Button onClick={submit} disabled={submitting}>
+                {submitting ? 'Creating…' : 'Create Project'}
+              </Button>
+            )}
+          </div>
+        </div>
       </div>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline gap-3">
+      <span className="text-[var(--hud-text-muted)] tracking-widest uppercase min-w-[120px]">
+        {label}
+      </span>
+      <span className="text-[var(--hud-text-primary)]">{value}</span>
     </div>
   );
 }

--- a/frontend/src/pages/projects/index.tsx
+++ b/frontend/src/pages/projects/index.tsx
@@ -3,37 +3,48 @@ import { Link } from 'react-router-dom';
 import Button from '@/components/ui/Button';
 import Loading from '@/components/common/Loading';
 import EmptyState from '@/components/common/EmptyState';
+import Pager, { PaginatedResponse } from '@/components/common/Pager';
 import { apiGet } from '@/services/api';
 
 interface Project {
   id: string;
   name: string;
   description?: string;
+  task_type?: 'detect' | 'classify' | null;
 }
+
+const PAGE_SIZE = 24;
 
 export default function ProjectsIndex() {
   const [loading, setLoading] = useState(true);
   const [projects, setProjects] = useState<Project[]>([]);
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
 
   useEffect(() => {
-    apiGet<Project[]>('/api/projects')
-      .then(setProjects)
+    setLoading(true);
+    apiGet<PaginatedResponse<Project>>(`/api/projects?page=${page}&page_size=${PAGE_SIZE}`)
+      .then((data) => {
+        setProjects(data.items);
+        setTotal(data.total);
+      })
       .catch(console.error)
       .finally(() => setLoading(false));
-  }, []);
+  }, [page]);
 
   return (
     <div className="space-y-4">
-      {/* Page header */}
       <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
         <div>
           <div className="label-overline mb-0.5">// Projects</div>
           <h1>Projects</h1>
         </div>
-        <Button as-child="true">
-          {/* @ts-expect-error allow as-child semantics via attribute only */}
-          <Link to="/projects/create">+ New Project</Link>
-        </Button>
+        <Link
+          to="/projects/create"
+          className="inline-flex items-center h-8 px-3 text-xs font-mono font-medium bg-[var(--hud-accent)] text-[oklch(0.10_0.008_240)] border border-[var(--hud-accent)] hover:bg-[var(--hud-accent-hover)] tracking-wide"
+        >
+          + NEW PROJECT
+        </Link>
       </div>
 
       {loading ? (
@@ -43,42 +54,52 @@ export default function ProjectsIndex() {
           title="No projects"
           description="Create your first project to begin managing datasets and training runs."
         >
-          <Button as-child="true">
-            {/* @ts-expect-error allow as-child semantics via attribute only */}
-            <Link to="/projects/create">+ New Project</Link>
-          </Button>
+          <Link
+            to="/projects/create"
+            className="inline-flex items-center h-8 px-3 text-xs font-mono font-medium bg-[var(--hud-accent)] text-[oklch(0.10_0.008_240)] hover:bg-[var(--hud-accent-hover)] tracking-wide"
+          >
+            + NEW PROJECT
+          </Link>
         </EmptyState>
       ) : (
-        <div className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-3 bg-[var(--hud-border-default)]">
-          {projects.map((p) => (
-            <div
-              key={p.id}
-              className="bg-[var(--hud-surface)] p-4 flex flex-col gap-2 hover:bg-[var(--hud-elevated)] transition-colors group"
-            >
-              <div className="flex items-start justify-between gap-2">
-                <div className="text-[0.625rem] font-mono text-[var(--hud-text-muted)] tracking-widest uppercase">
-                  PROJECT
+        <>
+          <div className="grid grid-cols-1 gap-px sm:grid-cols-2 lg:grid-cols-3 bg-[var(--hud-border-default)]">
+            {projects.map((p) => (
+              <div
+                key={p.id}
+                className="bg-[var(--hud-surface)] p-4 flex flex-col gap-2 hover:bg-[var(--hud-elevated)] transition-colors group"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="text-[0.625rem] font-mono text-[var(--hud-text-muted)] tracking-widest uppercase">
+                    PROJECT
+                  </div>
+                  {p.task_type && (
+                    <span className="text-[0.625rem] font-mono text-[var(--hud-accent)] border border-[var(--hud-border-default)] px-1.5 py-0.5 tracking-widest uppercase">
+                      {p.task_type}
+                    </span>
+                  )}
+                </div>
+                <div className="font-semibold text-sm text-[var(--hud-text-primary)] tracking-wide">
+                  {p.name}
+                </div>
+                {p.description && (
+                  <p className="text-xs text-[var(--hud-text-muted)] leading-relaxed line-clamp-2">
+                    {p.description}
+                  </p>
+                )}
+                <div className="mt-auto pt-2 border-t border-[var(--hud-border-subtle)]">
+                  <Link
+                    to={`/projects/${p.id}`}
+                    className="text-xs font-mono text-[var(--hud-accent)] hover:text-[var(--hud-accent-hover)] tracking-wide transition-colors"
+                  >
+                    OPEN DASHBOARD →
+                  </Link>
                 </div>
               </div>
-              <div className="font-semibold text-sm text-[var(--hud-text-primary)] tracking-wide">
-                {p.name}
-              </div>
-              {p.description && (
-                <p className="text-xs text-[var(--hud-text-muted)] leading-relaxed line-clamp-2">
-                  {p.description}
-                </p>
-              )}
-              <div className="mt-auto pt-2 border-t border-[var(--hud-border-subtle)]">
-                <Link
-                  to={`/projects/${p.id}`}
-                  className="text-xs font-mono text-[var(--hud-accent)] hover:text-[var(--hud-accent-hover)] tracking-wide transition-colors"
-                >
-                  OPEN DASHBOARD →
-                </Link>
-              </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+          <Pager page={page} pageSize={PAGE_SIZE} total={total} onChange={setPage} />
+        </>
       )}
     </div>
   );

--- a/specs/phases-roadmap.md
+++ b/specs/phases-roadmap.md
@@ -1,0 +1,134 @@
+# VisionForge — Post-Foundation Phases Roadmap
+
+**Date:** 2026-05-09
+**Branch:** `claude/visionforge-phases-review-M94dh`
+**Context:** PR #9 (cluster management) and PR #10 ("Phase 1 — annotator, evaluation, inference, datumaro, bcrypt-only") are merged into `main`. This document tracks the remaining gaps between the comprehensive product plan and the current implementation, grouped into phases. Naming continues from the user's PR #10 ("Phase 1") — so this doc covers Phases 2 → 5.
+
+---
+
+## Audit Summary (against the comprehensive product plan)
+
+| # | Capability | Status | Notes |
+|---|---|---|---|
+| 1 | Teams / workspaces / RBAC | ✅ | `models/workspace.py`, `api/rbac.py` |
+| 2 | Project + task wizard | ⚠️ | only a simple create-form — no multi-step flow |
+| 3 | Dataset import (Datumaro) | ✅ | COCO/YOLO native + Datumaro fallback |
+| 4 | Annotation pipeline | ✅ | bbox/polygon/keypoint/classify, undo/redo, hotkeys, optimistic lock |
+| 5 | Annotation quality control | ❌ | no review queues, no consensus, no error mining |
+| 6 | Dataset versioning | ✅ | snapshots, lock, version list |
+| 7 | Evaluation | ✅ | first-class job, confusion matrix, FP/FN viewer |
+| 8 | Active learning | ✅ | uncertainty + diverse coreset |
+| 9 | Model training | ✅ | per-cluster routing, full hyperparams + augmentation |
+| 10 | Model artifacts | ⚠️ | no `.pt` download endpoint, no real lineage view |
+| 11 | Inference | ✅ | LRU cache, `/predict`, bbox overlay UI |
+| 12 | Compute clusters | ✅ | NVIDIA + ROCm + CPU, train/eval routing, telemetry, picker |
+| 13 | Observability | ✅ | Prometheus + structlog + request_id; Grafana provisioning present |
+| 14 | Auth / security | ✅ | bcrypt + JWT + rate limiting; MFA/SSO deferred per spec |
+| 15 | Frame extraction | ✅ | Celery task + presigned-URL frames; **UI trigger not surfaced** |
+| 16 | Plugin / extensibility | ❌ | no registry for trainers / task types |
+
+**Cluster requirements** (CPU/RAM/disk/GPU telemetry, NVIDIA+ROCm vendor support, train+eval selection, agent heartbeat) are 5.5/6 met. The single gap is the **ONNX export form has no cluster picker UI** (the backend already accepts `clusterId`).
+
+---
+
+## Phase 2 — Annotation & Dataset Polish
+
+Focus: close gaps in the data-entry path that block labelling teams.
+
+1. **Multi-step project / task wizard**
+   - New `/projects/new` flow: task type (detect/classify) → class definition → default dataset settings → import option (skip / upload / Datumaro).
+   - Persist `task_type` on the `Project` *and* on `Dataset` (`Dataset.task_type` column + Alembic migration) so training can validate dataset-task compatibility.
+2. **Annotator bulk-save** *(carried over from PR #10 caveats)*
+   - Replace per-annotation `PUT` with a single `POST /api/annotations/bulk` that accepts an array of {id, version, payload} and returns per-row 200 / 409.
+3. **Pre-populate classes from `ClassMap`**
+   - On annotator load, `GET /api/datasets/{id}` and seed the class sidebar instead of starting from `["object"]`.
+4. **Annotation quality control (MVP)**
+   - `Annotation.review_status` enum (`unreviewed | approved | rejected`) + reviewer assignment.
+   - `/datasets/{id}/review` queue page: filter by status, approve / reject / send back, with diff vs. previous version.
+   - Optional consensus mode: assign N annotators to the same asset, surface disagreement.
+   - Error mining: nightly Celery task that runs the latest model over labelled assets and flags annotations whose IoU vs. prediction is below a threshold.
+5. **Pagination on list pages** (datasets, experiments, artifacts, evaluations, AL runs)
+   - Server-side `?page=&page_size=` + `X-Total-Count`; frontend pager component.
+
+**Exit criteria:** a new team can land on the home page, click "New Project", and reach a labelled, reviewed dataset version without ever needing to construct a URL by hand.
+
+---
+
+## Phase 3 — Model Lifecycle Polish
+
+Focus: make trained models discoverable, downloadable, and traceable.
+
+1. **`.pt` model download**
+   - `GET /api/artifacts/models/{id}/download` → presigned MinIO GET URL (or streaming `FileResponse` for small artifacts).
+   - DOWNLOAD button on `/artifacts` row (next to PREDICT / EXPORT ONNX).
+2. **Real lineage view** (replaces the duplicate LINEAGE button)
+   - `/artifacts/{id}/lineage` page: training run → dataset version → parent class map → evaluations using this artifact, all with deep links.
+3. **ONNX export form: cluster picker**
+   - Add `<ClusterSelect kind="train">` to `frontend/src/pages/artifacts/export.tsx`; pass `clusterId` in the POST body.
+4. **System status panel wired to reality**
+   - Replace the hardcoded `● ONLINE` badges with calls to `/health` and a Celery-inspect endpoint.
+5. **Frame extraction UI**
+   - Surface the existing backend task in the dataset upload page — "this is a video, extract frames at N fps" toggle.
+6. **Detection mAP@[.5:.95]** *(carried over from PR #10 caveats)*
+   - Extend `EvaluationService` to compute mAP averaged across IoU thresholds in 0.05 steps, stored alongside the existing single-IoU number.
+
+**Exit criteria:** a developer can trace any deployed model back to the exact dataset version + run + evaluation, download the weights, and re-run an evaluation against new data.
+
+---
+
+## Phase 4 — Production Inference & Scale
+
+Focus: scale beyond a single backend container and start treating inference as a real product surface.
+
+1. **Triton serving front-end** *(carried over from PR #10 caveats)*
+   - Optional `INFERENCE_BACKEND=triton` mode where `/predict` proxies to a Triton container. Auto-generate Triton model repo layout from a `ModelArtifact` (config.pbtxt + ONNX engine).
+   - Cluster table grows a `kind=infer` option and an `inference_url` column.
+2. **Plugin registry**
+   - `app/plugins/registry.py` exposing `register_trainer(name, fn)` and `register_task_type(name, schema)`. Document a contributed-plugin example (e.g. a Timm-based trainer). Used by training service to look up the trainer.
+3. **API pagination + search** (filters on all list endpoints, server-side ordering, full-text search where pgvector/`pg_trgm` makes sense).
+4. **Better active-learning uncertainty**
+   - When a `ModelArtifact` exists for the project, score AL candidates by real per-asset entropy / margin instead of the random bootstrap. Random remains the default for cold-start projects.
+5. **Annotation history diff UI**
+   - Render the JSON diff between annotation versions (we already store `history`).
+
+**Exit criteria:** a user can stand up an inference cluster, point projects at it, and serve predictions independently of the API container. Plugin authors can ship a new trainer without touching core code.
+
+---
+
+## Phase 5 — Production Hardening
+
+Focus: things that block a real prod deployment.
+
+1. **MFA + SSO** (deferred from the original plan)
+   - OIDC (Google) and SAML (Okta). Auth architecture stays provider-agnostic.
+2. **Kubernetes / Helm chart**
+   - Replace docker-compose for prod. Per-cluster agent install moves to a Helm sub-chart; ConfigMap-driven cluster registration.
+3. **CI/CD via GitHub Actions**
+   - PR pipeline: lint → unit → integration (services in containers) → contract → Playwright visual.
+   - Release pipeline: build & sign images, push to GHCR, Helm chart release.
+4. **Production frontend build**
+   - Replace Vite dev server in `docker-compose` with an nginx stage serving the `vite build` output.
+5. **Hardening pass**
+   - Parameterise CORS origins per env (already partly done — verify).
+   - Access-token refresh logic in `auth-store.tsx`.
+   - Secrets via Vault / K8s secrets, not env files.
+   - Pen-test pass on auth + upload paths; OWASP top-10 review.
+6. **Operations**
+   - Backup / restore runbooks for Postgres + MinIO.
+   - Grafana alert rules (error rate, queue depth, cluster heartbeat staleness).
+   - One-command agent install script: `curl ... | bash` → `docker run` with token.
+
+**Exit criteria:** a customer can deploy VisionForge into their own cloud account from a Helm chart, with CI gates, automated backups, alerting, SSO, and a documented agent install path.
+
+---
+
+## Quick wins to sequence first
+
+If we want a tight first PR after this audit, these are the cheapest wins from Phase 2 + Phase 3:
+
+1. ONNX export cluster picker (frontend-only; backend already supports it).
+2. Pre-populate annotator classes from `ClassMap` (one fetch + state seed).
+3. `/api/artifacts/models/{id}/download` endpoint + DOWNLOAD button.
+4. System status panel wired to `/health`.
+
+Each is < ~50 lines and ships a visible improvement.


### PR DESCRIPTION
Captures the audit of the current implementation against the
comprehensive product plan (cluster requirements, annotation pipeline,
model lifecycle, observability, etc.) and groups remaining gaps into
Phases 2 through 5. Persists the plan to disk so it survives across
Claude sessions.

https://claude.ai/code/session_01WG3JsYvy1qRNxe76i9c5sk