### PR TITLE
docs: document compute clusters feature in CLAUDE.md and README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,16 +240,18 @@ Migrations live in `backend/src/app/db/migrations/versions/`. On app startup, `m
 ```
 User ──< Membership >── Workspace ──< Project ──< Dataset ──< DatasetVersion
                                                           └──< ClassMap
-Project ──< ExperimentRun
+Project ──< ExperimentRun ──> Cluster
          ──< ModelArtifact
 Dataset ──< Asset ──< Annotation
 Project ──< ALRun ──< ALItem
+Cluster (standalone — worker / agent telemetry)
 ```
 
 - All PKs are UUIDs.
 - Workspace membership uses a `Role` enum: `viewer | annotator | developer | admin | owner`.
 - `Asset.label_status` tracks annotation progress.
-- `ExperimentRun` stores `params` and `metrics` as JSON columns.
+- `ExperimentRun` stores `params` and `metrics` as JSON columns and an optional `cluster_id` FK recording which cluster ran the job.
+- `Cluster` rows store static capacity (CPU / RAM / disk / GPU), live telemetry, a `kind` (`train | eval | both`), GPU `vendor` (`nvidia | rocm | cpu`), a `status` (`online | offline | busy | error`), an `enabled` flag, and a `register_token` used by the agent to authenticate heartbeats.
 - Vector embeddings use pgvector (`pgvector` extension auto-registered in `session.py`).
 
 ---
@@ -257,7 +259,7 @@ Project ──< ALRun ──< ALItem
 ## API Structure
 
 - All routes are prefixed with `/api/` except auth (`/auth/`) and health (`/health`, `/metrics`).
-- Router files: `api/auth.py`, `api/projects.py`, `api/datasets.py`, `api/experiments.py`, `api/artifacts.py`, `api/jobs.py`, `api/al.py`, `api/ops.py`, `api/rbac.py`.
+- Router files: `api/auth.py`, `api/projects.py`, `api/datasets.py`, `api/experiments.py`, `api/artifacts.py`, `api/jobs.py`, `api/al.py`, `api/ops.py`, `api/rbac.py`, `api/clusters.py`.
 - CORS is configured for `localhost:5173` and `127.0.0.1:5173` (update for production).
 
 ---
@@ -268,7 +270,34 @@ Long-running operations (training, embedding generation, frame extraction, ONNX 
 
 - Broker: Redis (`REDIS_URL` env var)
 - Serialization: JSON
-- Queue: `default`
+- Default queue: `default`
+- Per-cluster queues: when a job is launched against a specific cluster, the task is routed to a dedicated queue named `cluster.{cluster_id}` so only that cluster's agent picks it up.
+
+---
+
+## Compute Clusters
+
+VisionForge supports first-class **compute clusters** (worker nodes / agents) for routing training and evaluation jobs. Each cluster reports live resource telemetry via heartbeat so users can pick an idle, capable cluster when launching a job.
+
+### Backend
+
+- **Model**: `models/cluster.py` — `Cluster` table holds static capacity (CPU cores, RAM, disk, GPU vendor / count / model / memory), live telemetry (CPU/RAM/disk/GPU usage, per-GPU JSON breakdown), `kind` (`train | eval | both`), `status` (`online | offline | busy | error`), `enabled`, `active_job_id`, `register_token`, and `last_heartbeat_at`.
+- **Schemas**: `schemas/cluster.py` — `ClusterCreate`, `ClusterUpdate`, `ClusterHeartbeat`, `Cluster`, `ClusterRegistration` (includes the `register_token`, returned only on creation), `ClusterSummary`, `ClusterHeartbeatAck`, plus `GpuInfo` for per-GPU telemetry.
+- **Service**: `services/cluster_service.py` — handles CRUD, heartbeat ingestion with token auth, `is_available()` filtering (enabled + online + idle + fresh heartbeat + matches workload `kind`), `reserve_cluster()` / `release_cluster()`, and stale-heartbeat auto-degrade (`HEARTBEAT_TIMEOUT = 90s`).
+- **Router**: `api/clusters.py` mounted at `/api/clusters`. The `POST /api/clusters/{id}/heartbeat` endpoint is **unauthenticated** (no user dependency) — the agent authenticates by including the cluster's `register_token` in the body.
+- **Integration**: `services/training_service.py` and `services/onnx_service.py` accept an optional `cluster_id`. On launch they call `cluster_service.reserve_cluster()` (raising `ClusterNotAvailableError` → HTTP 409 if unavailable), persist `experiment_runs.cluster_id`, and route the Celery task to the `cluster.{cluster_id}` queue. `services/jobs_service.py` calls `release_cluster()` on terminal job status.
+- **Migration**: `db/migrations/versions/0003_clusters.py` creates the `clusters` table and adds `experiment_runs.cluster_id` FK.
+
+### Frontend
+
+- **Pages**: `pages/clusters/index.tsx` (live grid polled every 5s with CPU/RAM/disk/GPU bars, vendor badges, heartbeat freshness) and `pages/clusters/new.tsx` (registration form that surfaces the agent install command and `register_token` exactly once).
+- **Component**: `components/common/ClusterSelect.tsx` is the reusable selector grouped by Available / Unavailable, used by the training and ONNX export wizards.
+- **Route**: `/clusters` and `/clusters/new`, with an `AppShell` nav entry "CLUSTERS".
+- **API contract**: training (`/api/train`) and ONNX export (`/api/export/onnx`) accept an optional `clusterId` field; both return `409` if the chosen cluster is no longer available.
+
+### Cluster Agent
+
+The agent is an unattended daemon that runs on a worker machine. After registering a cluster in the UI, install the agent on the worker using the Docker command shown on the "Cluster registered" page — it embeds the cluster ID and `register_token` as env vars. The agent then POSTs telemetry to `/api/clusters/{id}/heartbeat` periodically (default expected cadence < 90s to stay "online").
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,11 @@ VisionForge is a full-stack computer vision platform for managing datasets, anno
 
 ```
 VisionForge/
+├── agent/                       # Cluster agent (runs on worker machines)
+│   ├── src/vf_agent/            # discover, server, heartbeat, identity, main
+│   ├── tests/                   # pytest agent/tests/
+│   ├── requirements.txt         # agent-only deps (psutil, pynvml, ...)
+│   └── Dockerfile               # builds visionforge/agent:latest
 ├── backend/
 │   ├── src/app/
 │   │   ├── main.py              # FastAPI app init, middleware, startup
@@ -81,6 +86,7 @@ VisionForge/
 ├── specs/                       # Feature specification docs
 ├── scripts/lint_all.sh          # Run all linters
 ├── docker-compose.yml
+├── compose.agent.yml            # Optional dev overlay: run the agent locally
 └── .env.example
 ```
 
@@ -277,27 +283,47 @@ Long-running operations (training, embedding generation, frame extraction, ONNX 
 
 ## Compute Clusters
 
-VisionForge supports first-class **compute clusters** (worker nodes / agents) for routing training and evaluation jobs. Each cluster reports live resource telemetry via heartbeat so users can pick an idle, capable cluster when launching a job.
+VisionForge supports first-class **compute clusters** (worker nodes / agents) for routing training, evaluation, and ONNX export jobs. Registration is **discovery-based**: the operator installs the agent on the worker, then the backend probes the agent's HTTP info endpoint to auto-populate hardware specs.
+
+### Lifecycle
+
+1. Operator runs `docker run -e VF_AGENT_TOKEN=<random> -p 9443:9443 visionforge/agent:latest` on the worker.
+2. Operator opens `/clusters/new`, enters **name + host + port + kind**, and submits. The agent token is generated client-side and embedded in the Step 1 command, so the operator never types it twice.
+3. Backend calls `GET http(s)://{host}:{port}/info` on the agent with the bearer token, validates the response, and creates a `Cluster` row populated from it.
+4. Backend then calls `POST /adopt` on the agent with `{cluster_id, register_token, api_url}`. The agent persists those to `/var/lib/vf-agent/identity.json` and starts a Celery worker bound to `cluster.{cluster_id}` plus a heartbeat loop.
+5. The agent's heartbeats keep `status` fresh; the platform routes any job with `clusterId` to the dedicated queue and the agent picks it up.
 
 ### Backend
 
-- **Model**: `models/cluster.py` — `Cluster` table holds static capacity (CPU cores, RAM, disk, GPU vendor / count / model / memory), live telemetry (CPU/RAM/disk/GPU usage, per-GPU JSON breakdown), `kind` (`train | eval | both`), `status` (`online | offline | busy | error`), `enabled`, `active_job_id`, `register_token`, and `last_heartbeat_at`.
-- **Schemas**: `schemas/cluster.py` — `ClusterCreate`, `ClusterUpdate`, `ClusterHeartbeat`, `Cluster`, `ClusterRegistration` (includes the `register_token`, returned only on creation), `ClusterSummary`, `ClusterHeartbeatAck`, plus `GpuInfo` for per-GPU telemetry.
-- **Service**: `services/cluster_service.py` — handles CRUD, heartbeat ingestion with token auth, `is_available()` filtering (enabled + online + idle + fresh heartbeat + matches workload `kind`), `reserve_cluster()` / `release_cluster()`, and stale-heartbeat auto-degrade (`HEARTBEAT_TIMEOUT = 90s`).
-- **Router**: `api/clusters.py` mounted at `/api/clusters`. The `POST /api/clusters/{id}/heartbeat` endpoint is **unauthenticated** (no user dependency) — the agent authenticates by including the cluster's `register_token` in the body.
-- **Integration**: `services/training_service.py` and `services/onnx_service.py` accept an optional `cluster_id`. On launch they call `cluster_service.reserve_cluster()` (raising `ClusterNotAvailableError` → HTTP 409 if unavailable), persist `experiment_runs.cluster_id`, and route the Celery task to the `cluster.{cluster_id}` queue. `services/jobs_service.py` calls `release_cluster()` on terminal job status.
-- **Migration**: `db/migrations/versions/0003_clusters.py` creates the `clusters` table and adds `experiment_runs.cluster_id` FK.
+- **Model**: `models/cluster.py` — `Cluster` holds static capacity (CPU / RAM / disk / GPU vendor / count / model / memory), live telemetry (CPU/RAM/disk/GPU usage + per-GPU JSON), `kind` (`train | eval | both`), `status` (`online | offline | busy | error`), `enabled`, `active_job_id`, `register_token`, `last_heartbeat_at`, **plus** `agent_host`, `agent_port`, `agent_version`, `os_name`, `os_release`, `arch`.
+- **Schemas**: `schemas/cluster.py` — `ClusterDiscoverRequest` (the operator payload), `AgentInfo` (the agent's `/info` response shape), `ClusterHeartbeat`, `Cluster`, `ClusterRegistration` (includes `register_token`, returned only on creation/rotate), `ClusterSummary`, `ClusterHeartbeatAck`, `GpuInfo`.
+- **Service**: `services/cluster_service.py` — `discover_cluster()` probes `/info` and `/adopt` via `httpx`, `record_heartbeat()` authenticates by `register_token`, `is_available()` filters (enabled + online + idle + fresh heartbeat + matches `kind`), `reserve_cluster()` / `release_cluster()`, `rotate_register_token()`, and stale-heartbeat auto-degrade (`HEARTBEAT_TIMEOUT = 90s`). `AgentUnreachableError(reason=connect|timeout|auth|bad_response)` is mapped to HTTP 502 with `[reason=...]` appended to the detail string.
+- **Router**: `api/clusters.py` mounted at `/api/clusters`. The heartbeat endpoint is **unauthenticated** (agent runs unattended; auth is via `register_token` in the body). The discover endpoint reads `VF_PLATFORM_PUBLIC_URL` (or falls back to `request.base_url`) and passes that to the agent's `/adopt` call so the agent knows where to heartbeat.
+- **Integration**: `services/training_service.py`, `services/evaluation_service.py`, and `services/onnx_service.py` accept an optional `cluster_id`. They call `reserve_cluster()` (raising `ClusterNotAvailableError` → HTTP 409 if unavailable), persist `experiment_runs.cluster_id`, and route the Celery task to `cluster.{cluster_id}`. `services/jobs_service.py` calls `release_cluster()` on terminal job status.
+- **Migrations**: `0003_clusters.py` creates the table; `0004_cluster_discovery.py` adds the agent/OS columns.
 
 ### Frontend
 
-- **Pages**: `pages/clusters/index.tsx` (live grid polled every 5s with CPU/RAM/disk/GPU bars, vendor badges, heartbeat freshness) and `pages/clusters/new.tsx` (registration form that surfaces the agent install command and `register_token` exactly once).
-- **Component**: `components/common/ClusterSelect.tsx` is the reusable selector grouped by Available / Unavailable, used by the training and ONNX export wizards.
+- **Pages**: `pages/clusters/index.tsx` (live grid polled every 5s with CPU/RAM/disk/GPU bars, vendor badges, heartbeat freshness, OS line, and agent endpoint footer) and `pages/clusters/new.tsx` (two-step wizard: Step 1 shows the `docker run` install command with a client-generated `VF_AGENT_TOKEN`; Step 2 takes name + host + port + kind and submits `POST /api/clusters/discover`).
+- **Component**: `components/common/ClusterSelect.tsx` — selector grouped by Available / Unavailable, used by training and ONNX export wizards.
 - **Route**: `/clusters` and `/clusters/new`, with an `AppShell` nav entry "CLUSTERS".
-- **API contract**: training (`/api/train`) and ONNX export (`/api/export/onnx`) accept an optional `clusterId` field; both return `409` if the chosen cluster is no longer available.
+- **API contract**: training (`/api/train`), evaluation (`/api/evaluations`), and ONNX export (`/api/export/onnx`) accept an optional `clusterId`; all return `409` if the chosen cluster is no longer available.
 
-### Cluster Agent
+### Agent Runtime
 
-The agent is an unattended daemon that runs on a worker machine. After registering a cluster in the UI, install the agent on the worker using the Docker command shown on the "Cluster registered" page — it embeds the cluster ID and `register_token` as env vars. The agent then POSTs telemetry to `/api/clusters/{id}/heartbeat` periodically (default expected cadence < 90s to stay "online").
+The agent lives in `agent/` and is built from `agent/Dockerfile`. It is a single image bundling the backend's `app.jobs.tasks.*` (so it can run training / evaluation / ONNX export jobs) plus the agent-only modules under `agent/src/vf_agent/`:
+
+- `discover.py` — hardware + OS probe via `psutil`, `pynvml` (NVIDIA), and `rocm-smi` (AMD).
+- `server.py` — FastAPI HTTP server exposing `GET /health` (unauth), `GET /info`, `GET /telemetry`, `POST /adopt` (all bearer-auth via `VF_AGENT_TOKEN`).
+- `heartbeat.py` — pushes telemetry to `/api/clusters/{id}/heartbeat` every `VF_AGENT_HEARTBEAT_INTERVAL` seconds.
+- `identity.py` — persists `{cluster_id, register_token, api_url}` to `/var/lib/vf-agent/identity.json` after adoption.
+- `main.py` — supervisor that starts the HTTP server, blocks until adoption, then spawns the heartbeat process and Celery worker bound to `cluster.{cluster_id}`.
+
+Two tokens are in play:
+- `VF_AGENT_TOKEN` — operator-supplied secret set at `docker run` time. Authenticates the platform → agent direction (calls to `/info`, `/telemetry`, `/adopt`).
+- `register_token` — platform-issued on cluster creation. Authenticates the agent → platform direction (heartbeats). Rotatable via `POST /api/clusters/{id}/rotate-token`.
+
+Tests for the agent live in `agent/tests/` (`pytest agent/tests/`) and use `httpx.MockTransport` to stay hermetic.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -234,38 +234,73 @@ Full interactive documentation is available at [`/docs`](http://localhost:8000/d
 
 ## Compute Clusters
 
-VisionForge can dispatch training and ONNX export jobs to **registered compute clusters** (external worker nodes / agents) rather than running everything on the API host. The `/clusters` page shows a live grid of registered clusters with per-cluster CPU, RAM, disk and GPU telemetry, and the new-training / new-export wizards include a cluster picker grouped by Available / Unavailable.
+VisionForge can dispatch training, evaluation, and ONNX export jobs to **registered compute clusters** (external worker nodes) rather than running everything on the API host. The `/clusters` page shows a live grid with per-cluster CPU, RAM, disk and GPU telemetry, OS info, and agent version. The training, evaluation, and ONNX export wizards include a cluster picker grouped by Available / Unavailable.
 
-### Lifecycle
+Registration is **discovery-based**: you install a `vf-agent` Docker container on the worker, and the platform reaches out to it to auto-detect hardware. No manual spec entry.
 
-1. **Register the cluster** in the UI at **`/clusters/new`** (or `POST /api/clusters`). You'll provide a name, workload `kind` (`train`, `eval`, or `both`), declared capacity (CPU cores, RAM, disk), and GPU info (vendor: `nvidia` / `rocm` / `cpu`, count, model, memory).
-2. **Save the register token**. On creation the API returns a `register_token` exactly once. The UI also generates a ready-to-run `docker run` command for the agent that embeds the token. Treat the token as a secret — it authenticates all heartbeats from the agent.
-3. **Run the agent** on the worker machine. The agent posts telemetry to `POST /api/clusters/{id}/heartbeat` (unauthenticated; the agent supplies the `register_token` in the body). A cluster is treated as **online** when its last heartbeat is within `90s`, otherwise it auto-degrades to `offline`.
-4. **Launch jobs against the cluster**. Both `/api/train` and `/api/export/onnx` accept an optional `clusterId`. If supplied, the cluster is reserved (status flips to `busy`) and the Celery task is routed to a dedicated queue `cluster.{cluster_id}` so only that cluster's agent picks it up. The cluster is released automatically when the job reaches a terminal status.
+### Step 1 · Install the agent on the worker
+
+Run this on the worker machine. The UI at **`/clusters/new`** generates the exact command for you (with a freshly-randomised token), but the shape is:
+
+```bash
+docker run -d --name vf-agent \
+  --restart unless-stopped \
+  --gpus all \
+  -p 9443:9443 \
+  -v vf-agent-state:/var/lib/vf-agent \
+  -e VF_AGENT_TOKEN=<random-secret> \
+  -e REDIS_URL=redis://<platform-host>:6379/0 \
+  visionforge/agent:latest
+```
+
+The agent exposes:
+
+| Endpoint | Auth | Purpose |
+|---|---|---|
+| `GET /health` | none | Liveness check |
+| `GET /info` | `Bearer $VF_AGENT_TOKEN` | Full hardware + OS snapshot used by discovery |
+| `GET /telemetry` | `Bearer $VF_AGENT_TOKEN` | Live CPU/RAM/disk/GPU usage |
+| `POST /adopt` | `Bearer $VF_AGENT_TOKEN` | Called once by the platform to assign `cluster_id` + `register_token` |
+
+Until adoption, the agent does **not** start its Celery worker — it cannot pick up jobs.
+
+### Step 2 · Register the cluster from the UI
+
+At `/clusters/new`, enter:
+
+- **Name** — display label.
+- **Host** — IP or hostname reachable from the platform.
+- **Port** — `9443` by default.
+- **Workload kind** — `train`, `eval`, or `both`.
+
+The agent token from Step 1 is pre-filled. On submit, the backend calls `GET /info` on the agent, creates the `Cluster` row populated from the response, then calls `POST /adopt` so the agent knows its `cluster_id`. The agent immediately starts a Celery worker subscribed to `cluster.{cluster_id}` and a heartbeat loop targeting the platform.
+
+If the agent is unreachable, the API returns **`502 Bad Gateway`** with `[reason=connect|timeout|auth|bad_response]` appended to the detail; the UI surfaces a matching hint (e.g. "agent rejected the token").
 
 ### Selection rules
 
-A cluster is **available** when all of the following hold:
+A cluster is **available** when:
 - `enabled = true`
 - `status = online`
 - No `active_job_id` set (i.e., it is idle)
 - Last heartbeat received within `90s`
 - `kind` matches the requested workload (`kind = "both"` matches any)
 
-If a selected cluster is no longer available at launch time (e.g., another user grabbed it), the API returns **`409 Conflict`** and the UI surfaces the error.
+If a selected cluster is no longer available at launch time, the relevant endpoint returns **`409 Conflict`**.
 
 ### API quick reference
 
 | Method | Path | Auth | Purpose |
 |---|---|---|---|
-| `GET` | `/api/clusters` | user | Full cluster list with telemetry |
+| `GET` | `/api/clusters` | user | Full cluster list with telemetry, OS, agent metadata |
 | `GET` | `/api/clusters/available?kind=train\|eval\|both` | user | Filtered list for the selector |
-| `POST` | `/api/clusters` | user | Register a new cluster (returns `register_token`) |
+| `POST` | `/api/clusters/discover` | user | Probe a running agent and register the cluster |
 | `GET` | `/api/clusters/{id}` | user | Single cluster detail |
 | `PATCH` | `/api/clusters/{id}` | user | Update name / description / kind / enabled |
 | `DELETE` | `/api/clusters/{id}` | user | Remove a cluster |
-| `POST` | `/api/clusters/{id}/heartbeat` | **agent token** | Push telemetry (called by the agent) |
+| `POST` | `/api/clusters/{id}/heartbeat` | **register_token** | Push telemetry (called by the agent) |
 | `POST` | `/api/clusters/{id}/release` | user | Manually release a stuck reservation |
+| `POST` | `/api/clusters/{id}/rotate-token` | user | Issue a new `register_token`; old one is invalidated |
 
 ### GPU vendors
 
@@ -274,6 +309,25 @@ If a selected cluster is no longer available at launch time (e.g., another user 
 | `nvidia` | CUDA / `nvidia-smi` — recommended for YOLO training |
 | `rocm` | AMD ROCm |
 | `cpu` | No GPU — training will run on CPU and is significantly slower |
+
+### Local development
+
+To run the agent on the same Docker network as the platform for testing:
+
+```bash
+VF_AGENT_TOKEN=dev-agent-token \
+  docker compose -f docker-compose.yml -f compose.agent.yml up -d agent
+```
+
+Then at `/clusters/new` use host `agent`, port `9443`, token `dev-agent-token`.
+
+### Security
+
+The agent's HTTP API is plain HTTP by default; deploy agents on a **private network or VPN**. The `scheme=https` option in the discover request is supported but you are responsible for terminating TLS in front of the agent.
+
+Two tokens are involved:
+- **`VF_AGENT_TOKEN`** — operator-supplied; the platform uses it to talk to the agent (`/info`, `/telemetry`, `/adopt`).
+- **`register_token`** — platform-issued at discovery time; the agent uses it to heartbeat. Rotatable via `POST /api/clusters/{id}/rotate-token`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ VisionForge centralises dataset management, collaborative annotation, model trai
 - [Configuration](#configuration)
 - [Service Endpoints](#service-endpoints)
 - [API Overview](#api-overview)
+- [Compute Clusters](#compute-clusters)
 - [Running Tests](#running-tests)
 - [Linting & Formatting](#linting--formatting)
 - [Database Migrations](#database-migrations)
@@ -33,8 +34,9 @@ VisionForge centralises dataset management, collaborative annotation, model trai
 | **Training** | YOLO model training via Ultralytics, configurable hyperparameters, experiment tracking |
 | **Active Learning** | Uncertainty sampling, high-value sample selection, automated retrain loops |
 | **Model Registry** | Versioned artifacts, staging/production promotion, ONNX export with validation |
+| **Compute Clusters** | Register external worker nodes, live CPU/RAM/disk/GPU telemetry (NVIDIA / AMD ROCm / CPU), pick an idle cluster when launching training or ONNX export |
 | **RBAC** | Workspace-level roles: `viewer`, `annotator`, `developer`, `admin`, `owner` |
-| **Async Jobs** | Celery-backed task queue; frontend polls job status with live progress |
+| **Async Jobs** | Celery-backed task queue with per-cluster routing; frontend polls job status with live progress |
 | **Observability** | Prometheus metrics, Grafana dashboards, structured JSON logs with request IDs |
 | **API-first** | Full REST API under `/api/`; automatable end-to-end via HTTP |
 
@@ -224,8 +226,54 @@ All application routes are prefixed with `/api/`. Authentication routes are unde
 | `/api/al/` | Active learning runs and items |
 | `/api/rbac/` | Role management |
 | `/api/ops/` | Admin / ops utilities |
+| `/api/clusters/` | Compute cluster registration, live telemetry, heartbeat (agent-facing), availability selector |
 
 Full interactive documentation is available at [`/docs`](http://localhost:8000/docs) when the server is running.
+
+---
+
+## Compute Clusters
+
+VisionForge can dispatch training and ONNX export jobs to **registered compute clusters** (external worker nodes / agents) rather than running everything on the API host. The `/clusters` page shows a live grid of registered clusters with per-cluster CPU, RAM, disk and GPU telemetry, and the new-training / new-export wizards include a cluster picker grouped by Available / Unavailable.
+
+### Lifecycle
+
+1. **Register the cluster** in the UI at **`/clusters/new`** (or `POST /api/clusters`). You'll provide a name, workload `kind` (`train`, `eval`, or `both`), declared capacity (CPU cores, RAM, disk), and GPU info (vendor: `nvidia` / `rocm` / `cpu`, count, model, memory).
+2. **Save the register token**. On creation the API returns a `register_token` exactly once. The UI also generates a ready-to-run `docker run` command for the agent that embeds the token. Treat the token as a secret — it authenticates all heartbeats from the agent.
+3. **Run the agent** on the worker machine. The agent posts telemetry to `POST /api/clusters/{id}/heartbeat` (unauthenticated; the agent supplies the `register_token` in the body). A cluster is treated as **online** when its last heartbeat is within `90s`, otherwise it auto-degrades to `offline`.
+4. **Launch jobs against the cluster**. Both `/api/train` and `/api/export/onnx` accept an optional `clusterId`. If supplied, the cluster is reserved (status flips to `busy`) and the Celery task is routed to a dedicated queue `cluster.{cluster_id}` so only that cluster's agent picks it up. The cluster is released automatically when the job reaches a terminal status.
+
+### Selection rules
+
+A cluster is **available** when all of the following hold:
+- `enabled = true`
+- `status = online`
+- No `active_job_id` set (i.e., it is idle)
+- Last heartbeat received within `90s`
+- `kind` matches the requested workload (`kind = "both"` matches any)
+
+If a selected cluster is no longer available at launch time (e.g., another user grabbed it), the API returns **`409 Conflict`** and the UI surfaces the error.
+
+### API quick reference
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `GET` | `/api/clusters` | user | Full cluster list with telemetry |
+| `GET` | `/api/clusters/available?kind=train\|eval\|both` | user | Filtered list for the selector |
+| `POST` | `/api/clusters` | user | Register a new cluster (returns `register_token`) |
+| `GET` | `/api/clusters/{id}` | user | Single cluster detail |
+| `PATCH` | `/api/clusters/{id}` | user | Update name / description / kind / enabled |
+| `DELETE` | `/api/clusters/{id}` | user | Remove a cluster |
+| `POST` | `/api/clusters/{id}/heartbeat` | **agent token** | Push telemetry (called by the agent) |
+| `POST` | `/api/clusters/{id}/release` | user | Manually release a stuck reservation |
+
+### GPU vendors
+
+| Vendor | Toolchain |
+|---|---|
+| `nvidia` | CUDA / `nvidia-smi` — recommended for YOLO training |
+| `rocm` | AMD ROCm |
+| `cpu` | No GPU — training will run on CPU and is significantly slower |
 
 ---
 

--- a/agent/.dockerignore
+++ b/agent/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.venv/
+node_modules/
+*.egg-info/

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app/src:/agent/src
+
+WORKDIR /app
+
+# Install backend deps (Celery tasks + ML libs are imported by the worker).
+COPY backend/requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /app/requirements.txt
+
+# Backend source supplies the Celery app + task modules executed by the worker.
+COPY backend /app
+
+# Install agent-only deps and copy agent source.
+COPY agent/requirements.txt /agent/requirements.txt
+RUN pip install --no-cache-dir -r /agent/requirements.txt
+COPY agent /agent
+
+# Agent state (identity.json) persists here; mount a volume in production.
+RUN mkdir -p /var/lib/vf-agent && chmod 700 /var/lib/vf-agent
+
+EXPOSE 9443
+
+ENTRYPOINT ["python", "-m", "vf_agent.main"]

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.2
+uvicorn[standard]==0.32.0
+httpx==0.27.2
+psutil==6.1.0
+pynvml==11.5.3
+pydantic==2.9.2

--- a/agent/src/vf_agent/__init__.py
+++ b/agent/src/vf_agent/__init__.py
@@ -1,0 +1,7 @@
+"""VisionForge cluster agent.
+
+Runs on a worker machine to expose hardware info via HTTP, push telemetry
+heartbeats to the platform, and execute Celery jobs routed to this cluster.
+"""
+
+__version__ = "0.1.0"

--- a/agent/src/vf_agent/discover.py
+++ b/agent/src/vf_agent/discover.py
@@ -1,0 +1,204 @@
+"""Hardware and OS discovery for the agent.
+
+Produces the JSON payload returned by `GET /info` and used by the backend's
+discovery endpoint to populate a Cluster row on registration.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+from typing import Any
+
+
+def _cpu_info() -> dict[str, Any]:
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        return {"cores": os.cpu_count() or 0, "usage_pct": 0.0}
+    return {
+        "cores": psutil.cpu_count(logical=True) or 0,
+        "usage_pct": float(psutil.cpu_percent(interval=0.2)),
+    }
+
+
+def _ram_info() -> dict[str, Any]:
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        return {"total_mb": 0, "used_mb": 0}
+    vm = psutil.virtual_memory()
+    return {"total_mb": int(vm.total // (1024 * 1024)), "used_mb": int(vm.used // (1024 * 1024))}
+
+
+def _disk_info() -> dict[str, Any]:
+    # Report the root filesystem; this is what training output / model artifacts land on.
+    path = os.getenv("VF_AGENT_DISK_PATH", "/")
+    try:
+        usage = shutil.disk_usage(path)
+    except OSError:
+        return {"total_gb": 0, "used_gb": 0, "path": path}
+    return {
+        "total_gb": int(usage.total // (1024**3)),
+        "used_gb": int(usage.used // (1024**3)),
+        "path": path,
+    }
+
+
+def _nvidia_gpus() -> list[dict[str, Any]] | None:
+    try:
+        import pynvml  # type: ignore
+    except ImportError:
+        return None
+    try:
+        pynvml.nvmlInit()
+    except Exception:
+        return None
+    try:
+        count = pynvml.nvmlDeviceGetCount()
+    except Exception:
+        return None
+    gpus: list[dict[str, Any]] = []
+    for i in range(count):
+        try:
+            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+            name = pynvml.nvmlDeviceGetName(handle)
+            if isinstance(name, bytes):
+                name = name.decode("utf-8", errors="replace")
+            mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            util = pynvml.nvmlDeviceGetUtilizationRates(handle)
+            try:
+                temp = float(pynvml.nvmlDeviceGetTemperature(handle, pynvml.NVML_TEMPERATURE_GPU))
+            except Exception:
+                temp = None
+            gpus.append(
+                {
+                    "index": i,
+                    "name": name,
+                    "memory_mb": int(mem.total // (1024 * 1024)),
+                    "mem_used_mb": int(mem.used // (1024 * 1024)),
+                    "util_pct": float(util.gpu),
+                    "temperature_c": temp,
+                }
+            )
+        except Exception:
+            continue
+    try:
+        pynvml.nvmlShutdown()
+    except Exception:
+        pass
+    return gpus
+
+
+def _rocm_gpus() -> list[dict[str, Any]] | None:
+    rocm_smi = shutil.which("rocm-smi")
+    if not rocm_smi:
+        return None
+    try:
+        out = subprocess.run(
+            [rocm_smi, "--showproductname", "--showmeminfo", "vram", "--showuse", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if out.returncode != 0 or not out.stdout.strip():
+        return None
+    try:
+        data = json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+    gpus: list[dict[str, Any]] = []
+    for key, value in data.items():
+        if not key.startswith("card"):
+            continue
+        try:
+            idx = int(key.replace("card", ""))
+        except ValueError:
+            continue
+        name = value.get("Card series") or value.get("Card model") or value.get("Card vendor")
+        total = _to_int(value.get("VRAM Total Memory (B)"))
+        used = _to_int(value.get("VRAM Total Used Memory (B)"))
+        gpus.append(
+            {
+                "index": idx,
+                "name": name,
+                "memory_mb": int(total // (1024 * 1024)) if total else 0,
+                "mem_used_mb": int(used // (1024 * 1024)) if used else 0,
+                "util_pct": _to_float(value.get("GPU use (%)")),
+                "temperature_c": _to_float(value.get("Temperature (Sensor edge) (C)")),
+            }
+        )
+    return gpus or None
+
+
+def _to_int(v: Any) -> int:
+    try:
+        return int(str(v))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _to_float(v: Any) -> float:
+    try:
+        return float(str(v).rstrip("%"))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def detect_gpus() -> tuple[str, list[dict[str, Any]]]:
+    """Return `(vendor, gpus[])` where vendor is one of nvidia | rocm | cpu."""
+    gpus = _nvidia_gpus()
+    if gpus:
+        return "nvidia", gpus
+    gpus = _rocm_gpus()
+    if gpus:
+        return "rocm", gpus
+    return "cpu", []
+
+
+def _os_info() -> dict[str, Any]:
+    return {
+        "name": platform.system(),
+        "release": platform.release(),
+        "version": platform.version(),
+        "arch": platform.machine(),
+        "python": platform.python_version(),
+    }
+
+
+def discover() -> dict[str, Any]:
+    """Return a full hardware + OS snapshot for the backend discover endpoint."""
+    vendor, gpus = detect_gpus()
+    cpu = _cpu_info()
+    ram = _ram_info()
+    disk = _disk_info()
+    return {
+        "cpu_cores": cpu["cores"],
+        "cpu_usage_pct": cpu["usage_pct"],
+        "ram_total_mb": ram["total_mb"],
+        "ram_used_mb": ram["used_mb"],
+        "disk_total_gb": disk["total_gb"],
+        "disk_used_gb": disk["used_gb"],
+        "disk_path": disk["path"],
+        "gpu_vendor": vendor,
+        "gpu_count": len(gpus),
+        "gpu_model": gpus[0]["name"] if gpus else None,
+        "gpu_memory_mb": gpus[0]["memory_mb"] if gpus else 0,
+        "gpu_usage_pct": (sum(g["util_pct"] for g in gpus) / len(gpus)) if gpus else 0.0,
+        "gpus": gpus,
+        "os": _os_info(),
+    }
+
+
+def main() -> None:
+    print(json.dumps(discover(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/src/vf_agent/heartbeat.py
+++ b/agent/src/vf_agent/heartbeat.py
@@ -1,0 +1,81 @@
+"""Heartbeat loop: pushes telemetry to the platform every N seconds."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+
+from vf_agent import discover, identity
+
+logger = logging.getLogger("vf_agent.heartbeat")
+
+HEARTBEAT_INTERVAL_S = int(os.getenv("VF_AGENT_HEARTBEAT_INTERVAL", "30"))
+HEARTBEAT_TIMEOUT_S = float(os.getenv("VF_AGENT_HEARTBEAT_TIMEOUT", "10"))
+
+
+def _payload(ident: identity.Identity) -> dict[str, Any]:
+    snap = discover.discover()
+    return {
+        "register_token": ident.register_token,
+        "status": "online",
+        "cpu_usage_pct": snap["cpu_usage_pct"],
+        "ram_used_mb": snap["ram_used_mb"],
+        "disk_used_gb": snap["disk_used_gb"],
+        "gpu_usage_pct": snap["gpu_usage_pct"],
+        "gpus": snap["gpus"],
+        "cpu_cores": snap["cpu_cores"],
+        "ram_total_mb": snap["ram_total_mb"],
+        "disk_total_gb": snap["disk_total_gb"],
+        "gpu_vendor": snap["gpu_vendor"],
+        "gpu_count": snap["gpu_count"],
+        "gpu_model": snap["gpu_model"],
+        "gpu_memory_mb": snap["gpu_memory_mb"],
+    }
+
+
+def send_once(ident: identity.Identity, *, client: httpx.Client | None = None) -> int:
+    """Send a single heartbeat. Returns HTTP status code (0 on transport error)."""
+    url = f"{ident.api_url}/api/clusters/{ident.cluster_id}/heartbeat"
+    own = client is None
+    c = client or httpx.Client(timeout=HEARTBEAT_TIMEOUT_S)
+    try:
+        resp = c.post(url, json=_payload(ident))
+        return resp.status_code
+    except httpx.HTTPError as exc:
+        logger.warning("heartbeat transport error: %s", exc)
+        return 0
+    finally:
+        if own:
+            c.close()
+
+
+def run_forever() -> None:
+    """Block forever, posting heartbeats. Waits for identity to exist before starting."""
+    logging.basicConfig(level=os.getenv("VF_AGENT_LOG_LEVEL", "INFO"))
+    while True:
+        ident = identity.load()
+        if ident is None:
+            time.sleep(2)
+            continue
+        with httpx.Client(timeout=HEARTBEAT_TIMEOUT_S) as client:
+            while True:
+                code = send_once(ident, client=client)
+                if code == 0:
+                    logger.warning("heartbeat failed (transport)")
+                elif code >= 400:
+                    logger.warning("heartbeat failed: HTTP %s", code)
+                else:
+                    logger.debug("heartbeat ok: %s", code)
+                time.sleep(HEARTBEAT_INTERVAL_S)
+
+
+def main() -> None:
+    run_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/src/vf_agent/identity.py
+++ b/agent/src/vf_agent/identity.py
@@ -1,0 +1,46 @@
+"""Persistent agent identity: cluster_id + register_token granted at adoption."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Optional
+
+IDENTITY_PATH = Path(os.getenv("VF_AGENT_IDENTITY_PATH", "/var/lib/vf-agent/identity.json"))
+
+
+@dataclass
+class Identity:
+    cluster_id: str
+    register_token: str
+    api_url: str
+
+
+def load() -> Optional[Identity]:
+    if not IDENTITY_PATH.exists():
+        return None
+    try:
+        data = json.loads(IDENTITY_PATH.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    try:
+        return Identity(
+            cluster_id=data["cluster_id"],
+            register_token=data["register_token"],
+            api_url=data["api_url"],
+        )
+    except KeyError:
+        return None
+
+
+def save(identity: Identity) -> None:
+    IDENTITY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    IDENTITY_PATH.write_text(json.dumps(asdict(identity), indent=2))
+    os.chmod(IDENTITY_PATH, 0o600)
+
+
+def clear() -> None:
+    if IDENTITY_PATH.exists():
+        IDENTITY_PATH.unlink()

--- a/agent/src/vf_agent/main.py
+++ b/agent/src/vf_agent/main.py
@@ -1,0 +1,129 @@
+"""Agent supervisor: starts the HTTP server, waits for adoption, then launches
+the heartbeat loop and Celery worker bound to this cluster's queue.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+
+from vf_agent import identity
+
+logger = logging.getLogger("vf_agent.main")
+
+HTTP_PORT = int(os.getenv("VF_AGENT_PORT", "9443"))
+HTTP_HOST = os.getenv("VF_AGENT_HOST", "0.0.0.0")  # noqa: S104 - intended; agent serves on LAN
+WAIT_FOR_IDENTITY_S = float(os.getenv("VF_AGENT_ADOPT_POLL", "2"))
+
+
+def _spawn_http() -> subprocess.Popen[bytes]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "vf_agent.server:app",
+        "--host",
+        HTTP_HOST,
+        "--port",
+        str(HTTP_PORT),
+        "--log-level",
+        os.getenv("VF_AGENT_LOG_LEVEL", "info").lower(),
+    ]
+    logger.info("starting agent HTTP server: %s", " ".join(cmd))
+    return subprocess.Popen(cmd)
+
+
+def _spawn_heartbeat() -> subprocess.Popen[bytes]:
+    cmd = [sys.executable, "-m", "vf_agent.heartbeat"]
+    logger.info("starting heartbeat loop")
+    return subprocess.Popen(cmd)
+
+
+def _spawn_celery(ident: identity.Identity) -> subprocess.Popen[bytes]:
+    queue = f"cluster.{ident.cluster_id}"
+    cmd = [
+        sys.executable,
+        "-m",
+        "celery",
+        "-A",
+        "app.jobs.celery_app",
+        "worker",
+        "-Q",
+        queue,
+        "--loglevel",
+        os.getenv("VF_AGENT_LOG_LEVEL", "info").lower(),
+        "--concurrency",
+        os.getenv("VF_AGENT_CELERY_CONCURRENCY", "1"),
+    ]
+    env = os.environ.copy()
+    env.setdefault("PYTHONPATH", "/app/src")
+    logger.info("starting celery worker bound to %s", queue)
+    return subprocess.Popen(cmd, env=env)
+
+
+def _wait_for_identity() -> identity.Identity:
+    logger.info("waiting for adoption (POST /adopt on the HTTP server)...")
+    while True:
+        ident = identity.load()
+        if ident is not None:
+            logger.info("adopted as cluster %s", ident.cluster_id)
+            return ident
+        time.sleep(WAIT_FOR_IDENTITY_S)
+
+
+def run() -> int:
+    logging.basicConfig(
+        level=os.getenv("VF_AGENT_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    if not os.getenv("VF_AGENT_TOKEN"):
+        logger.error("VF_AGENT_TOKEN is not set; refusing to start")
+        return 2
+
+    http = _spawn_http()
+    ident = _wait_for_identity()
+    heartbeat = _spawn_heartbeat()
+    celery_proc = _spawn_celery(ident)
+
+    children: list[subprocess.Popen[bytes]] = [http, heartbeat, celery_proc]
+
+    def _shutdown(*_: object) -> None:
+        logger.info("shutting down agent")
+        for child in children:
+            if child.poll() is None:
+                child.terminate()
+        for child in children:
+            try:
+                child.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                child.kill()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    exit_code = 0
+    try:
+        while True:
+            for child in children:
+                ret = child.poll()
+                if ret is not None:
+                    logger.error("child process exited with code %s; tearing down", ret)
+                    exit_code = ret or 1
+                    raise SystemExit(exit_code)
+            time.sleep(2)
+    except SystemExit:
+        _shutdown()
+        return exit_code
+
+
+def main() -> None:
+    sys.exit(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/src/vf_agent/server.py
+++ b/agent/src/vf_agent/server.py
@@ -1,0 +1,86 @@
+"""Agent HTTP server.
+
+Endpoints (all gated by `Authorization: Bearer $VF_AGENT_TOKEN`):
+
+- GET  /info        full hardware + OS snapshot used by the backend's discover flow
+- GET  /telemetry   live CPU / RAM / disk / GPU usage (smaller payload, polled by backend)
+- GET  /health      liveness check (no auth)
+- POST /adopt       called once by the backend to assign cluster_id + register_token
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fastapi import Depends, FastAPI, Header, HTTPException, status
+from pydantic import BaseModel
+
+from vf_agent import __version__, discover, identity
+
+
+class AdoptPayload(BaseModel):
+    cluster_id: str
+    register_token: str
+    api_url: str
+
+
+def _require_token(authorization: str | None = Header(default=None)) -> None:
+    expected = os.getenv("VF_AGENT_TOKEN")
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="agent not configured (VF_AGENT_TOKEN unset)",
+        )
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="missing bearer token")
+    presented = authorization.split(" ", 1)[1].strip()
+    if presented != expected:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid agent token")
+
+
+def build_app() -> FastAPI:
+    app = FastAPI(title="VisionForge Agent", version=__version__)
+
+    @app.get("/health")
+    def health() -> dict[str, Any]:
+        ident = identity.load()
+        return {
+            "ok": True,
+            "version": __version__,
+            "adopted": ident is not None,
+            "cluster_id": ident.cluster_id if ident else None,
+        }
+
+    @app.get("/info", dependencies=[Depends(_require_token)])
+    def info() -> dict[str, Any]:
+        snapshot = discover.discover()
+        snapshot["agent_version"] = __version__
+        return snapshot
+
+    @app.get("/telemetry", dependencies=[Depends(_require_token)])
+    def telemetry() -> dict[str, Any]:
+        snap = discover.discover()
+        return {
+            "cpu_usage_pct": snap["cpu_usage_pct"],
+            "ram_used_mb": snap["ram_used_mb"],
+            "disk_used_gb": snap["disk_used_gb"],
+            "gpu_usage_pct": snap["gpu_usage_pct"],
+            "gpus": snap["gpus"],
+        }
+
+    @app.post("/adopt", dependencies=[Depends(_require_token)])
+    def adopt(payload: AdoptPayload) -> dict[str, Any]:
+        identity.save(
+            identity.Identity(
+                cluster_id=payload.cluster_id,
+                register_token=payload.register_token,
+                api_url=payload.api_url.rstrip("/"),
+            )
+        )
+        return {"ok": True, "cluster_id": payload.cluster_id}
+
+    return app
+
+
+app = build_app()

--- a/agent/tests/conftest.py
+++ b/agent/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "src"
+sys.path.insert(0, str(ROOT))
+
+# Ensure the server module reads a known token in tests.
+os.environ.setdefault("VF_AGENT_TOKEN", "test-token")

--- a/agent/tests/test_heartbeat.py
+++ b/agent/tests/test_heartbeat.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from vf_agent import heartbeat, identity
+
+
+def _identity() -> identity.Identity:
+    return identity.Identity(
+        cluster_id="c-1",
+        register_token="tok",
+        api_url="http://platform:8000",
+    )
+
+
+def test_send_once_posts_correct_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["json"] = request.read().decode()
+        return httpx.Response(202, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        code = heartbeat.send_once(_identity(), client=client)
+
+    assert code == 202
+    assert captured["url"] == "http://platform:8000/api/clusters/c-1/heartbeat"
+    body = captured["json"]
+    assert isinstance(body, str)
+    assert '"register_token":"tok"' in body
+    assert '"status":"online"' in body
+
+
+def test_send_once_transport_error_returns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        code = heartbeat.send_once(_identity(), client=client)
+    assert code == 0

--- a/agent/tests/test_server.py
+++ b/agent/tests/test_server.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from vf_agent import identity, server
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(identity, "IDENTITY_PATH", tmp_path / "identity.json")
+    monkeypatch.setenv("VF_AGENT_TOKEN", "test-token")
+    return TestClient(server.build_app())
+
+
+def _auth() -> dict[str, str]:
+    return {"Authorization": "Bearer test-token"}
+
+
+def test_health_no_auth_required(client: TestClient) -> None:
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["adopted"] is False
+    assert "version" in body
+
+
+def test_info_requires_token(client: TestClient) -> None:
+    assert client.get("/info").status_code == 401
+    assert client.get("/info", headers={"Authorization": "Bearer wrong"}).status_code == 401
+
+
+def test_info_returns_discovery_shape(client: TestClient) -> None:
+    resp = client.get("/info", headers=_auth())
+    assert resp.status_code == 200
+    body = resp.json()
+    for key in (
+        "cpu_cores",
+        "ram_total_mb",
+        "disk_total_gb",
+        "gpu_vendor",
+        "gpu_count",
+        "gpus",
+        "os",
+        "agent_version",
+    ):
+        assert key in body, f"missing {key} in /info response"
+    assert body["gpu_vendor"] in ("nvidia", "rocm", "cpu")
+    assert body["os"]["name"]
+    assert body["os"]["arch"]
+
+
+def test_adopt_persists_identity(client: TestClient) -> None:
+    resp = client.post(
+        "/adopt",
+        headers=_auth(),
+        json={
+            "cluster_id": "c-123",
+            "register_token": "tok-abc",
+            "api_url": "http://platform:8000/",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["cluster_id"] == "c-123"
+
+    ident = identity.load()
+    assert ident is not None
+    assert ident.cluster_id == "c-123"
+    assert ident.register_token == "tok-abc"
+    # Trailing slash stripped.
+    assert ident.api_url == "http://platform:8000"
+
+    # /health now reports adopted=True with the saved cluster_id.
+    health = client.get("/health").json()
+    assert health["adopted"] is True
+    assert health["cluster_id"] == "c-123"
+
+
+def test_telemetry_requires_token(client: TestClient) -> None:
+    assert client.get("/telemetry").status_code == 401
+    resp = client.get("/telemetry", headers=_auth())
+    assert resp.status_code == 200
+    body = resp.json()
+    for key in ("cpu_usage_pct", "ram_used_mb", "disk_used_gb", "gpu_usage_pct", "gpus"):
+        assert key in body
+
+
+def test_token_unset_returns_503(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VF_AGENT_TOKEN", raising=False)
+    fresh_app = server.build_app()
+    fresh_client = TestClient(fresh_app)
+    resp = fresh_client.get("/info", headers=_auth())
+    assert resp.status_code == 503

--- a/backend/src/app/api/clusters.py
+++ b/backend/src/app/api/clusters.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
 from sqlalchemy.orm import Session
 
 from app.db.deps import get_current_user, get_db
 from app.models.user import User
 from app.schemas.cluster import Cluster as ClusterSchema
 from app.schemas.cluster import (
-    ClusterCreate,
+    ClusterDiscoverRequest,
     ClusterHeartbeat,
     ClusterHeartbeatAck,
     ClusterRegistration,
@@ -20,6 +21,14 @@ from app.schemas.cluster import (
 from app.services import cluster_service
 
 router = APIRouter(prefix="/api/clusters", tags=["clusters"])
+
+
+def _platform_api_url(request: Request) -> str:
+    """Return the public base URL the agent should heartbeat back to."""
+    override = os.getenv("VF_PLATFORM_PUBLIC_URL")
+    if override:
+        return override.rstrip("/")
+    return str(request.base_url).rstrip("/")
 
 
 @router.get("", response_model=list[ClusterSchema])
@@ -49,13 +58,30 @@ def list_available_clusters(
     return [ClusterSummary(**s) for s in cluster_service.summarize(rows, kind=kind)]
 
 
-@router.post("", response_model=ClusterRegistration, status_code=201)
-def create_cluster(
-    payload: ClusterCreate,
+@router.post("/discover", response_model=ClusterRegistration, status_code=201)
+def discover_cluster(
+    payload: ClusterDiscoverRequest,
+    request: Request,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    cluster = cluster_service.create_cluster(db, payload)
+    """Reach out to a running agent at host:port, fetch hardware specs, and register the cluster.
+
+    Returns 502 if the agent is unreachable, with `reason` set to one of
+    `connect | timeout | auth | bad_response`.
+    """
+    try:
+        cluster = cluster_service.discover_cluster(
+            db, payload, api_url=_platform_api_url(request)
+        )
+    except cluster_service.AgentUnreachableError as exc:
+        # Encode the reason in the detail string so the frontend (which only sees
+        # `detail`) can distinguish connect / timeout / auth / bad_response.
+        raise HTTPException(
+            status_code=502,
+            detail=f"{exc} [reason={exc.reason}]",
+        ) from exc
+
     data = cluster_to_dict(cluster)
     data["register_token"] = cluster.register_token
     return ClusterRegistration(**data)
@@ -131,3 +157,19 @@ def release(
     if not cluster:
         raise HTTPException(status_code=404, detail="Cluster not found")
     return ClusterSchema(**cluster_to_dict(cluster))
+
+
+@router.post("/{cluster_id}/rotate-token", response_model=ClusterRegistration)
+def rotate_token(
+    cluster_id: str = Path(...),
+    request: Request = None,  # type: ignore[assignment]
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Re-issue the cluster's register_token. The agent must be re-adopted afterwards."""
+    cluster = cluster_service.rotate_register_token(db, cluster_id)
+    if not cluster:
+        raise HTTPException(status_code=404, detail="Cluster not found")
+    data = cluster_to_dict(cluster)
+    data["register_token"] = cluster.register_token
+    return ClusterRegistration(**data)

--- a/backend/src/app/db/migrations/versions/0004_cluster_discovery.py
+++ b/backend/src/app/db/migrations/versions/0004_cluster_discovery.py
@@ -1,0 +1,34 @@
+"""Add agent connection + OS columns to clusters for the discovery flow.
+
+Revision ID: 0004_cluster_discovery
+Revises: 0003_clusters
+Create Date: 2026-05-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0004_cluster_discovery"
+down_revision = "0003_clusters"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("clusters") as batch:
+        batch.add_column(sa.Column("agent_host", sa.String(length=255), nullable=True))
+        batch.add_column(sa.Column("agent_port", sa.Integer(), nullable=True))
+        batch.add_column(sa.Column("agent_version", sa.String(length=32), nullable=True))
+        batch.add_column(sa.Column("os_name", sa.String(length=64), nullable=True))
+        batch.add_column(sa.Column("os_release", sa.String(length=128), nullable=True))
+        batch.add_column(sa.Column("arch", sa.String(length=32), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("clusters") as batch:
+        batch.drop_column("arch")
+        batch.drop_column("os_release")
+        batch.drop_column("os_name")
+        batch.drop_column("agent_version")
+        batch.drop_column("agent_port")
+        batch.drop_column("agent_host")

--- a/backend/src/app/models/cluster.py
+++ b/backend/src/app/models/cluster.py
@@ -63,6 +63,16 @@ class Cluster(Base):
     # Registration token used by the agent to authenticate heartbeats
     register_token: Mapped[str] = mapped_column(String(64), nullable=False, default=_token)
 
+    # Agent reachability (populated by the discovery flow)
+    agent_host: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    agent_port: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    agent_version: Mapped[str | None] = mapped_column(String(32), nullable=True)
+
+    # OS metadata reported by the agent at discovery time
+    os_name: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    os_release: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    arch: Mapped[str | None] = mapped_column(String(32), nullable=True)
+
     last_heartbeat_at: Mapped[object | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[object] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[object] = mapped_column(

--- a/backend/src/app/schemas/cluster.py
+++ b/backend/src/app/schemas/cluster.py
@@ -22,6 +22,13 @@ class GpuInfo(BaseModel):
 
 
 class ClusterCreate(BaseModel):
+    """Internal-only creation payload used by the discovery service.
+
+    The public API does not accept manually-entered hardware specs anymore;
+    clients should call POST /api/clusters/discover instead, which probes the
+    agent and fills these fields from the agent's /info response.
+    """
+
     name: str = Field(..., min_length=1, max_length=255)
     description: str | None = None
     kind: ClusterKind = "both"
@@ -32,6 +39,43 @@ class ClusterCreate(BaseModel):
     gpu_count: int = 0
     gpu_model: str | None = None
     gpu_memory_mb: int = 0
+    agent_host: str | None = None
+    agent_port: int | None = None
+    agent_version: str | None = None
+    os_name: str | None = None
+    os_release: str | None = None
+    arch: str | None = None
+
+
+class ClusterDiscoverRequest(BaseModel):
+    """Operator-supplied tuple used to reach a running agent on the worker."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    host: str = Field(..., min_length=1, max_length=255)
+    port: int = Field(9443, ge=1, le=65535)
+    agent_token: str = Field(..., min_length=1)
+    kind: ClusterKind = "both"
+    description: str | None = None
+    scheme: Literal["http", "https"] = "http"
+
+
+class AgentInfo(BaseModel):
+    """Schema for the JSON returned by the agent's `/info` endpoint."""
+
+    cpu_cores: int = 0
+    ram_total_mb: int = 0
+    disk_total_gb: int = 0
+    gpu_vendor: GpuVendor = "cpu"
+    gpu_count: int = 0
+    gpu_model: str | None = None
+    gpu_memory_mb: int = 0
+    gpus: list[GpuInfo] = Field(default_factory=list)
+    cpu_usage_pct: float = 0.0
+    ram_used_mb: int = 0
+    disk_used_gb: int = 0
+    gpu_usage_pct: float = 0.0
+    os: dict[str, Any] = Field(default_factory=dict)
+    agent_version: str | None = None
 
 
 class ClusterUpdate(BaseModel):
@@ -93,6 +137,13 @@ class Cluster(BaseModel):
     created_at: datetime | None = None
 
     gpus: list[GpuInfo] = Field(default_factory=list)
+
+    agent_host: str | None = None
+    agent_port: int | None = None
+    agent_version: str | None = None
+    os_name: str | None = None
+    os_release: str | None = None
+    arch: str | None = None
 
 
 class ClusterRegistration(Cluster):
@@ -161,4 +212,10 @@ def cluster_to_dict(model: Any) -> dict[str, Any]:
         "last_heartbeat_at": model.last_heartbeat_at,
         "created_at": model.created_at,
         "gpus": gpus,
+        "agent_host": getattr(model, "agent_host", None),
+        "agent_port": getattr(model, "agent_port", None),
+        "agent_version": getattr(model, "agent_version", None),
+        "os_name": getattr(model, "os_name", None),
+        "os_release": getattr(model, "os_release", None),
+        "arch": getattr(model, "arch", None),
     }

--- a/backend/src/app/services/cluster_service.py
+++ b/backend/src/app/services/cluster_service.py
@@ -4,12 +4,15 @@ import json
 from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
 
+import httpx
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.models.cluster import Cluster
 from app.schemas.cluster import (
+    AgentInfo,
     ClusterCreate,
+    ClusterDiscoverRequest,
     ClusterHeartbeat,
     ClusterUpdate,
 )
@@ -18,6 +21,9 @@ from app.schemas.cluster import (
 # was received within this window, regardless of last persisted status.
 HEARTBEAT_TIMEOUT = timedelta(seconds=90)
 
+# Agent discovery timeouts. Kept short so an unreachable host returns quickly.
+DISCOVER_TIMEOUT = 5.0
+
 
 class ClusterError(Exception):
     pass
@@ -25,6 +31,14 @@ class ClusterError(Exception):
 
 class ClusterNotAvailableError(ClusterError):
     pass
+
+
+class AgentUnreachableError(ClusterError):
+    """Raised when the discover flow can't reach or authenticate against an agent."""
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason  # one of: connect | timeout | auth | bad_response
 
 
 def create_cluster(db: Session, payload: ClusterCreate) -> Cluster:
@@ -39,11 +53,143 @@ def create_cluster(db: Session, payload: ClusterCreate) -> Cluster:
         gpu_count=payload.gpu_count,
         gpu_model=payload.gpu_model,
         gpu_memory_mb=payload.gpu_memory_mb,
+        agent_host=payload.agent_host,
+        agent_port=payload.agent_port,
+        agent_version=payload.agent_version,
+        os_name=payload.os_name,
+        os_release=payload.os_release,
+        arch=payload.arch,
         status="offline",
     )
     db.add(cluster)
     db.commit()
     db.refresh(cluster)
+    return cluster
+
+
+def _probe_agent(
+    host: str,
+    port: int,
+    agent_token: str,
+    *,
+    scheme: str = "http",
+    client: httpx.Client | None = None,
+) -> AgentInfo:
+    """Call the agent's /info endpoint. Raises AgentUnreachableError on failure."""
+    base = f"{scheme}://{host}:{port}"
+    headers = {"Authorization": f"Bearer {agent_token}"}
+    own = client is None
+    c = client or httpx.Client(timeout=DISCOVER_TIMEOUT)
+    try:
+        resp = c.get(f"{base}/info", headers=headers)
+    except httpx.TimeoutException as exc:
+        raise AgentUnreachableError("timeout", f"agent {host}:{port} timed out") from exc
+    except httpx.ConnectError as exc:
+        raise AgentUnreachableError("connect", f"agent {host}:{port} not reachable") from exc
+    except httpx.HTTPError as exc:
+        raise AgentUnreachableError("connect", str(exc)) from exc
+    finally:
+        if own:
+            c.close()
+
+    if resp.status_code in (401, 403):
+        raise AgentUnreachableError("auth", "agent rejected the supplied agent token")
+    if resp.status_code != 200:
+        raise AgentUnreachableError(
+            "bad_response", f"agent returned HTTP {resp.status_code}: {resp.text[:200]}"
+        )
+    try:
+        return AgentInfo.model_validate(resp.json())
+    except Exception as exc:
+        raise AgentUnreachableError("bad_response", f"agent /info malformed: {exc}") from exc
+
+
+def _adopt_agent(
+    host: str,
+    port: int,
+    agent_token: str,
+    cluster_id: str,
+    register_token: str,
+    api_url: str,
+    *,
+    scheme: str = "http",
+    client: httpx.Client | None = None,
+) -> None:
+    base = f"{scheme}://{host}:{port}"
+    headers = {"Authorization": f"Bearer {agent_token}"}
+    body = {"cluster_id": cluster_id, "register_token": register_token, "api_url": api_url}
+    own = client is None
+    c = client or httpx.Client(timeout=DISCOVER_TIMEOUT)
+    try:
+        resp = c.post(f"{base}/adopt", headers=headers, json=body)
+    except httpx.HTTPError as exc:
+        raise AgentUnreachableError("connect", f"adopt failed: {exc}") from exc
+    finally:
+        if own:
+            c.close()
+    if resp.status_code >= 400:
+        raise AgentUnreachableError("bad_response", f"adopt rejected: HTTP {resp.status_code}")
+
+
+def discover_cluster(
+    db: Session,
+    payload: ClusterDiscoverRequest,
+    *,
+    api_url: str,
+    client: httpx.Client | None = None,
+) -> Cluster:
+    """Probe an agent, create a Cluster row from its /info, then adopt it.
+
+    `api_url` is the publicly-reachable base URL of the platform (e.g.
+    `http://platform:8000`); this gets persisted on the agent so it knows
+    where to send heartbeats.
+    """
+    info = _probe_agent(
+        payload.host,
+        payload.port,
+        payload.agent_token,
+        scheme=payload.scheme,
+        client=client,
+    )
+
+    os_meta = info.os or {}
+    create_payload = ClusterCreate(
+        name=payload.name,
+        description=payload.description,
+        kind=payload.kind,
+        cpu_cores=info.cpu_cores,
+        ram_total_mb=info.ram_total_mb,
+        disk_total_gb=info.disk_total_gb,
+        gpu_vendor=info.gpu_vendor,
+        gpu_count=info.gpu_count,
+        gpu_model=info.gpu_model,
+        gpu_memory_mb=info.gpu_memory_mb,
+        agent_host=payload.host,
+        agent_port=payload.port,
+        agent_version=info.agent_version,
+        os_name=str(os_meta.get("name") or "") or None,
+        os_release=str(os_meta.get("release") or "") or None,
+        arch=str(os_meta.get("arch") or "") or None,
+    )
+    cluster = create_cluster(db, create_payload)
+
+    # Persist the per-GPU breakdown so the UI can display it before the first heartbeat.
+    if info.gpus:
+        cluster.gpus_json = json.dumps([g.model_dump() for g in info.gpus])
+        db.add(cluster)
+        db.commit()
+        db.refresh(cluster)
+
+    _adopt_agent(
+        payload.host,
+        payload.port,
+        payload.agent_token,
+        cluster.id,
+        cluster.register_token,
+        api_url,
+        scheme=payload.scheme,
+        client=client,
+    )
     return cluster
 
 
@@ -193,6 +339,22 @@ def release_cluster(db: Session, cluster_id: str) -> Cluster | None:
     cluster.active_job_id = None
     if cluster.status == "busy":
         cluster.status = "online"
+    db.add(cluster)
+    db.commit()
+    db.refresh(cluster)
+    return cluster
+
+
+def rotate_register_token(db: Session, cluster_id: str) -> Cluster | None:
+    import secrets
+
+    cluster = db.get(Cluster, cluster_id)
+    if not cluster:
+        return None
+    cluster.register_token = secrets.token_urlsafe(32)
+    # Force the agent to re-adopt by treating the cluster as offline until next heartbeat.
+    cluster.status = "offline"
+    cluster.last_heartbeat_at = None
     db.add(cluster)
     db.commit()
     db.refresh(cluster)

--- a/backend/tests/integration/test_clusters_api.py
+++ b/backend/tests/integration/test_clusters_api.py
@@ -1,24 +1,27 @@
 """Integration tests for the /api/clusters endpoints.
 
-We bypass `get_current_user` with a dependency override so these tests focus on
-cluster API behaviour and don't depend on the auth/bcrypt stack being healthy
-in the test environment.
+The cluster creation path now goes through `/api/clusters/discover`, which
+probes a running agent. We stub the agent with `httpx.MockTransport` injected
+into the service via monkeypatch so the suite stays hermetic.
 """
 
 from __future__ import annotations
 
 import uuid
+from typing import Any
 
+import httpx
+import pytest
 from fastapi.testclient import TestClient
 
 from app.db.deps import get_current_user
 from app.main import app
 from app.models.user import User
+from app.services import cluster_service
 
 
 def _fake_user() -> User:
-    u = User(id="test-user", email="tester@example.com", name="Tester", password_hash="x")
-    return u
+    return User(id="test-user", email="tester@example.com", name="Tester", password_hash="x")
 
 
 app.dependency_overrides[get_current_user] = _fake_user
@@ -29,43 +32,107 @@ def _unique(prefix: str) -> str:
     return f"{prefix}-{uuid.uuid4().hex[:8]}"
 
 
-def test_register_cluster_returns_token_and_lists_offline():
-    name = _unique("ci")
+def _info_payload(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "cpu_cores": 4,
+        "ram_total_mb": 8192,
+        "disk_total_gb": 100,
+        "gpu_vendor": "nvidia",
+        "gpu_count": 1,
+        "gpu_model": "RTX 4090",
+        "gpu_memory_mb": 24576,
+        "gpus": [{"index": 0, "name": "RTX 4090", "memory_mb": 24576, "util_pct": 0.0}],
+        "cpu_usage_pct": 0.0,
+        "ram_used_mb": 0,
+        "disk_used_gb": 0,
+        "gpu_usage_pct": 0.0,
+        "os": {"name": "Linux", "release": "6.18.5", "arch": "x86_64"},
+        "agent_version": "0.1.0",
+    }
+    base.update(overrides)
+    return base
+
+
+def _stub_agent(monkeypatch: pytest.MonkeyPatch, info: dict[str, Any]) -> None:
+    """Patch httpx.Client in cluster_service so /info + /adopt return canned data."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/info"):
+            return httpx.Response(200, json=info)
+        if request.url.path.endswith("/adopt"):
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    original = httpx.Client
+
+    def factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        kwargs["transport"] = transport
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cluster_service.httpx, "Client", factory)
+
+
+def _discover(monkeypatch: pytest.MonkeyPatch, info_overrides: dict[str, Any] | None = None, *, name_prefix: str = "ci", kind: str = "both") -> dict[str, Any]:
+    _stub_agent(monkeypatch, _info_payload(**(info_overrides or {})))
     r = client.post(
-        "/api/clusters",
+        "/api/clusters/discover",
         json={
-            "name": name,
-            "description": "test",
-            "kind": "both",
-            "cpu_cores": 4,
-            "ram_total_mb": 8192,
-            "disk_total_gb": 100,
-            "gpu_vendor": "nvidia",
-            "gpu_count": 1,
-            "gpu_model": "RTX 4090",
-            "gpu_memory_mb": 24576,
+            "name": _unique(name_prefix),
+            "host": "10.0.0.10",
+            "port": 9443,
+            "agent_token": "stub-token",
+            "kind": kind,
         },
     )
     assert r.status_code == 201, r.text
-    body = r.json()
-    cluster_id = body["id"]
+    return r.json()
+
+
+def test_discover_returns_token_and_populates_specs_from_agent(monkeypatch):
+    body = _discover(monkeypatch, {"gpu_count": 2, "gpu_model": "A100 80GB", "gpu_memory_mb": 81920})
     assert body["register_token"]
     assert body["status"] == "offline"
     assert body["gpu_vendor"] == "nvidia"
+    assert body["gpu_count"] == 2
+    assert body["gpu_model"] == "A100 80GB"
+    assert body["agent_host"] == "10.0.0.10"
+    assert body["agent_port"] == 9443
+    assert body["agent_version"] == "0.1.0"
+    assert body["os_name"] == "Linux"
+    assert body["arch"] == "x86_64"
 
-    r2 = client.get("/api/clusters")
-    assert r2.status_code == 200
-    found = [c for c in r2.json() if c["id"] == cluster_id]
-    assert found and found[0]["status"] == "offline"
 
+def test_discover_502s_when_agent_unreachable(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("nope", request=request)
 
-def test_heartbeat_makes_cluster_available_for_training():
-    r = client.post(
-        "/api/clusters",
-        json={"name": _unique("ci-train"), "kind": "train", "gpu_vendor": "rocm", "gpu_count": 1},
+    transport = httpx.MockTransport(handler)
+    original = httpx.Client
+    monkeypatch.setattr(
+        cluster_service.httpx,
+        "Client",
+        lambda *a, **kw: original(*a, **{**kw, "transport": transport}),
     )
-    cluster_id = r.json()["id"]
-    token = r.json()["register_token"]
+
+    r = client.post(
+        "/api/clusters/discover",
+        json={
+            "name": _unique("ci-unreachable"),
+            "host": "10.0.0.99",
+            "port": 9443,
+            "agent_token": "x",
+            "kind": "both",
+        },
+    )
+    assert r.status_code == 502, r.text
+    assert "[reason=connect]" in r.json()["detail"]
+
+
+def test_heartbeat_makes_cluster_available_for_training(monkeypatch):
+    body = _discover(monkeypatch, {"gpu_vendor": "rocm", "gpu_count": 1}, name_prefix="ci-train", kind="train")
+    cluster_id = body["id"]
+    token = body["register_token"]
 
     hb = client.post(
         f"/api/clusters/{cluster_id}/heartbeat",
@@ -77,13 +144,7 @@ def test_heartbeat_makes_cluster_available_for_training():
             "disk_used_gb": 10,
             "gpu_usage_pct": 5.0,
             "gpus": [
-                {
-                    "index": 0,
-                    "name": "MI250",
-                    "memory_mb": 65536,
-                    "util_pct": 5.0,
-                    "mem_used_mb": 1024,
-                }
+                {"index": 0, "name": "MI250", "memory_mb": 65536, "util_pct": 5.0, "mem_used_mb": 1024}
             ],
         },
     )
@@ -96,25 +157,23 @@ def test_heartbeat_makes_cluster_available_for_training():
 
     eval_avail = client.get("/api/clusters/available?kind=eval").json()
     found_eval = [c for c in eval_avail if c["id"] == cluster_id]
-    # train-only cluster should appear in eval list but be marked unavailable
     assert found_eval and found_eval[0]["available"] is False
 
 
-def test_heartbeat_rejects_invalid_token():
-    r = client.post("/api/clusters", json={"name": _unique("ci-badtoken")})
-    cluster_id = r.json()["id"]
+def test_heartbeat_rejects_invalid_token(monkeypatch):
+    body = _discover(monkeypatch, name_prefix="ci-badtoken")
     bad = client.post(
-        f"/api/clusters/{cluster_id}/heartbeat",
+        f"/api/clusters/{body['id']}/heartbeat",
         json={"register_token": "wrong", "status": "online"},
     )
     assert bad.status_code == 403
 
 
-def test_train_with_unavailable_cluster_returns_409():
+def test_train_with_unavailable_cluster_returns_409(monkeypatch):
     r = client.post("/api/projects", json={"name": _unique("ClusterProj"), "description": ""})
     proj_id = r.json()["id"]
-    r2 = client.post("/api/clusters", json={"name": _unique("ci-offline")})
-    cluster_id = r2.json()["id"]
+    body = _discover(monkeypatch, name_prefix="ci-offline")
+    cluster_id = body["id"]
 
     train = client.post(
         "/api/train",
@@ -129,21 +188,36 @@ def test_train_with_unavailable_cluster_returns_409():
     assert train.status_code == 409, train.text
 
 
-def test_train_with_available_cluster_marks_it_busy():
+def test_train_with_available_cluster_routes_to_cluster_queue(monkeypatch):
+    """Canonical Phase 4 proof: training launched against an available cluster must
+    enqueue the Celery task on the dedicated cluster.{id} queue."""
     r = client.post("/api/projects", json={"name": _unique("ClusterProj2"), "description": ""})
     proj_id = r.json()["id"]
 
-    r2 = client.post(
-        "/api/clusters",
-        json={"name": _unique("ci-online"), "kind": "both", "gpu_vendor": "nvidia", "gpu_count": 1},
-    )
-    cluster_id = r2.json()["id"]
-    token = r2.json()["register_token"]
+    body = _discover(monkeypatch, name_prefix="ci-online")
+    cluster_id = body["id"]
+    token = body["register_token"]
 
     client.post(
         f"/api/clusters/{cluster_id}/heartbeat",
         json={"register_token": token, "status": "online"},
     )
+
+    # Capture the Celery dispatch so we can assert the queue routing without a real broker.
+    captured: dict[str, Any] = {}
+    from app.services import training_service
+
+    def fake_send_task(name: str, **kwargs: Any) -> Any:
+        captured["name"] = name
+        captured["queue"] = kwargs.get("queue")
+        captured["args"] = kwargs.get("args")
+
+        class _R:
+            id = "celery-id"
+
+        return _R()
+
+    monkeypatch.setattr(training_service.celery_app, "send_task", fake_send_task)
 
     train = client.post(
         "/api/train",
@@ -157,6 +231,27 @@ def test_train_with_available_cluster_marks_it_busy():
     )
     assert train.status_code == 202, train.text
 
+    assert captured["name"] == "app.jobs.tasks.training.train_task"
+    assert captured["queue"] == f"cluster.{cluster_id}"
+    assert captured["args"][0]["clusterId"] == cluster_id
+
     info = client.get(f"/api/clusters/{cluster_id}").json()
     assert info["status"] == "busy"
     assert info["active_job_id"]
+
+
+def test_rotate_token_invalidates_old_token(monkeypatch):
+    body = _discover(monkeypatch, name_prefix="ci-rotate")
+    cluster_id = body["id"]
+    old_token = body["register_token"]
+
+    rot = client.post(f"/api/clusters/{cluster_id}/rotate-token")
+    assert rot.status_code == 200, rot.text
+    new_token = rot.json()["register_token"]
+    assert new_token != old_token
+
+    bad = client.post(
+        f"/api/clusters/{cluster_id}/heartbeat",
+        json={"register_token": old_token, "status": "online"},
+    )
+    assert bad.status_code == 403

--- a/backend/tests/unit/test_cluster_service.py
+++ b/backend/tests/unit/test_cluster_service.py
@@ -141,6 +141,137 @@ def test_release_returns_cluster_to_online(db):
     assert released.status == "online"
 
 
+def test_discover_probes_agent_and_creates_cluster(db):
+    import httpx
+
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        if request.url.path.endswith("/info"):
+            assert request.headers.get("authorization") == "Bearer agent-secret"
+            return httpx.Response(
+                200,
+                json={
+                    "cpu_cores": 32,
+                    "ram_total_mb": 65536,
+                    "disk_total_gb": 1000,
+                    "gpu_vendor": "nvidia",
+                    "gpu_count": 2,
+                    "gpu_model": "A100 80GB",
+                    "gpu_memory_mb": 81920,
+                    "gpus": [
+                        {"index": 0, "name": "A100", "memory_mb": 81920, "util_pct": 0.0},
+                        {"index": 1, "name": "A100", "memory_mb": 81920, "util_pct": 0.0},
+                    ],
+                    "cpu_usage_pct": 0.0,
+                    "ram_used_mb": 0,
+                    "disk_used_gb": 0,
+                    "gpu_usage_pct": 0.0,
+                    "os": {"name": "Linux", "release": "6.18.5", "arch": "x86_64"},
+                    "agent_version": "0.1.0",
+                },
+            )
+        if request.url.path.endswith("/adopt"):
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        from app.schemas.cluster import ClusterDiscoverRequest
+
+        cluster = cluster_service.discover_cluster(
+            db,
+            ClusterDiscoverRequest(
+                name="rig-01",
+                host="10.0.0.10",
+                port=9443,
+                agent_token="agent-secret",
+                kind="both",
+            ),
+            api_url="http://platform:8000",
+            client=client,
+        )
+
+    assert cluster.cpu_cores == 32
+    assert cluster.ram_total_mb == 65536
+    assert cluster.gpu_vendor == "nvidia"
+    assert cluster.gpu_count == 2
+    assert cluster.gpu_model == "A100 80GB"
+    assert cluster.agent_host == "10.0.0.10"
+    assert cluster.agent_port == 9443
+    assert cluster.agent_version == "0.1.0"
+    assert cluster.os_name == "Linux"
+    assert cluster.os_release == "6.18.5"
+    assert cluster.arch == "x86_64"
+    assert cluster.gpus_json and "A100" in cluster.gpus_json
+
+    # Both /info and /adopt were called.
+    paths = [r.url.path for r in captured]
+    assert "/info" in paths
+    assert "/adopt" in paths
+
+
+def test_discover_returns_connect_error_when_agent_down(db):
+    import httpx
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("nope", request=request)
+
+    from app.schemas.cluster import ClusterDiscoverRequest
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        with pytest.raises(cluster_service.AgentUnreachableError) as exc:
+            cluster_service.discover_cluster(
+                db,
+                ClusterDiscoverRequest(
+                    name="x", host="h", port=9443, agent_token="t", kind="both"
+                ),
+                api_url="http://platform:8000",
+                client=client,
+            )
+    assert exc.value.reason == "connect"
+
+
+def test_discover_returns_auth_error_on_401(db):
+    import httpx
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"detail": "bad token"})
+
+    from app.schemas.cluster import ClusterDiscoverRequest
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        with pytest.raises(cluster_service.AgentUnreachableError) as exc:
+            cluster_service.discover_cluster(
+                db,
+                ClusterDiscoverRequest(
+                    name="x", host="h", port=9443, agent_token="wrong", kind="both"
+                ),
+                api_url="http://platform:8000",
+                client=client,
+            )
+    assert exc.value.reason == "auth"
+
+
+def test_rotate_register_token_invalidates_old_token(db):
+    cluster = _create(db)
+    old_token = cluster.register_token
+    rotated = cluster_service.rotate_register_token(db, cluster.id)
+    assert rotated is not None
+    assert rotated.register_token != old_token
+    assert rotated.status == "offline"
+    # Old token now fails heartbeats
+    with pytest.raises(cluster_service.ClusterError):
+        cluster_service.record_heartbeat(
+            db,
+            cluster.id,
+            ClusterHeartbeat(register_token=old_token, status="online"),
+        )
+
+
 def test_stale_heartbeat_treated_as_offline(db):
     cluster = _create(db)
     cluster_service.record_heartbeat(

--- a/compose.agent.yml
+++ b/compose.agent.yml
@@ -1,0 +1,36 @@
+# Local-dev overlay: runs a cluster agent alongside the platform.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f compose.agent.yml up -d agent
+#
+# Then in the UI: /clusters/new
+#   - Host:        agent           (or the host IP if calling from outside Docker)
+#   - Port:        9443
+#   - Agent token: value of VF_AGENT_TOKEN below
+#
+# In production the agent runs on the worker machine, not in this compose file.
+services:
+  agent:
+    build:
+      context: .
+      dockerfile: agent/Dockerfile
+    environment:
+      VF_AGENT_TOKEN: ${VF_AGENT_TOKEN:-dev-agent-token}
+      VF_AGENT_PORT: "9443"
+      VF_AGENT_HEARTBEAT_INTERVAL: "30"
+      REDIS_URL: redis://redis:6379/0
+      DATABASE_URL: ${DATABASE_URL:-}
+      MINIO_ENDPOINT: minio:9000
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+      S3_BUCKET: ${S3_BUCKET:-visionforge}
+    ports:
+      - "9443:9443"
+    depends_on:
+      redis:
+        condition: service_healthy
+    volumes:
+      - vf_agent_state:/var/lib/vf-agent
+
+volumes:
+  vf_agent_state:

--- a/frontend/src/pages/clusters/index.tsx
+++ b/frontend/src/pages/clusters/index.tsx
@@ -37,6 +37,12 @@ interface Cluster {
   active_job_id?: string | null;
   last_heartbeat_at?: string | null;
   gpus: Gpu[];
+  agent_host?: string | null;
+  agent_port?: number | null;
+  agent_version?: string | null;
+  os_name?: string | null;
+  os_release?: string | null;
+  arch?: string | null;
 }
 
 const REFRESH_MS = 5000;
@@ -155,6 +161,17 @@ function ClusterCard({ c }: { c: Cluster }) {
       )}
 
       <div className="flex items-center justify-between text-[0.6875rem] font-mono text-[var(--hud-text-muted)] pt-1 border-t border-[var(--hud-border-subtle)]">
+        <span className="truncate">
+          {c.os_name ? `${c.os_name} ${c.os_release || ''} · ${c.arch || ''}` : 'OS unknown'}
+        </span>
+        {c.agent_host && (
+          <span className="text-[var(--hud-text-data)]">
+            {c.agent_host}:{c.agent_port}
+            {c.agent_version ? ` · v${c.agent_version}` : ''}
+          </span>
+        )}
+      </div>
+      <div className="flex items-center justify-between text-[0.6875rem] font-mono text-[var(--hud-text-muted)]">
         <span>HEARTBEAT · {heartbeatAgo}</span>
         {c.active_job_id && (
           <span className="text-[var(--hud-info-text)]">JOB · {c.active_job_id.slice(0, 8)}</span>

--- a/frontend/src/pages/clusters/new.tsx
+++ b/frontend/src/pages/clusters/new.tsx
@@ -1,34 +1,68 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import Input from '@/components/ui/Input';
 import Select from '@/components/ui/Select';
 import Button from '@/components/ui/Button';
 import Alert from '@/components/ui/Alert';
+import Badge from '@/components/ui/Badge';
 import { apiPost } from '@/services/api';
 
-interface RegisteredCluster {
+interface DiscoveredCluster {
   id: string;
   name: string;
+  cpu_cores: number;
+  ram_total_mb: number;
+  disk_total_gb: number;
+  gpu_vendor: 'nvidia' | 'rocm' | 'cpu';
+  gpu_count: number;
+  gpu_model?: string | null;
+  gpu_memory_mb: number;
+  agent_host?: string | null;
+  agent_port?: number | null;
+  agent_version?: string | null;
+  os_name?: string | null;
+  os_release?: string | null;
+  arch?: string | null;
   register_token: string;
 }
 
+function randomToken(): string {
+  // 32-byte URL-safe token, generated client-side so the operator never has to
+  // think one up. The agent reads this value as VF_AGENT_TOKEN.
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
 export default function ClustersNew() {
+  const navigate = useNavigate();
+  const [agentToken] = useState<string>(() => randomToken());
   const [form, setForm] = useState({
     name: '',
-    description: '',
+    host: '',
+    port: 9443,
     kind: 'both' as 'train' | 'eval' | 'both',
-    cpu_cores: 8,
-    ram_total_mb: 16384,
-    disk_total_gb: 200,
-    gpu_vendor: 'nvidia' as 'nvidia' | 'rocm' | 'cpu',
-    gpu_count: 1,
-    gpu_model: '',
-    gpu_memory_mb: 24576,
+    description: '',
+    scheme: 'http' as 'http' | 'https',
   });
-  const [registered, setRegistered] = useState<RegisteredCluster | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const navigate = useNavigate();
+  const [registered, setRegistered] = useState<DiscoveredCluster | null>(null);
+
+  const installCmd = useMemo(() => {
+    const apiBase = window.location.origin.replace(':5173', ':8000');
+    return `docker run -d --name vf-agent \\
+  --restart unless-stopped \\
+  --gpus all \\
+  -p 9443:9443 \\
+  -v vf-agent-state:/var/lib/vf-agent \\
+  -e VF_AGENT_TOKEN=${agentToken} \\
+  -e REDIS_URL=${apiBase.replace(/:\d+$/, ':6379')}/0 \\
+  visionforge/agent:latest`;
+  }, [agentToken]);
 
   function setField<K extends keyof typeof form>(key: K, value: (typeof form)[K]) {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -36,49 +70,84 @@ export default function ClustersNew() {
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!form.name.trim()) {
-      setError('Cluster name is required');
-      return;
-    }
-    setLoading(true);
     setError(null);
+    if (!form.name.trim()) return setError('Cluster name is required');
+    if (!form.host.trim()) return setError('Host (IP or hostname) is required');
+    setLoading(true);
     try {
-      const res = await apiPost<RegisteredCluster>('/api/clusters', form);
+      const res = await apiPost<DiscoveredCluster>('/api/clusters/discover', {
+        name: form.name,
+        host: form.host,
+        port: form.port,
+        agent_token: agentToken,
+        kind: form.kind,
+        description: form.description || undefined,
+        scheme: form.scheme,
+      });
       setRegistered(res);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to register cluster');
+      // The API returns 502 with detail "<message> [reason=<code>]" for
+      // agent-unreachable errors; surface a human-readable hint for the code.
+      const raw = err instanceof Error ? err.message : 'Failed to register cluster';
+      const m = raw.match(/\[reason=([a-z_]+)\]/);
+      const hint =
+        m?.[1] === 'connect'
+          ? ' (host or port unreachable)'
+          : m?.[1] === 'timeout'
+            ? ' (agent did not respond in time)'
+            : m?.[1] === 'auth'
+              ? ' (agent rejected the token)'
+              : m?.[1] === 'bad_response'
+                ? ' (agent returned malformed data)'
+                : '';
+      setError(`${raw}${hint}`);
     } finally {
       setLoading(false);
     }
   }
 
   if (registered) {
-    const apiBase = window.location.origin.replace('5173', '8000');
-    const installCmd = `docker run -d --name vf-agent \\
-  --restart unless-stopped \\
-  --gpus all \\
-  -e VF_API_URL=${apiBase} \\
-  -e VF_CLUSTER_ID=${registered.id} \\
-  -e VF_REGISTER_TOKEN=${registered.register_token} \\
-  visionforge/agent:latest`;
     return (
       <div className="max-w-2xl space-y-4">
-        <h1>Cluster registered</h1>
-        <Alert variant="success">
-          Run this command on the worker machine to start the agent. The token below appears only once
-          — save it now.
-        </Alert>
-        <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)] p-3">
-          <div className="label-overline mb-2">Cluster ID</div>
-          <div className="font-mono text-xs text-[var(--hud-text-data)] mb-3">{registered.id}</div>
-          <div className="label-overline mb-2">Register token</div>
-          <div className="font-mono text-xs text-[var(--hud-text-data)] break-all mb-3">
-            {registered.register_token}
+        <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
+          <div>
+            <div className="label-overline mb-0.5">// Clusters / Registered</div>
+            <h1>Cluster registered</h1>
           </div>
-          <div className="label-overline mb-2">Agent install command</div>
-          <pre className="bg-[var(--hud-inset)] border border-[var(--hud-border-subtle)] p-3 text-[0.6875rem] font-mono whitespace-pre-wrap break-all text-[var(--hud-text-data)]">
-            {installCmd}
-          </pre>
+        </div>
+        <Alert variant="success">
+          Specs discovered from the agent at {registered.agent_host}:{registered.agent_port}. The
+          agent has been adopted and will start posting heartbeats within {30}s.
+        </Alert>
+        <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)] p-3 space-y-3">
+          <div>
+            <div className="label-overline mb-1">Cluster</div>
+            <div className="text-sm text-[var(--hud-text-primary)]">{registered.name}</div>
+            <div className="font-mono text-[0.6875rem] text-[var(--hud-text-data)]">
+              {registered.id}
+            </div>
+          </div>
+          <div>
+            <div className="label-overline mb-1">Discovered hardware</div>
+            <div className="flex flex-wrap gap-1">
+              <Badge variant="info">{registered.cpu_cores} CPU cores</Badge>
+              <Badge variant="info">{(registered.ram_total_mb / 1024).toFixed(1)} GB RAM</Badge>
+              <Badge variant="info">{registered.disk_total_gb} GB disk</Badge>
+              {registered.gpu_count > 0 && (
+                <Badge variant="success">
+                  {registered.gpu_vendor.toUpperCase()} · {registered.gpu_count}× {registered.gpu_model || 'GPU'}
+                </Badge>
+              )}
+              {registered.os_name && (
+                <Badge variant="default">
+                  {registered.os_name} {registered.os_release || ''} · {registered.arch || ''}
+                </Badge>
+              )}
+              {registered.agent_version && (
+                <Badge variant="default">agent v{registered.agent_version}</Badge>
+              )}
+            </div>
+          </div>
         </div>
         <div className="flex gap-2">
           <Button onClick={() => navigate('/clusters')}>Done</Button>
@@ -91,111 +160,109 @@ export default function ClustersNew() {
   }
 
   return (
-    <div className="max-w-xl space-y-4">
+    <div className="max-w-2xl space-y-4">
       <div className="flex items-center justify-between border-b border-[var(--hud-border-subtle)] pb-3">
         <div>
           <div className="label-overline mb-0.5">// Clusters / New</div>
           <h1>Register Cluster</h1>
+          <p className="text-xs text-[var(--hud-text-muted)] mt-1">
+            VisionForge auto-discovers hardware from a running agent. Install the agent first,
+            then enter the worker's IP below.
+          </p>
         </div>
-        <Link to="/clusters" className="text-xs font-mono text-[var(--hud-accent)] hover:underline">
+        <Link
+          to="/clusters"
+          className="text-xs font-mono text-[var(--hud-accent)] hover:underline"
+        >
           ← CLUSTERS
         </Link>
       </div>
 
-      <form onSubmit={onSubmit} className="space-y-3">
+      <div className="border border-[var(--hud-border-default)] bg-[var(--hud-surface)] p-3 space-y-2">
+        <div className="label-overline">Step 1 · Install the agent on the worker machine</div>
+        <p className="text-[0.75rem] text-[var(--hud-text-muted)]">
+          Run this command on the worker. It pulls the agent image, generates a random
+          authentication token (already filled below), and exposes the agent's discovery API on
+          port <span className="font-mono">9443</span>.
+        </p>
+        <pre className="bg-[var(--hud-inset)] border border-[var(--hud-border-subtle)] p-3 text-[0.6875rem] font-mono whitespace-pre-wrap break-all text-[var(--hud-text-data)]">
+          {installCmd}
+        </pre>
+        <p className="text-[0.6875rem] text-[var(--hud-text-muted)]">
+          The agent stays in <span className="font-mono">unadopted</span> mode until you complete
+          Step 2; before then it accepts no jobs.
+        </p>
+      </div>
+
+      <form
+        onSubmit={onSubmit}
+        className="space-y-3 border border-[var(--hud-border-default)] bg-[var(--hud-surface)] p-3"
+      >
+        <div className="label-overline">Step 2 · Register the cluster</div>
         <div>
           <label className="label-overline block mb-1">Name</label>
-          <Input value={form.name} onChange={(e) => setField('name', e.target.value)} placeholder="gpu-rig-01" />
+          <Input
+            value={form.name}
+            onChange={(e) => setField('name', e.target.value)}
+            placeholder="gpu-rig-01"
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="label-overline block mb-1">Host (IP / hostname)</label>
+            <Input
+              value={form.host}
+              onChange={(e) => setField('host', e.target.value)}
+              placeholder="10.0.0.10"
+            />
+          </div>
+          <div>
+            <label className="label-overline block mb-1">Port</label>
+            <Input
+              type="number"
+              min={1}
+              max={65535}
+              value={form.port}
+              onChange={(e) => setField('port', parseInt(e.target.value) || 9443)}
+            />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="label-overline block mb-1">Scheme</label>
+            <Select
+              value={form.scheme}
+              onChange={(e) => setField('scheme', e.target.value as typeof form.scheme)}
+            >
+              <option value="http">http (private network)</option>
+              <option value="https">https</option>
+            </Select>
+          </div>
+          <div>
+            <label className="label-overline block mb-1">Workload kind</label>
+            <Select
+              value={form.kind}
+              onChange={(e) => setField('kind', e.target.value as typeof form.kind)}
+            >
+              <option value="both">Training + Evaluation</option>
+              <option value="train">Training only</option>
+              <option value="eval">Evaluation only</option>
+            </Select>
+          </div>
         </div>
         <div>
-          <label className="label-overline block mb-1">Description</label>
+          <label className="label-overline block mb-1">Description (optional)</label>
           <Input
             value={form.description}
             onChange={(e) => setField('description', e.target.value)}
             placeholder="On-prem 2× A100 box"
           />
         </div>
-        <div>
-          <label className="label-overline block mb-1">Workload kind</label>
-          <Select value={form.kind} onChange={(e) => setField('kind', e.target.value as typeof form.kind)}>
-            <option value="both">Training + Evaluation</option>
-            <option value="train">Training only</option>
-            <option value="eval">Evaluation only</option>
-          </Select>
-        </div>
-        <div className="grid grid-cols-3 gap-3">
-          <div>
-            <label className="label-overline block mb-1">CPU cores</label>
-            <Input
-              type="number"
-              min={1}
-              value={form.cpu_cores}
-              onChange={(e) => setField('cpu_cores', parseInt(e.target.value) || 0)}
-            />
-          </div>
-          <div>
-            <label className="label-overline block mb-1">RAM (MB)</label>
-            <Input
-              type="number"
-              min={0}
-              value={form.ram_total_mb}
-              onChange={(e) => setField('ram_total_mb', parseInt(e.target.value) || 0)}
-            />
-          </div>
-          <div>
-            <label className="label-overline block mb-1">Disk (GB)</label>
-            <Input
-              type="number"
-              min={0}
-              value={form.disk_total_gb}
-              onChange={(e) => setField('disk_total_gb', parseInt(e.target.value) || 0)}
-            />
-          </div>
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="label-overline block mb-1">GPU vendor</label>
-            <Select
-              value={form.gpu_vendor}
-              onChange={(e) => setField('gpu_vendor', e.target.value as typeof form.gpu_vendor)}
-            >
-              <option value="nvidia">NVIDIA (CUDA)</option>
-              <option value="rocm">AMD (ROCm)</option>
-              <option value="cpu">CPU only</option>
-            </Select>
-          </div>
-          <div>
-            <label className="label-overline block mb-1">GPU count</label>
-            <Input
-              type="number"
-              min={0}
-              value={form.gpu_count}
-              onChange={(e) => setField('gpu_count', parseInt(e.target.value) || 0)}
-            />
-          </div>
-          <div>
-            <label className="label-overline block mb-1">GPU model</label>
-            <Input
-              value={form.gpu_model}
-              onChange={(e) => setField('gpu_model', e.target.value)}
-              placeholder="A100 80GB / RX 7900 XTX"
-            />
-          </div>
-          <div>
-            <label className="label-overline block mb-1">GPU memory (MB)</label>
-            <Input
-              type="number"
-              min={0}
-              value={form.gpu_memory_mb}
-              onChange={(e) => setField('gpu_memory_mb', parseInt(e.target.value) || 0)}
-            />
-          </div>
-        </div>
 
         {error && <Alert variant="error">{error}</Alert>}
 
         <Button type="submit" disabled={loading}>
-          {loading ? 'Registering…' : 'Register cluster'}
+          {loading ? 'Probing agent…' : 'Discover & register'}
         </Button>
       </form>
     </div>

--- a/specs/004-cluster-discovery/plan.md
+++ b/specs/004-cluster-discovery/plan.md
@@ -1,0 +1,38 @@
+# Plan: Cluster Discovery & Agent Runtime
+
+## Phases
+
+| # | Phase | Outputs |
+|---|---|---|
+| 1 | Agent runtime | `agent/` package, Dockerfile, supervisor entrypoint, hardware probe, HTTP server, heartbeat loop |
+| 2 | Backend discovery | `POST /api/clusters/discover`, schema columns + Alembic migration, `AgentUnreachableError`, removal of manual entry |
+| 3 | Frontend wizard | Rewritten `/clusters/new` (token generated client-side, hardware fields removed); `/clusters` shows OS + agent version |
+| 4 | E2E proof | Stubbed integration test asserts Celery routing to `cluster.{id}` and the busy→online lifecycle |
+| 5 | Hardening | Token rotation endpoint + test; agent version field in `/info` |
+| 6 | Documentation | CLAUDE.md, README.md, this spec |
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Discovery direction | Backend pulls from agent | Operator-stated requirement; avoids needing operators to type specs |
+| Job transport | Celery + Redis (push) | Matches existing wiring; operators with no platform-side changes |
+| Manual entry | Removed entirely | User decision (see questions in branch history); reduces UI complexity |
+| TLS | Plain HTTP for v1 | Agents are expected on private networks; `scheme=https` is supported but not certificate-managed by the platform |
+| Token lifecycle | Operator-supplied agent token persists across restarts; platform-issued register token rotatable on demand | Two-token design isolates the agent's bootstrap identity from its platform-issued session identity |
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Agent on NAT'd network unreachable from platform | Document the private-network requirement; future work: HTTP long-poll fallback (out of scope for v1) |
+| Agent image grows large (includes torch/cuda) | Backend image already has the same deps; agent image extends it — no duplicate ML stack to maintain |
+| `register_token` leaks | `POST /rotate-token` invalidates the old token and forces re-adoption |
+| Operator mistypes the agent token | `[reason=auth]` returned in 502 detail; UI surfaces "agent rejected the token" |
+
+## Test Strategy
+
+- **Agent**: `agent/tests/` — `pytest` against `httpx.MockTransport`; no Docker required.
+- **Backend service**: `backend/tests/unit/test_cluster_service.py` — pure SQLite + `httpx.MockTransport`.
+- **Backend API**: `backend/tests/integration/test_clusters_api.py` — FastAPI `TestClient` with `monkeypatch` on `cluster_service.httpx.Client`.
+- **Canonical proof**: `test_train_with_available_cluster_routes_to_cluster_queue` asserts both queue name and cluster `busy` state after discover→heartbeat→train.

--- a/specs/004-cluster-discovery/spec.md
+++ b/specs/004-cluster-discovery/spec.md
@@ -1,0 +1,80 @@
+# Feature Spec: Cluster Discovery & Agent Runtime
+
+**Branch**: `claude/cluster-discovery-feature`
+**Status**: In Progress
+**Owners**: Platform team
+
+## Summary
+
+Replace the manual-entry cluster registration flow with **discovery-based registration**: operators run an unattended **agent** on a worker machine, then in the UI enter only the cluster name, host:port, and agent token. The backend reaches out to the agent's HTTP info endpoint, auto-populates hardware/OS specs, and adopts the agent for the cluster.
+
+This closes the gap where the previous design referenced a `visionforge/agent:latest` image that did not exist in the repo, and required operators to type CPU/RAM/GPU specs by hand.
+
+## Goals
+
+1. Operators register a cluster with **only** a name + host + port + token.
+2. Hardware (CPU/RAM/disk/GPU) and OS metadata are **auto-discovered** from a running agent.
+3. The agent runs in Docker and bundles all of VisionForge's ML dependencies (PyTorch, Ultralytics, ONNX, open-clip) so it can execute training, evaluation, and ONNX export jobs.
+4. Jobs continue to route via the existing per-cluster Celery queue (`cluster.{id}`).
+5. The platform can detect an unreachable agent (timeout / connect refused / bad token) and surface a precise error reason to the UI.
+
+## Non-Goals
+
+- mTLS or signed-JWT auth between platform ↔ agent (HTTP + bearer token is sufficient for v1; agents are expected to be on a private network).
+- Auto-update of the agent image. (Tracked under "agent version visibility" in Phase 5; in-place upgrades are future work.)
+- Multi-tenant agent pools (one cluster row = one agent process).
+
+## User Stories
+
+- **As a platform admin** I install the agent on a new GPU box with a single `docker run`, paste the IP into the UI, and the cluster is registered with the correct specs without me typing them in.
+- **As an ML engineer** launching a training run I see the cluster's discovered specs (CPU/RAM/GPU/OS) in the cluster picker so I can pick the right hardware.
+- **As a security-conscious admin** I can rotate a cluster's `register_token` from the UI and immediately invalidate the old token, forcing the agent to be re-adopted.
+
+## Architecture
+
+```
+┌───────────────────────────────┐     POST /api/clusters/discover     ┌─────────────────┐
+│  Operator browser  (UI)       │ ───────────────────────────────────▶│  Platform API   │
+└───────────────────────────────┘                                     │                 │
+                                          GET  /info  (bearer agent)  │                 │
+                                  ◀────────────────────────────────── │                 │
+┌───────────────────────────────┐                                     │                 │
+│  Worker machine               │   POST /adopt {cluster_id,token}    │                 │
+│                               │ ◀────────────────────────────────── │                 │
+│  ┌─────────────────────────┐  │                                     │                 │
+│  │ vf-agent HTTP (9443)    │  │   POST /api/clusters/{id}/heartbeat │                 │
+│  │ + heartbeat loop        │  │ ──────────────────────────────────▶ │                 │
+│  │ + Celery worker         │  │                                     │                 │
+│  │   (-Q cluster.{id})     │  │   pickup tasks from Redis           │  Redis + Celery │
+│  └─────────────────────────┘  │ ◀────────────────────────────────── │                 │
+└───────────────────────────────┘                                     └─────────────────┘
+```
+
+## Functional Requirements
+
+| ID | Requirement |
+|---|---|
+| F1 | The agent exposes `GET /info` returning a JSON snapshot with `cpu_cores`, `ram_total_mb`, `disk_total_gb`, `gpu_vendor`, `gpu_count`, `gpu_model`, `gpu_memory_mb`, `gpus[]`, `os{name,release,arch}`, `agent_version`. |
+| F2 | The agent exposes `GET /telemetry` returning current usage figures. |
+| F3 | The agent exposes `POST /adopt` accepting `{cluster_id, register_token, api_url}` and persisting them to a volume. |
+| F4 | `/info`, `/telemetry`, `/adopt` all require `Authorization: Bearer $VF_AGENT_TOKEN`. `/health` is unauthenticated. |
+| F5 | `POST /api/clusters/discover` (auth: user) takes `{name, host, port, agent_token, kind, description?, scheme?}`, calls the agent's `/info` then `/adopt`, persists a `Cluster` row, and returns it including `register_token`. |
+| F6 | The platform returns HTTP 502 with a `[reason=connect\|timeout\|auth\|bad_response]` suffix when the agent is unreachable. |
+| F7 | `POST /api/clusters/{id}/rotate-token` re-issues `register_token` and forces the cluster to `offline`, invalidating the agent's old token. |
+| F8 | The agent's Celery worker subscribes to queue `cluster.{cluster_id}` only after adoption. |
+| F9 | The cluster row stores `agent_host`, `agent_port`, `agent_version`, `os_name`, `os_release`, `arch` alongside the existing fields. |
+| F10 | The UI removes manual hardware-entry fields. The "Register cluster" wizard shows the `docker run` command with a pre-generated agent token, then asks only for name + host + port + kind. |
+
+## Out of Scope (Documented)
+
+- Manual cluster entry is **removed** from both API and UI. Air-gapped sites that cannot reach the agent over HTTP are not supported in v1.
+- The agent assumes Docker, a Linux host, and (optionally) NVIDIA CUDA or AMD ROCm drivers preinstalled.
+- The platform's Redis must be reachable from the worker (private network / VPN).
+
+## Acceptance Criteria
+
+1. `python -m vf_agent.discover` prints valid JSON containing CPU cores, disk total, and OS info.
+2. Agent unit tests pass: `pytest agent/tests/` (8 tests covering server auth, /info shape, adopt persistence, heartbeat payload, transport error handling).
+3. Backend cluster unit + integration tests pass: 12 unit tests + 7 integration tests, including a stubbed end-to-end that asserts training jobs route to `cluster.{cluster_id}` and the cluster transitions to `busy`.
+4. The UI wizard at `/clusters/new` collects only name + host + port + kind; submitting it against a stub agent shows the discovered hardware in the success page.
+5. `docker build -t visionforge/agent:dev -f agent/Dockerfile .` succeeds and produces an image that includes torch, ultralytics, onnxruntime, psutil, and pynvml.

--- a/specs/004-cluster-discovery/tasks.md
+++ b/specs/004-cluster-discovery/tasks.md
@@ -1,0 +1,54 @@
+# Tasks: Cluster Discovery & Agent Runtime
+
+Each task lists a **verifiable output** — a concrete observation that proves it's done.
+
+## Phase 1: Agent runtime
+
+- [X] **T001** `agent/Dockerfile`, `agent/requirements.txt`, `agent/src/vf_agent/`.
+  *Verify:* directory exists; `agent/Dockerfile` references `python:3.11-slim` and copies both `backend/` and `agent/`.
+- [X] **T002** `vf_agent/discover.py`: hardware + OS probe via psutil / pynvml / rocm-smi / platform.
+  *Verify:* `PYTHONPATH=agent/src python -m vf_agent.discover` prints JSON with `cpu_cores`, `disk_total_gb`, `gpu_vendor`, `os.{name,release,arch}`.
+- [X] **T003** `vf_agent/server.py`: FastAPI app with `/health` (no auth), `/info`, `/telemetry`, `/adopt` (bearer auth).
+  *Verify:* `pytest agent/tests/test_server.py` — 6 cases including 401 on bad token and 503 when `VF_AGENT_TOKEN` is unset.
+- [X] **T004** `vf_agent/heartbeat.py`: posts telemetry to the platform every `VF_AGENT_HEARTBEAT_INTERVAL` seconds.
+  *Verify:* `pytest agent/tests/test_heartbeat.py` — payload includes `register_token` and `status=online`; transport error returns code 0.
+- [X] **T005** `vf_agent/main.py`: supervisor that starts the HTTP server, waits for `identity.json`, then spawns the Celery worker bound to `cluster.{cluster_id}`.
+  *Verify:* `python -m vf_agent.main` aborts with exit code 2 when `VF_AGENT_TOKEN` is unset; otherwise launches uvicorn on port 9443 and blocks for identity.
+
+## Phase 2: Backend discovery endpoint
+
+- [X] **T006** New columns on `clusters`: `agent_host`, `agent_port`, `agent_version`, `os_name`, `os_release`, `arch`. Alembic revision `0004_cluster_discovery`.
+  *Verify:* migration file exists; `discover_cluster` test asserts these columns are populated from `/info`.
+- [X] **T007** `POST /api/clusters/discover` calls agent `/info` + `/adopt`, creates a `Cluster` row pre-populated from discovery.
+  *Verify:* `test_discover_probes_agent_and_creates_cluster` — Cluster row has `cpu_cores=32`, `gpu_count=2`, `agent_host`, `os_name="Linux"`.
+- [X] **T008** Remove `POST /api/clusters` (manual entry).
+  *Verify:* `router.routes` includes `/discover` but not the bare `POST /api/clusters`.
+- [X] **T009** `AgentUnreachableError` → 502 with `[reason=connect|timeout|auth|bad_response]`.
+  *Verify:* `test_discover_502s_when_agent_unreachable` — body contains `[reason=connect]`.
+
+## Phase 3: Frontend wizard
+
+- [X] **T010** Rewrite `frontend/src/pages/clusters/new.tsx` to a two-step flow: install command (Step 1) + name/host/port/kind (Step 2).
+  *Verify:* the file contains no `cpu_cores`/`ram_total_mb`/`gpu_count` form inputs and submits `POST /api/clusters/discover`.
+- [X] **T011** Show discovered specs on the result page (chips for CPU, RAM, disk, GPU, OS, agent version).
+  *Verify:* the registered-state JSX renders `<Badge>` chips for each field.
+- [X] **T012** `/clusters` index card shows OS and agent endpoint (`agent_host:agent_port · vX.Y.Z`).
+  *Verify:* `Cluster` interface includes the new fields and they're rendered in the card footer.
+
+## Phase 4: Stubbed E2E proof
+
+- [X] **T013** `test_train_with_available_cluster_routes_to_cluster_queue` asserts: cluster created via discover → heartbeat received → training launched → `celery_app.send_task` called with `queue=cluster.{cluster_id}` and `args[0].clusterId` set; cluster status flips to `busy` and `active_job_id` populated.
+  *Verify:* `pytest backend/tests/integration/test_clusters_api.py -k routes_to_cluster_queue` passes.
+
+## Phase 5: Hardening
+
+- [X] **T014** `POST /api/clusters/{id}/rotate-token` re-issues the register token; old token immediately fails heartbeat.
+  *Verify:* `test_rotate_register_token_invalidates_old_token` + `test_rotate_token_invalidates_old_token` integration test pass.
+- [X] **T015** `compose.agent.yml` overlay starts the agent on the same Docker network as the platform.
+  *Verify:* `docker compose -f docker-compose.yml -f compose.agent.yml config agent` resolves without error.
+
+## Phase 6: Documentation
+
+- [X] **T016** Update `CLAUDE.md` Compute Clusters section to describe the discovery flow and agent endpoints.
+- [X] **T017** Update `README.md` to replace lifecycle 1–4 with the discovery flow and add an "Agent quick install" subsection.
+- [X] **T018** This spec (`specs/004-cluster-discovery/`).


### PR DESCRIPTION
The clusters feature (PR #9) shipped without documentation. This adds:

- CLAUDE.md: new "Compute Clusters" section covering the model, schemas,
  service, routes, training/ONNX integration, and the agent lifecycle.
  Data-model diagram now shows ExperimentRun → Cluster and the standalone
  Cluster entity. API router list now mentions api/clusters.py. Async
  job section notes the per-cluster cluster.{id} Celery queue routing.
- README.md: adds Compute Clusters to Features, /api/clusters/ to the
  API overview, and a dedicated section covering registration lifecycle,
  selection rules (enabled + online + idle + fresh heartbeat + kind
  match), the 409-on-conflict behaviour, an endpoint quick reference,
  and the GPU vendor matrix.

https://claude.ai/code/session_01L7Bpzpgm98iAuhqiH8gCj2